### PR TITLE
Add support for Tool Call with Streaming Progress

### DIFF
--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -226,7 +226,14 @@ class ChatGPTService(LLMService):
                     else:
                         tool_result = {"message": "No tools found"}
                 else:
-                    tool_result = await self.execute_tool(tc.name, json.loads(tc.arguments), {"user_id": user_id})
+                    async for tr, is_final in self.execute_tool(tc.name, json.loads(tc.arguments), {"user_id": user_id}):
+                        if is_final:
+                            tool_result = tr
+                            break
+                        else:
+                            tc.progress = tr
+                            yield LLMResponse(context_id=context_id, tool_call=tc)
+
                 if self.debug:
                     logger.info(f"ToolCall result: {tool_result}")
 

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -215,7 +215,14 @@ class ClaudeService(LLMService):
                     else:
                         tool_result = {"message": "No tools found"}
                 else:
-                    tool_result = await self.execute_tool(tc.name, arguments_json, {"user_id": user_id})
+                    async for tr, is_final in self.execute_tool(tc.name, arguments_json, {"user_id": user_id}):
+                        if is_final:
+                            tool_result = tr
+                            break
+                        else:
+                            tc.progress = tr
+                            yield LLMResponse(context_id=context_id, tool_call=tc)
+
                 if self.debug:
                     logger.info(f"ToolCall result: {tool_result}")
 

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -261,7 +261,14 @@ class GeminiService(LLMService):
                     else:
                         tool_result = {"message": "No tools found"}
                 else:
-                    tool_result = await self.execute_tool(tc.name, tc.arguments, {"user_id": user_id})
+                    async for tr, is_final in self.execute_tool(tc.name, tc.arguments, {"user_id": user_id}):
+                        if is_final:
+                            tool_result = tr
+                            break
+                        else:
+                            tc.progress = tr
+                            yield LLMResponse(context_id=context_id, tool_call=tc)
+
                 if self.debug:
                     logger.info(f"ToolCall result: {tool_result}")
 

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -235,7 +235,14 @@ class LiteLLMService(LLMService):
                     else:
                         tool_result = {"message": "No tools found"}
                 else:
-                    tool_result = await self.execute_tool(tc.name, json.loads(tc.arguments), {"user_id": user_id})
+                    async for tr, is_final in self.execute_tool(tc.name, json.loads(tc.arguments), {"user_id": user_id}):
+                        if is_final:
+                            tool_result = tr
+                            break
+                        else:
+                            tc.progress = tr
+                            yield LLMResponse(context_id=context_id, tool_call=tc)
+
                 if self.debug:
                     logger.info(f"ToolCall result: {tool_result}")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="aiavatar",
-    version="0.7.0",
+    version="0.7.1",
     url="https://github.com/uezo/aiavatar",
     author="uezo",
     author_email="uezo@uezo.net",

--- a/tests/sts/llm/context_manager/test_pg_context_manager.py
+++ b/tests/sts/llm/context_manager/test_pg_context_manager.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 import json
 import os
+from uuid import uuid4
 import pytest
 from aiavatar.sts.llm.context_manager.postgres import PostgreSQLContextManager
 
@@ -28,7 +29,7 @@ async def test_get_histories_empty(context_manager):
 
 @pytest.mark.asyncio
 async def test_add_and_get_histories(context_manager):
