### PR TITLE
Enable embedding parameters into system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,32 @@ aiavatar_app = AIAvatar(
 ```
 
 
+### 📋 System Prompt Parameters
+
+You can embed parameters into your system prompt dynamically.
+
+First, define your `AIAvatar` instance with a system prompt containing placeholders:
+
+```python
+aiavatar_app = AIAvatar(
+    openai_api_key="YOUR_OPENAI_API_KEY",
+    model="gpt-4o",
+    system_prompt="User's name is {name}."
+)
+```
+
+When invoking, pass the parameters as a dictionary using `system_prompt_params`:
+
+```python
+aiavatar_app.sts.invoke(STSRequest(
+    # (other fields omitted)
+    system_prompt_params={"name": "Nekochan"}
+))
+```
+
+Placeholders in the system prompt, such as `{name}`, will be replaced with the corresponding values at runtime.
+
+
 ### 🔈 Audio device
 
 You can specify the audio devices to be used in components by device index.

--- a/aiavatar/adapter/http/client.py
+++ b/aiavatar/adapter/http/client.py
@@ -70,6 +70,7 @@ class AIAvatarHttpClient(AIAvatarClientBase):
                 text=None,
                 audio_data=data,
                 files=[],
+                system_prompt_params={},
                 metadata={}
             ))
 

--- a/aiavatar/adapter/http/server.py
+++ b/aiavatar/adapter/http/server.py
@@ -134,7 +134,8 @@ class AIAvatarHttpServer(Adapter):
                     context_id=request.context_id,
                     text=request.text,
                     audio_data=request.audio_data,
-                    files=request.files
+                    files=request.files,
+                    system_prompt_params=request.system_prompt_params
                 )):
                     aiavatar_response = AIAvatarResponse(
                         type=response.type,

--- a/aiavatar/adapter/local/client.py
+++ b/aiavatar/adapter/local/client.py
@@ -107,7 +107,8 @@ class AIAvatar(AIAvatarClientBase):
             context_id=request.context_id,
             text=request.text,
             audio_data=request.audio_data,
-            files=request.files
+            files=request.files,
+            system_prompt_params=request.system_prompt_params
         )):
             await self.sts.handle_response(r)
 

--- a/aiavatar/adapter/models.py
+++ b/aiavatar/adapter/models.py
@@ -17,6 +17,7 @@ class AIAvatarRequest(BaseModel):
     text: Optional[str] = None
     audio_data: Optional[Union[bytes, str]] = None
     files: Optional[List[Dict[str, str]]] = None
+    system_prompt_params: Optional[Dict] = None
     metadata: Optional[Dict] = None
 
 

--- a/aiavatar/adapter/websocket/client.py
+++ b/aiavatar/adapter/websocket/client.py
@@ -55,7 +55,8 @@ class AIAvatarWebSocketClient(AIAvatarClientBase):
                 context_id=request.context_id,
                 text=request.text,
                 audio_data=request.audio_data,
-                files=request.files
+                files=request.files,
+                system_prompt_params=request.system_prompt_params
             ).model_dump_json()
         )
 

--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -125,7 +125,8 @@ class AIAvatarWebSocketServer(WebSocketAdapter):
                 context_id=request.context_id,
                 text=request.text,
                 audio_data=request.audio_data,
-                files=request.files
+                files=request.files,
+                system_prompt_params=request.system_prompt_params
             )):
                 await self.sts.handle_response(r)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="aiavatar",
-    version="0.6.4",
+    version="0.6.5",
     url="https://github.com/uezo/aiavatar",
     author="uezo",
     author_email="uezo@uezo.net",


### PR DESCRIPTION
First, define your `AIAvatar` instance with a system prompt containing placeholders:

```python
aiavatar_app = AIAvatar(
    openai_api_key="YOUR_OPENAI_API_KEY",
    model="gpt-4o",
    system_prompt="User's name is {name}."
)
```

When invoking, pass the parameters as a dictionary using `system_prompt_params`:

```python
aiavatar_app.sts.invoke(STSRequest(
    # (other fields omitted)
    system_prompt_params={"name": "Nekochan"}
))
```

Placeholders in the system prompt, such as `{name}`, will be replaced with the corresponding values at runtime.