### PR TITLE
Add experimental support for vision input to ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Feel free to enjoy the conversation afterwards!
 - [🧩 RESTful APIs](#-restful-apis)
 - [🤿 Deep Dive](#-deep-dive)
   - [⚡️ Function Calling](#️-function-calling)
+  - [👀 Vision](#️-vision)
 - [🔍 Other Tips](#-other-tips)
   - [🎤 Testing Audio I/O](#-testing-audio-io)
   - [🎚️ Noise Filter](#-noise-filter)
@@ -764,6 +765,45 @@ And, after `get_weather` called, message to get voice response will be sent to C
     "name": "get_weather"
 }
 ```
+
+
+## 👀 Vision
+
+We provide the experimental support for vision input to ChatGPT. A new class, ChatGPTProcessorWithVisionBase, has been added to handle image inputs, inheriting from ChatGPTProcessor.
+
+An example implementation, ChatGPTProcessorWithVisionScreenShot, demonstrates how to capture screenshots using pyautogui. This gives "eyes" to your AIAvatar in metaverse platforms like VRChat.
+
+```python
+import io
+import pyautogui
+
+class ChatGPTProcessorWithVisionScreenShot(ChatGPTProcessorWithVisionBase):
+    async def get_image(self) -> bytes:
+        buffered = io.BytesIO()
+        image = pyautogui.screenshot(region=(0, 0, 1280, 720))
+        image.save(buffered, format="PNG")
+        image.save("image_to_chatgpt.png")
+        return buffered.getvalue()
+```
+
+To use this new feature, you can instantiate ChatGPTProcessorWithVisionScreenShot instead of ChatGPTProcessor and set it in the AIAvatar.
+
+```python
+chat_processor = ChatGPTProcessorWithVisionScreenShot(
+    api_key=OPENAI_API_KEY,
+    system_message_content=PROMPT
+)
+
+app = AIAvatar(
+    google_api_key=GOOGLE_API_KEY,
+    chat_processor=chat_processor
+)
+```
+
+**NOTE**
+
+* Only the latest image will be sent to ChatGPT to avoid performance issues.
+* The system uses function calling to determine if image retrieval is necessary, which adds approximately 500 milliseconds to 1 second to the processing time.
 
 
 # 🔍 Other Tips

--- a/tests/processors/test_chatgpt.py
+++ b/tests/processors/test_chatgpt.py
@@ -4,7 +4,7 @@ from aiavatar.processors.chatgpt import ChatGPTProcessor
 
 @pytest.fixture
 def chatgpt_processor():
-    return ChatGPTProcessor("YOUR_API_KEY", temperature=0.0, history_timeout=5.0)
+    return ChatGPTProcessor(api_key="YOUR_API_KEY", temperature=0.0, history_timeout=5.0)
 
 @pytest.mark.asyncio
 async def test_chat(chatgpt_processor: ChatGPTProcessor):
@@ -37,16 +37,17 @@ async def test_reset_histories(chatgpt_processor: ChatGPTProcessor):
 
     assert len(chatgpt_processor.histories) == 0
 
-def test_build_messages(chatgpt_processor: ChatGPTProcessor):
+@pytest.mark.asyncio
+async def test_build_messages(chatgpt_processor: ChatGPTProcessor):
     # Just current user message
     current_user_message = "current user message"
-    messages = chatgpt_processor.build_messages(current_user_message)
+    messages = await chatgpt_processor.build_messages(current_user_message)
     assert len(messages) == 1
     assert messages[-1]["content"] == current_user_message
 
     # With system message
     chatgpt_processor.system_message_content = "system message content"
-    messages = chatgpt_processor.build_messages(current_user_message)
+    messages = await chatgpt_processor.build_messages(current_user_message)
     assert len(messages) == 2
     assert messages[0]["content"] == chatgpt_processor.system_message_content
     assert messages[-1]["content"] == current_user_message
@@ -59,14 +60,14 @@ def test_build_messages(chatgpt_processor: ChatGPTProcessor):
 
     # With histories
     chatgpt_processor.system_message_content = None
-    messages = chatgpt_processor.build_messages(current_user_message)
+    messages = await chatgpt_processor.build_messages(current_user_message)
     assert len(messages) == 5
     assert messages[0]["content"] == "user message 1"
     assert messages[-1]["content"] == current_user_message
 
     # With system message + histories
     chatgpt_processor.system_message_content = "system message content"
-    messages = chatgpt_processor.build_messages(current_user_message)
+    messages = await chatgpt_processor.build_messages(current_user_message)
     assert len(messages) == 6
     assert messages[0]["content"] == chatgpt_processor.system_message_content
     assert messages[1]["content"] == "user message 1"
@@ -74,7 +75,7 @@ def test_build_messages(chatgpt_processor: ChatGPTProcessor):
 
     # After reset histories
     chatgpt_processor.reset_histories()
-    messages = chatgpt_processor.build_messages(current_user_message)
+    messages = await chatgpt_processor.build_messages(current_user_message)
     assert len(messages) == 2
     assert messages[0]["content"] == chatgpt_processor.system_message_content
     assert messages[-1]["content"] == current_user_message


### PR DESCRIPTION
This update introduces experimental support for vision input to ChatGPT. A new class, ChatGPTProcessorWithVisionBase, has been added to handle image inputs, inheriting from ChatGPTProcessor. An example implementation, ChatGPTProcessorWithVisionScreenShot, demonstrates how to capture screenshots using pyautogui.

```python
import io
import pyautogui

class ChatGPTProcessorWithVisionScreenShot(ChatGPTProcessorWithVisionBase):
    async def get_image(self) -> bytes:
        buffered = io.BytesIO()
        image = pyautogui.screenshot(region=(0, 0, 1280, 720))
        image.save(buffered, format="PNG")
        image.save("image_to_chatgpt.png")
        return buffered.getvalue()
```

To utilize this new feature, you can instantiate ChatGPTProcessorWithVisionScreenShot instead of ChatGPTProcessor and set it in the AIAvatar. Only the latest image will be sent to ChatGPT to avoid performance issues. The system uses function calling to determine if image retrieval is necessary, which adds approximately 500 milliseconds to 1 second to the processing time.