-    context_id = "test_context"
+    context_id = f"test_context_{uuid4()}"
     data_list = [
         {"message": "Hello, world!", "role": "user"},
         {"message": "Hi! How can I help you today?", "role": "assistant"}
@@ -47,7 +48,7 @@ async def test_add_and_get_histories(context_manager):
 
 @pytest.mark.asyncio
 async def test_get_histories_limit(context_manager):
-    context_id = "test_limit"
+    context_id = f"test_context_limit_{uuid4()}"
     data_list = [
         {"index": 1}, {"index": 2}, {"index": 3}, {"index": 4}, {"index": 5}
     ]
@@ -64,7 +65,7 @@ async def test_get_histories_limit(context_manager):
 
 @pytest.mark.asyncio
 async def test_get_histories_timeout(context_manager):
-    context_id = "test_timeout"
+    context_id = f"test_context_timeout_{uuid4()}"
     
     old_data = {"message": "Old data"}
     new_data = {"message": "New data"}

--- a/tests/sts/llm/test_chatgpt.py
+++ b/tests/sts/llm/test_chatgpt.py
@@ -1,9 +1,10 @@
+import asyncio
 import json
 import os
 import pytest
-from typing import Any, Dict
+from typing import Any, Dict, AsyncGenerator, Tuple
 from uuid import uuid4
-from aiavatar.sts.llm.chatgpt import ChatGPTService, ToolCall
+from aiavatar.sts.llm.chatgpt import ChatGPTService, ToolCall, Tool
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 IMAGE_URL = os.getenv("IMAGE_URL")
@@ -239,6 +240,89 @@ async def test_chatgpt_service_tool_calls():
 
     async for resp in service.chat_stream(context_id, "test_user", user_message):
         collected_text.append(resp.text)
+
+    # Check context
+    messages = await service.context_manager.get_histories(context_id)
+    assert len(messages) == 4
+
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == user_message
+
+    assert messages[1]["role"] == "assistant"
+    assert messages[1]["tool_calls"] is not None
+    assert messages[1]["tool_calls"][0]["function"]["name"] == "solve_math"
+    tool_call_id = messages[1]["tool_calls"][0]["id"]
+
+    assert messages[2]["role"] == "tool"
+    assert messages[2]["tool_call_id"] == tool_call_id
+    assert messages[2]["content"] == json.dumps({"answer": 2})
+
+    assert messages[3]["role"] == "assistant"
+    assert "2" in messages[3]["content"]
+
+    await service.openai_client.close()
+
+@pytest.mark.asyncio
+async def test_chatgpt_service_tool_calls_iter():
+    """
+    Test ChatGPTService with a registered tool that returns iteration.
+    The conversation might trigger the tool call, then the tool's result is fed back.
+    This is just an example. The actual trigger depends on the model response.
+    """
+    service = ChatGPTService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="You can call a tool to solve math problems if necessary.",
+        model=MODEL,
+        temperature=0.5
+    )
+    context_id = f"test_tool_iter_context_{uuid4()}"
+
+    # Register tool
+    tool_spec = {
+        "type": "function",
+        "function": {
+            "name": "solve_math",
+            "description": "Solve simple math problems",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "problem": {"type": "string"}
+                },
+                "required": ["problem"]
+            }
+        }
+    }
+    @service.tool(tool_spec)
+    async def solve_math(problem: str) -> AsyncGenerator[Tuple[Dict[str, Any], bool], None]:
+        """
+        Tool function example: parse the problem and return a result.
+        """
+        yield {"message": "It takes long time..."}, False
+        await asyncio.sleep(3)
+        yield {"message": "Solved! Preparing answer..."}, False
+        if problem.strip() == "1+1":
+            yield {"answer": 2}, True
+        else:
+            yield {"answer": "unknown"}, True
+
+    @service.on_before_tool_calls
+    async def on_before_tool_calls(tool_calls: list[ToolCall]):
+        assert len(tool_calls) > 0
+
+    user_message = "次の問題を解いて: 1+1"
+    collected_text = []
+
+    progress = []
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        if resp.tool_call:
+            if resp.tool_call.progress:
+                progress.append(resp.tool_call.progress)
+        collected_text.append(resp.text)
+
+    # Check progress
+    assert len(progress) == 2
+    assert progress[0]["message"] == "It takes long time..."
+    assert progress[1]["message"] == "Solved! Preparing answer..."
 
     # Check context
     messages = await service.context_manager.get_histories(context_id)

--- a/tests/sts/llm/test_chatgpt_azure.py
+++ b/tests/sts/llm/test_chatgpt_azure.py
@@ -1,9 +1,10 @@
+import asyncio
 import json
 import os
 import pytest
