### PR TITLE
Add experimental support for OpenAI audio APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,59 @@ azure_wakeword_listener = AzureWakewordListener(
 )
 ```
 
+
+## 🍥 Using OpenAI's audio APIs
+
+OpenAI's Speech-to-Text and Text-to-Speech capabilities provide dynamic speech recognition and voice output across multiple languages, without the need for fixed language settings.
+
+```python
+from aiavatar import AIAvatar
+from aiavatar.device import AudioDevice
+from aiavatar.listeners.openailisteners import (
+    OpenAIWakewordListener,
+    OpenAIVoiceRequestListener
+)
+from aiavatar.speech.openaispeech import OpenAISpeechController
+
+# Get default audio devices
+devices = AudioDevice()
+
+# Speech
+speech_controller = OpenAISpeechController(
+    api_key=OPENAI_API_KEY,
+    device_index=devices.output_device
+)
+
+# Wakeword
+async def on_wakeword(text):
+    await app.start_chat(request_on_start=text, skip_start_voice=True)
+
+wakeword_listener = OpenAIWakewordListener(
+    api_key=OPENAI_API_KEY,
+    device_index=devices.input_device,
+    wakewords=["こんにちは"],
+    on_wakeword=on_wakeword
+)
+
+# Request
+request_listener = OpenAIVoiceRequestListener(
+    api_key=OPENAI_API_KEY,
+    device_index=devices.input_device
+)
+
+# Create AIAvatar with OpenAI Components
+app = AIAvatar(
+    openai_api_key=OPENAI_API_KEY,
+    wakeword_listener=wakeword_listener,
+    request_listener=request_listener,
+    speech_controller=speech_controller,
+    noise_margin=10.0,
+    verbose=True
+)
+app.start_listening_wakeword()
+```
+
+
 ## 🔈 Audio device
 
 You can specify the audio devices to be used in components by name or index.

--- a/aiavatar/listeners/openailisteners.py
+++ b/aiavatar/listeners/openailisteners.py
@@ -1,0 +1,55 @@
+from logging import getLogger, NullHandler
+from io import BytesIO
+import wave
+import aiohttp
+from .voicerequest import VoiceRequestListener
+from .wakeword import WakewordListener
+
+
+logger = getLogger(__name__)
+logger.addHandler(NullHandler())
+
+
+def to_wave_file(raw_audio, rate):
+    buffer = BytesIO()
+    with wave.open(buffer, "wb") as wf:
+        wf.setnchannels(1)  # mono
+        wf.setsampwidth(2)  # 16bit
+        wf.setframerate(rate)  # sample rate
+        wf.writeframes(raw_audio)
+    buffer.seek(0)
+    return buffer
+
+
+async def openai_transcribe(api_key: str, rate: int, audio_data: list) -> str:
+    headers = {
+        "Authorization": f"Bearer {api_key}"
+    }
+
+    data = aiohttp.FormData()
+    data.add_field("file", to_wave_file(audio_data, rate), filename="audio.wav", content_type="audio/wav")
+    data.add_field("model", "whisper-1")
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            "https://api.openai.com/v1/audio/transcriptions",
+            headers=headers,
+            data=data
+        ) as resp:
+            j = await resp.json()
+
+            if resp.status != 200:
+                logger.error(f"Failed in recognition: {resp.status}\n{j}")
+                return None
+
+            return j.get("text")
+
+
+class OpenAIVoiceRequestListener(VoiceRequestListener):
+    async def transcribe(self, audio_data: list) -> str:
+        return await openai_transcribe(self.api_key, self.rate, audio_data)
+
+
+class OpenAIWakewordListener(WakewordListener):
+    async def transcribe(self, audio_data: list) -> str:
+        return await openai_transcribe(self.api_key, self.rate, audio_data)

--- a/aiavatar/speech/openaispeech.py
+++ b/aiavatar/speech/openaispeech.py
@@ -1,0 +1,34 @@
+import aiohttp
+from . import SpeechControllerBase, VoiceClip
+from .soundplayers import SoundPlayerBase
+
+class OpenAISpeechController(SpeechControllerBase):
+    def __init__(self, *, api_key: str=None, base_url: str=None, voice: str="alloy", model: str="tts-1", speed: float=1.0, device_index: int=-1, playback_margin: float=0.1, use_subprocess=True, subprocess_timeout: float=5.0, sound_player: SoundPlayerBase=None):
+        super().__init__(
+            base_url=base_url,
+            rate=None,
+            device_index=device_index,
+            playback_margin=playback_margin,
+            use_subprocess=use_subprocess,
+            subprocess_timeout=subprocess_timeout,
+            sound_player=sound_player
+        )
+        self.api_key = api_key
+        # alloy, echo, fable, onyx, nova, and shimmer
+        self.voice = voice
+        self.model = model
+        self.speed = speed
+
+    async def download(self, voice: VoiceClip):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        json = {
+            "model": self.model,
+            "voice": self.voice,
+            "input": voice.text,
+            "speed": self.speed,
+            "response_format": "wav"
+        }
+        url = (self.base_url or "https://api.openai.com/v1") + "/audio/speech"
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=json) as audio_resp:
+                voice.audio_clip = await audio_resp.read()


### PR DESCRIPTION
Add multilingual support for SpeechListeners using OpenAI's Speech-to-Text and SpeechController using Text-to-Speech. This update allows to handle both speech recognition and voice output in multiple languages dynamically, without needing explicit and static language settings.

Usage:

```python
from aiavatar import AIAvatar
from aiavatar.device import AudioDevice
from aiavatar.listeners.openailisteners import (
    OpenAIWakewordListener,
    OpenAIVoiceRequestListener
)
from aiavatar.speech.openaispeech import OpenAISpeechController

# Get default audio devices
devices = AudioDevice()

# Speech
speech_controller = OpenAISpeechController(
    api_key=OPENAI_API_KEY,
    device_index=devices.output_device
)

# Wakeword
async def on_wakeword(text):
    await app.start_chat(request_on_start=text, skip_start_voice=True)

wakeword_listener = OpenAIWakewordListener(
    api_key=OPENAI_API_KEY,
    device_index=devices.input_device,
    wakewords=["こんにちは"],
    on_wakeword=on_wakeword
)

# Request
request_listener = OpenAIVoiceRequestListener(
    api_key=OPENAI_API_KEY,
    device_index=devices.input_device
)

# Create AIAvatar with OpenAI Components
app = AIAvatar(
    openai_api_key=OPENAI_API_KEY,
    wakeword_listener=wakeword_listener,
    request_listener=request_listener,
    speech_controller=speech_controller,
    noise_margin=10.0,
    verbose=True
)
app.start_listening_wakeword()
```