### PR TITLE
Support getting audio device by name

### DIFF
--- a/aiavatar/bot.py
+++ b/aiavatar/bot.py
@@ -39,19 +39,33 @@ class AIAvatar:
         self.voicevox_speaker_id = voicevox_speaker_id
 
         # Audio Devices
-        if input_device < 0:
-            input_device_info = AudioDevice.get_default_input_device_info()
+        if isinstance(input_device, int):
+            if input_device < 0:
+                input_device_info = AudioDevice.get_default_input_device_info()
+                input_device = input_device_info["index"]
+            else:
+                input_device_info = AudioDevice.get_device_info(input_device)
+        elif isinstance(input_device, str):
+            input_device_info = AudioDevice.get_input_device_by_name(input_device)
+            if input_device_info is None:
+                input_device_info = AudioDevice.get_default_input_device_info()
             input_device = input_device_info["index"]
-        else:
-            input_device_info = AudioDevice.get_device_info(input_device)
+
         self.input_device = input_device
         self.logger.info(f"Input device: [{input_device}] {input_device_info['name']}")
 
-        if output_device < 0:
-            output_device_info = AudioDevice.get_default_output_device_info()
+        if isinstance(output_device, int):
+            if output_device < 0:
+                output_device_info = AudioDevice.get_default_output_device_info()
+                output_device = output_device_info["index"]
+            else:
+                output_device_info = AudioDevice.get_device_info(output_device)
+        elif isinstance(output_device, str):
+            output_device_info = AudioDevice.get_output_device_by_name(output_device)
+            if output_device_info is None:
+                output_device_info = AudioDevice.get_default_output_device_info()
             output_device = output_device_info["index"]
-        else:
-            output_device_info = AudioDevice.get_device_info(output_device)
+
         self.output_device = output_device
         self.logger.info(f"Output device: [{output_device}] {output_device_info['name']}")
 

--- a/aiavatar/device/audio.py
+++ b/aiavatar/device/audio.py
@@ -14,6 +14,22 @@ class AudioDevice:
         return PyAudio().get_device_info_by_index(index)
 
     @classmethod
+    def get_input_device_by_name(cls, name: str):
+        for d in AudioDevice.get_audio_devices():
+            if d["maxInputChannels"] > 0:
+                if name.lower() in d["name"].lower():
+                    return d
+        return None
+
+    @classmethod
+    def get_output_device_by_name(cls, name: str):
+        for d in AudioDevice.get_audio_devices():
+            if d["maxOutputChannels"] > 0:
+                if name.lower() in d["name"].lower():
+                    return d
+        return None
+
+    @classmethod
     def get_audio_devices(cls):
         devices = []
         pa = PyAudio()

--- a/tests/device/test_audio.py
+++ b/tests/device/test_audio.py
@@ -12,6 +12,24 @@ def test_get_default_output_device_info():
     assert d["index"] < 1000
     assert d["name"] is not None
 
+def test_get_input_device_by_name():
+    d = AudioDevice.get_input_device_by_name("マイク")
+    assert d is not None
+    assert d["index"] >= 0
+    assert d["maxInputChannels"] > 0
+
+    d = AudioDevice.get_input_device_by_name("_aiavater_dummy_")
+    assert d is None
+
+def test_get_output_device_by_name():
+    d = AudioDevice.get_output_device_by_name("スピーカー")
+    assert d is not None
+    assert d["index"] >= 0
+    assert d["maxOutputChannels"] > 0
+
+    d = AudioDevice.get_output_device_by_name("_aiavater_dummy_")
+    assert d is None
+
 def test_get_audio_devices():
     devices = AudioDevice.get_audio_devices()
     assert len(devices) >= 2


### PR DESCRIPTION
Add the methods below to `AudioDevice`.

- get_input_device_by_name(name: str)
- get_output_device_by_name(name: str)

Partial match, ignore case.

Now you can instantiate AIAvatar with the name of audio devices.

```python
app = AIAvatar(
    google_api_key=GOOGLE_API_KEY,
    openai_api_key=OPENAI_API_KEY,
    voicevox_url=VV_URL,
    voicevox_speaker_id=VV_SPEAKER,
    system_message_content=system_message_content,
    input_device="pro",               # matches `MacBook Pro Speaker`
    output_device="cable-b input",    # matches `CABLE-B Input (VB-Audio`
)
```