### PR TITLE
Add support Claude and Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ Feel free to enjoy the conversation afterwards!
 # 🔖 Contents
 
 - [📕 Configuration Guide](#-configuration-guide)
-  - [🎓 AI / ChatGPT](#-ai--chatgpt)
+  - [🎓 Generative AI](#-generative-ai)
+    - [ChatGPT](#chatgpt)
+    - [Claude](#claude)
+    - [Gemini](#gemini)
+    - [Other LLMs](#other-llms)
   - [🗣️ Voice](#️-voice)
   - [🐓 Wakeword Listener](#-wakeword-listener)
   - [🙏 Request Listener](#-request-listener)
@@ -82,7 +86,7 @@ Feel free to enjoy the conversation afterwards!
 Here are the configuration for each component.
 
 
-## 🎓 AI / ChatGPT
+## 🎓 Generative AI
 
 You can set model and system message content when instantiate `AIAvatar`.
 
@@ -94,6 +98,8 @@ app = AIAvatar(
     system_message_content="You are my cat."
 )
 ```
+
+### ChatGPT
 
 If you want to configure in detail, create instance of `ChatGPTProcessor` with custom parameters and set it to `AIAvatar`.
 
@@ -113,7 +119,49 @@ chat_processor = ChatGPTProcessor(
 app.chat_processor = chat_processor
 ```
 
-And also, you can make your custom processor that uses other generative AIs such as Claude 3 by implementing `ChatProcessor` interface. We provide the example later.🙏
+### Claude
+
+Create instance of `ClaudeProcessor` with custom parameters and set it to `AIAvatar`. The default model is `claude-3-sonnet-20240229`.
+
+```python
+from aiavatar.processors.claude import ClaudeProcessor
+
+claude_processor = ClaudeProcessor(
+    api_key="ANTHROPIC_API_KEY"
+)
+
+app = AIAvatar(
+    google_api_key=GOOGLE_API_KEY,
+    chat_processor=claude_processor
+)
+```
+
+NOTE: We support Claude 3 on Anthropic API, not Amazon Bedrock for now.
+
+
+### Gemini
+
+Create instance of `GeminiProcessor` with custom parameters and set it to `AIAvatar`. The default model is `gemini-pro`.
+
+```python
+from aiavatar.processors.gemini import GeminiProcessor
+
+gemini_processor = GeminiProcessor(
+    api_key="YOUR_GOOGLE_API_KEY"
+)
+
+app = AIAvatar(
+    google_api_key=GOOGLE_API_KEY,
+    chat_processor=gemini_processor
+)
+```
+
+NOTE: We support Gemini on Google AI Studio, not Vertex AI for now.
+
+
+### Other LLMs
+
+You can make your custom processor that uses other generative AIs such as Llama3 by implementing `ChatProcessor` interface. We provide the example later.🙏
 
 
 ## 🗣️　Voice

--- a/aiavatar/processors/claude.py
+++ b/aiavatar/processors/claude.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+from logging import getLogger, NullHandler
+import traceback
+from typing import AsyncGenerator
+from anthropic import AsyncAnthropic
+from . import ChatProcessor
+
+class ClaudeProcessor(ChatProcessor):
+    def __init__(self, *, api_key: str, model: str="claude-3-sonnet-20240229", temperature: float=1.0, max_tokens: int=200, functions: dict=None, system_message_content: str=None, history_count: int=10, history_timeout: float=60.0):
+        self.logger = getLogger(__name__)
+        self.logger.addHandler(NullHandler())
+
+        self.api_key = api_key
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.system_message_content = system_message_content
+        self.history_count = history_count
+        self.history_timeout = history_timeout
+        self.histories = []
+        self.last_chat_at = datetime.utcnow()
+        self.on_start_processing = None
+
+    def reset_histories(self):
+        self.histories.clear()
+
+    def build_messages(self, text):
+        messages = []
+        try:
+            # Histories
+            messages.extend(self.histories[-1 * self.history_count:])
+
+            # Current user message
+            messages.append({"role": "user", "content": text})
+        
+        except Exception as ex:
+            self.logger.error(f"Error at build_messages: {ex}\n{traceback.format_exc()}")
+
+        return messages
+
+    async def chat(self, text: str) -> AsyncGenerator[str, None]:
+        try:
+            async_client = AsyncAnthropic(api_key=self.api_key)
+
+            if (datetime.utcnow() - self.last_chat_at).total_seconds() > self.history_timeout:
+                self.reset_histories()
+
+            if self.on_start_processing:
+                await self.on_start_processing()
+
+            # Get context
+            messages = self.build_messages(text)
+
+            # Params
+            params = {
+                "messages": messages,
+                "model": self.model,
+                "temperature": self.temperature,
+                "max_tokens": self.max_tokens,
+                "stream": True,
+            }
+            if self.system_message_content:
+                params["system"] = self.system_message_content
+
+            # Stream
+            response_text = ""
+            stream_resp = await async_client.messages.create(**params)
+            async for chunk in stream_resp:
+                if chunk.type == "content_block_delta":
+                    content = chunk.delta.text
+                    response_text += content
+                    yield content
+            
+            # Save context
+            if response_text:
+                self.histories.append(messages[-1])
+                self.histories.append({"role": "assistant", "content": response_text})
+
+        except Exception as ex:
+            self.logger.error(f"Error at chat: {str(ex)}\n{traceback.format_exc()}")
+            raise ex
+        
+        finally:
+            self.last_chat_at = datetime.utcnow()
+            if not async_client.is_closed():
+                await async_client.close()

--- a/aiavatar/processors/gemini.py
+++ b/aiavatar/processors/gemini.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+from logging import getLogger, NullHandler
+import traceback
+from typing import AsyncGenerator
+import google.generativeai as genai
+from . import ChatProcessor
+
+class GeminiProcessor(ChatProcessor):
+    def __init__(self, *, api_key: str, model: str="gemini-pro", temperature: float=1.0, max_tokens: int=200, functions: dict=None, system_message_content: str=None, system_message_content_acknowledgement_content: str="了解しました。", history_count: int=10, history_timeout: float=60.0):
+        self.logger = getLogger(__name__)
+        self.logger.addHandler(NullHandler())
+
+        self.api_key = api_key
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.system_message_content = system_message_content
+        self.system_message_content_acknowledgement_content = system_message_content_acknowledgement_content
+        self.history_count = history_count
+        self.history_timeout = history_timeout
+        self.histories = []
+        self.last_chat_at = datetime.utcnow()
+        self.on_start_processing = None
+
+        genai.configure(api_key=self.api_key)
+        self.client = genai.GenerativeModel(self.model)
+
+    def reset_histories(self):
+        self.histories.clear()
+
+    def build_messages(self, text):
+        messages = []
+        try:
+            # System message
+            if self.system_message_content:
+                messages.append({"role": "user", "parts": [{"text": self.system_message_content}]})
+                messages.append({"role": "model", "parts": [{"text": self.system_message_content_acknowledgement_content}]})
+
+            # Histories
+            messages.extend(self.histories[-1 * self.history_count:])
+
+            # Current user message
+            messages.append({"role": "user", "parts": [{"text": text}]})
+        
+        except Exception as ex:
+            self.logger.error(f"Error at build_messages: {ex}\n{traceback.format_exc()}")
+
+        return messages
+
+    async def chat(self, text: str) -> AsyncGenerator[str, None]:
+        try:
+            if (datetime.utcnow() - self.last_chat_at).total_seconds() > self.history_timeout:
+                self.reset_histories()
+
+            if self.on_start_processing:
+                await self.on_start_processing()
+
+            # Get context
+            messages = self.build_messages(text)
+
+            # Params
+            generation_config = {
+                "temperature": self.temperature
+            }
+            if self.max_tokens:
+                generation_config["max_output_tokens"] = self.max_tokens
+
+            # Stream
+            response_text = ""
+            stream_resp = await self.client.generate_content_async(messages, generation_config=generation_config)
+            async for chunk in stream_resp:
+                content = chunk.candidates[0].content.parts[0].text
+                response_text += content
+                yield content
+
+            # Save context
+            if response_text:
+                self.histories.append(messages[-1])
+                self.histories.append({"role": "model", "parts": [{"text": response_text}]})
+
+        except Exception as ex:
+            self.logger.error(f"Error at chat: {str(ex)}\n{traceback.format_exc()}")
+            raise ex
+        
+        finally:
+            self.last_chat_at = datetime.utcnow()


### PR DESCRIPTION
We support Claude and Gemini as the Generative AI to process chat.

## Claude

Create instance of `ClaudeProcessor` with custom parameters and set it to `AIAvatar`. The default model is `claude-3-sonnet-20240229`.

```python
from aiavatar.processors.claude import ClaudeProcessor

claude_processor = ClaudeProcessor(
    api_key="ANTHROPIC_API_KEY"
)

app = AIAvatar(
    google_api_key=GOOGLE_API_KEY,
    chat_processor=claude_processor
)
```

NOTE: We support Claude 3 on Anthropic API, not Amazon Bedrock for now.


## Gemini

Create instance of `GeminiProcessor` with custom parameters and set it to `AIAvatar`. The default model is `gemini-pro`.

```python
from aiavatar.processors.gemini import GeminiProcessor

gemini_processor = GeminiProcessor(
    api_key="YOUR_GOOGLE_API_KEY"
)

app = AIAvatar(
    google_api_key=GOOGLE_API_KEY,
    chat_processor=gemini_processor
)
```

NOTE: We support Gemini on Google AI Studio, not Vertex AI for now.
