### PR TITLE
Add experimental SpeechController to handle speech in separate process

### DIFF
--- a/aiavatar/speech/__init__.py
+++ b/aiavatar/speech/__init__.py
@@ -1,4 +1,10 @@
 from abc import ABC, abstractmethod
+import asyncio
+from logging import getLogger, NullHandler
+import traceback
+from .soundplayers import SoundPlayerBase
+from .soundplayers.sounddevice_player import SoundDevicePlayer
+
 
 class SpeechController(ABC):
     @abstractmethod
@@ -12,3 +18,70 @@ class SpeechController(ABC):
     @abstractmethod
     def is_speaking(self) -> bool:
         pass
+
+
+class VoiceClip:
+    def __init__(self, text: str):
+        self.text = text
+        self.download_task = None
+        self.audio_clip = None
+
+
+class SpeechControllerBase(SpeechController):
+    def __init__(self, *, base_url: str, device_index: int=-1, playback_margin: float=0.1, use_subprocess=False, subprocess_timeout: float=0.5, sound_player: SoundPlayerBase=None):
+        self.logger = getLogger(__name__)
+        self.logger.addHandler(NullHandler())
+
+        self.base_url = base_url
+        self.device_index = device_index
+        self.playback_margin = playback_margin
+        self.subprocess_timeout = subprocess_timeout
+        self.use_subprocess = use_subprocess
+
+        if sound_player:
+            self.sound_player = sound_player
+        else:
+            self.sound_player = SoundDevicePlayer(
+                device_index=self.device_index,
+                playback_margin=self.playback_margin,
+                subprocess_timeout=self.subprocess_timeout
+            )
+
+        self.voice_clips = {}
+        self._is_speaking = False
+
+    async def download(self, voice: VoiceClip):
+        raise NotImplementedError("`download` is not implemented")
+
+    def prefetch(self, text: str):
+        v = self.voice_clips.get(text)
+        if v:
+            return v
+
+        v = VoiceClip(text)
+        v.download_task = asyncio.create_task(self.download(v))
+        self.voice_clips[text] = v
+        return v
+
+    async def speak(self, text: str):
+        voice = self.prefetch(text)
+        
+        if not voice.audio_clip:
+            await voice.download_task
+        
+        try:
+            self._is_speaking = True
+
+            if self.use_subprocess:
+                await self.sound_player.play_wave_on_subprocess(voice.audio_clip)
+            else:
+                await self.sound_player.play_wave(voice.audio_clip)
+
+        except Exception as ex:
+            self.logger.error(f"Error at speaking: {str(ex)}\n{traceback.format_exc()}")
+
+        finally:
+            self._is_speaking = False
+
+    def is_speaking(self) -> bool:
+        return self._is_speaking

--- a/aiavatar/speech/soundplayers/__init__.py
+++ b/aiavatar/speech/soundplayers/__init__.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+class SoundPlayerBase(ABC):
+    @abstractmethod
+    async def play_wave(self, data):
+        pass
+
+    @abstractmethod
+    async def play_wave_on_subprocess(self, data):
+        pass

--- a/aiavatar/speech/soundplayers/sounddevice_player.py
+++ b/aiavatar/speech/soundplayers/sounddevice_player.py
@@ -1,0 +1,71 @@
+import asyncio
+import io
+import os
+import select
+import sys
+import wave
+import numpy
+import sounddevice
+
+
+if __name__ == "__main__":
+    device_index = int(sys.argv[1]) if len(sys.argv) > 2 else 0
+    timeout = float(sys.argv[2]) if len(sys.argv) > 3 else 5.0
+
+    try:
+        ready, _, _ = select.select([sys.stdin], [], [], timeout)
+
+        if not ready:
+            raise Exception(f"Sound timeout ({timeout}sec)")
+
+        data = sys.stdin.buffer.read()
+
+        if not data:
+            raise Exception("No sound data")
+
+        with wave.open(io.BytesIO(data), "rb") as f:
+            data = numpy.frombuffer(
+                f.readframes(f.getnframes()),
+                dtype=numpy.int16
+            )
+            framerate = f.getframerate()
+            sounddevice.play(data, framerate, device=device_index)
+            sounddevice.wait()
+    
+    except Exception as ex:
+        sys.stderr.write(f"{ex}\n")
+        sys.exit(1)
+
+else:
+    from . import SoundPlayerBase
+
+    class SoundDevicePlayer(SoundPlayerBase):
+        def __init__(self, device_index: int=-1, playback_margin: float=0.1, subprocess_timeout: float=5.0):
+            self.device_index = device_index
+            self.playback_margin = playback_margin
+            self.subprocess_timeout = subprocess_timeout
+
+        async def play_wave(self, data):
+            with wave.open(io.BytesIO(data), "rb") as f:
+                data = numpy.frombuffer(
+                    f.readframes(f.getnframes()),
+                    dtype=numpy.int16
+                )
+                framerate = f.getframerate()
+                sounddevice.play(data, framerate, device=self.device_index, blocking=False)
+                await asyncio.sleep(len(data) / framerate + self.playback_margin)
+
+        async def play_wave_on_subprocess(self, data):
+            process = await asyncio.create_subprocess_exec(
+                "python", os.path.abspath(__file__), str(self.device_index), str(self.subprocess_timeout),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+
+            stdout, stderr = await process.communicate(input=data)
+
+            if process.returncode != 0:
+                raise Exception(stderr.decode())
+
+            return stdout


### PR DESCRIPTION
Introduced an experimental SpeechController to address the issue of popping noises during speech playback while concurrently receiving ChatGPT's stream. The SpeechController manages speech operations in a separate process, aiming to isolate and minimize audio disruptions. This modification is intended to enhance audio quality and stability during simultaneous stream reception and speech output.

You can use the new SpeechController by adding the following code after instantiate AIAvatar:

```python
from aiavatar.speech.voicevox import VoicevoxSpeechControllerSubProcess
app.avatar_controller.speech_controller = VoicevoxSpeechControllerSubProcess(
    base_url="http://127.0.0.1:50021",
    speaker_id=46,
    device_index=app.output_device
)
```