### PR TITLE
Support voice detection threshold per session

### DIFF
--- a/aiavatar/adapter/local/client.py
+++ b/aiavatar/adapter/local/client.py
@@ -150,9 +150,10 @@ class AIAvatar(AIAvatarClientBase):
             aiavatar_response.avatar_control_request = self.parse_avatar_control_request(response.text)
 
         elif response.type == "final":
-            if image_source_match := re.search(r"\[vision:(\w+)\]", response.text):
-                aiavatar_response.type = "vision"
-                aiavatar_response.metadata={"source": image_source_match.group(1)}
+            if response.text:
+                if image_source_match := re.search(r"\[vision:(\w+)\]", response.text):
+                    aiavatar_response.type = "vision"
+                    aiavatar_response.metadata={"source": image_source_match.group(1)}
 
         await self.response_queue.put(aiavatar_response)
 
@@ -174,7 +175,7 @@ class AIAvatar(AIAvatarClientBase):
             volume_threshold_db = int(noise_level) + self.noise_margin
 
             logger.info(f"Set volume threshold: {volume_threshold_db}dB")
-            self.sts.volume_db_threshold = volume_threshold_db
+            self.sts.vad.set_volume_db_threshold(session_id, volume_threshold_db)
         else:
             logger.info(f"Set volume threshold: {self.sts.vad.volume_db_threshold}dB")
 

--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -121,6 +121,11 @@ class AIAvatarWebSocketServer(WebSocketAdapter):
             audio_data = base64.b64decode(request.audio_data)
             await self.sts.vad.process_samples(audio_data, request.session_id)
 
+        elif request.type == "config":
+            volume_db_threshold = request.metadata.get("volume_db_threshold")
+            if volume_db_threshold:
+                self.sts.vad.set_volume_db_threshold(request.session_id, volume_db_threshold)
+
         elif request.type == "stop":
             logger.info(f"WebSocket disconnect for session: {request.session_id}")
             await websocket.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-litests>=0.3.7
+litests>=0.3.8
 numpy>=2.2.3
 PyAudio>=0.2.14

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     # long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["examples*", "tests*"]),
-    install_requires=["litests>=0.3.7", "numpy>=2.2.3", "PyAudio>=0.2.14"],
+    install_requires=["litests>=0.3.8", "numpy>=2.2.3", "PyAudio>=0.2.14"],
     license="Apache v2",
     classifiers=[
         "Programming Language :: Python :: 3"


### PR DESCRIPTION
Internal change.

To adjust threshold in WebSocket, send `config` message like below:

```json
{ "type": "config", "session_id": "SESSION_ID", "metadata": {"volume_db_threshold": -30} }
```