### PR TITLE
Enable external control of WakewordListener

### DIFF
--- a/aiavatar/bot.py
+++ b/aiavatar/bot.py
@@ -90,6 +90,8 @@ class AIAvatar:
                 verbose=verbose
             )
         
+        self.wakeword_listener_thread = None
+
         # Avatar Controller with Speech, Animation and Face
         self.avatar_controller = AvatarController(
             speech_controller or VoicevoxSpeechController(
@@ -171,8 +173,14 @@ class AIAvatar:
             self.chat_task.cancel()
 
     def start_listening_wakeword(self, wait: bool=True):
-        ww_thread = self.wakeword_listener.start()
+        self.wakeword_listener_thread = self.wakeword_listener.start()
         if wait:
-            ww_thread.join()
+            self.wakeword_listener_thread.join()
         else:
-            return ww_thread
+            return self.wakeword_listener_thread
+
+    def stop_listening_wakeword(self, wait: bool=True):
+        self.wakeword_listener.stop()
+
+    def is_wakeword_listener_listening(self):
+        return self.wakeword_listener_thread is not None and self.wakeword_listener_thread.is_alive()

--- a/aiavatar/listeners/__init__.py
+++ b/aiavatar/listeners/__init__.py
@@ -20,6 +20,10 @@ class WakewordListenerBase(ABC):
     def start(self):
         ...
 
+    @abstractmethod
+    def stop(self):
+        ...
+
 
 class SpeechListenerBase:
     def __init__(self, api_key: str, on_speech_recognized: Callable, volume_threshold: int=3000, timeout: float=1.0, detection_timeout: float=0.0, min_duration: float=0.3, max_duration: float=20.0, lang: str="ja-JP", rate: int=44100, channels: int=1, device_index: int=-1):
@@ -178,4 +182,5 @@ class SpeechListenerBase:
             self.is_listening = False
 
     def stop_listening(self):
+        # ToDo: make stream inactive in `record_audio()` to stop listening immediately
         self.is_listening = False

--- a/aiavatar/listeners/wakeword.py
+++ b/aiavatar/listeners/wakeword.py
@@ -21,3 +21,6 @@ class WakewordListener(WakewordListenerBase, SpeechListenerBase):
         th = Thread(target=asyncio.run, args=(self.start_listening(),), daemon=True)
         th.start()
         return th
+
+    def stop(self):
+        self.is_listening = False


### PR DESCRIPTION
This commit introduces the ability to start and stop the WakewordListener externally. This enhancement allows for better control and integration with other system components.

- Add methods to `stop_listening_wakeword` to AIAvatar.
- Add `wakeword_listener_thread` to AIAvatar to manage the thread wherever the AIAvatar is available in your app.
- Add `stop` method to the interface of WakewordListeners internally.