-from typing import Any, Dict
+from typing import Any, Dict, AsyncGenerator, Tuple
 from uuid import uuid4
-from aiavatar.sts.llm.chatgpt import ChatGPTService, ToolCall
+from aiavatar.sts.llm.chatgpt import ChatGPTService, ToolCall, Tool
 
 AZURE_OPENAI_API_KEY = os.getenv("AZURE_OPENAI_API_KEY")
 AZURE_OPENAI_ENDPOINT = os.getenv("AZURE_OPENAI_ENDPOINT")
@@ -244,6 +245,91 @@ async def test_chatgpt_azure_service_tool_calls():
 
     async for resp in service.chat_stream(context_id, "test_user", user_message):
         collected_text.append(resp.text)
+
+    # Check context
+    messages = await service.context_manager.get_histories(context_id)
+    assert len(messages) == 4
+
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == user_message
+
+    assert messages[1]["role"] == "assistant"
+    assert messages[1]["tool_calls"] is not None
+    assert messages[1]["tool_calls"][0]["function"]["name"] == "solve_math"
+    tool_call_id = messages[1]["tool_calls"][0]["id"]
+
+    assert messages[2]["role"] == "tool"
+    assert messages[2]["tool_call_id"] == tool_call_id
+    assert messages[2]["content"] == json.dumps({"answer": 2})
+
+    assert messages[3]["role"] == "assistant"
+    assert "2" in messages[3]["content"]
+
+    await service.openai_client.close()
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_azure_service_tool_calls_iter():
+    """
+    Test ChatGPTService with a registered tool that returns iteration.
+    The conversation might trigger the tool call, then the tool's result is fed back.
+    This is just an example. The actual trigger depends on the model response.
+    """
+    service = ChatGPTService(
+        openai_api_key=AZURE_OPENAI_API_KEY,
+        base_url=AZURE_OPENAI_ENDPOINT,
+        system_prompt="You can call a tool to solve math problems if necessary.",
+        model="azure",
+        temperature=0.5
+    )
+    context_id = f"test_tool_context_iter_{uuid4()}"
+
+    # Register tool
+    tool_spec = {
+        "type": "function",
+        "function": {
+            "name": "solve_math",
+            "description": "Solve simple math problems",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "problem": {"type": "string"}
+                },
+                "required": ["problem"]
+            }
+        }
+    }
+    @service.tool(tool_spec)
+    async def solve_math(problem: str) -> AsyncGenerator[Tuple[Dict[str, Any], bool], None]:
+        """
+        Tool function example: parse the problem and return a result.
+        """
+        yield {"message": "It takes long time..."}, False
+        await asyncio.sleep(3)
+        yield {"message": "Solved! Preparing answer..."}, False
+        if problem.strip() == "1+1":
+            yield {"answer": 2}, True
+        else:
+            yield {"answer": "unknown"}, True
+
+    @service.on_before_tool_calls
+    async def on_before_tool_calls(tool_calls: list[ToolCall]):
+        assert len(tool_calls) > 0
+
+    user_message = "次の問題を解いて: 1+1"
+    collected_text = []
+
+    progress = []
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        if resp.tool_call:
+            if resp.tool_call.progress:
+                progress.append(resp.tool_call.progress)
+        collected_text.append(resp.text)
+
+    # Check progress
+    assert len(progress) == 2
+    assert progress[0]["message"] == "It takes long time..."
+    assert progress[1]["message"] == "Solved! Preparing answer..."
 
     # Check context
     messages = await service.context_manager.get_histories(context_id)


### PR DESCRIPTION
This commit enables tool functions to return progress updates via async generators.

By yielding intermediate values with a `done=False` flag and a final result with `done=True`, tools can now provide real-time feedback during long-running operations.

This is especially useful in voice-based scenarios or when integrating with external agent frameworks, where user experience benefits from incremental updates.

Example:

```python
yield ({"message": "Resolving location"}, False)
yield ({"message": "Calling weather API"}, False)
yield ({"weather": "clear", "temperature": 23.4}, True)  # Final response
```