### PR TITLE
Add voice feedback support for streaming tool calls

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -11,9 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 class ToolCallResult:
-    def __init__(self, data: dict = None, is_final: bool = True):
+    def __init__(self, data: dict = None, is_final: bool = True, text: str = None):
         self.data = data or {}
         self.is_final = is_final
+        self.text = text
 
 
 class ToolCall:
@@ -239,10 +240,14 @@ The list of tools is as follows:
             async for r in tool_result:
                 if isinstance(r, Tuple):
                     yield ToolCallResult(data=r[0], is_final=r[1])
+                elif isinstance(r, dict):
+                    yield ToolCallResult(data=r, is_final=False)
+                elif isinstance(r, str):
+                    yield ToolCallResult(text=r, is_final=False)
                 else:
                     yield r
         elif isinstance(tool_result, ToolCallResult):
-            yield await tool_result
+            yield tool_result
         else:
             yield ToolCallResult(data=await tool_result)
 

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -231,10 +231,13 @@ class ChatGPTService(LLMService):
                 else:
                     async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"user_id": user_id}):
                         tc.result = tr
-                        yield LLMResponse(context_id=context_id, tool_call=tc)
-                        if tr.is_final:
-                            tool_result = tr.data
-                            break
+                        if tr.text:
+                            yield LLMResponse(context_id=context_id, text=tr.text)
+                        else:
+                            yield LLMResponse(context_id=context_id, tool_call=tc)
+                            if tr.is_final:
+                                tool_result = tr.data
+                                break
 
                 if self.debug:
                     logger.info(f"ToolCall result: {tool_result}")

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -231,10 +231,13 @@ class ClaudeService(LLMService):
                 else:
                     async for tr in self.execute_tool(tc.name, arguments_json, {"user_id": user_id}):
                         tc.result = tr
-                        yield LLMResponse(context_id=context_id, tool_call=tc)
-                        if tr.is_final:
-                            tool_result = tr.data
-                            break
+                        if tr.text:
+                            yield LLMResponse(context_id=context_id, text=tr.text)
+                        else:
+                            yield LLMResponse(context_id=context_id, tool_call=tc)
+                            if tr.is_final:
+                                tool_result = tr.data
+                                break
 
                 if self.debug:
                     logger.info(f"ToolCall result: {tool_result}")

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -301,10 +301,13 @@ class GeminiService(LLMService):
 
                     async for tr in self.execute_tool(tc.name, tc.arguments, {"user_id": user_id}):
                         tc.result = tr
-                        yield LLMResponse(context_id=context_id, tool_call=tc)
-                        if tr.is_final:
-                            tool_result = tr.data
-                            break
+                        if tr.text:
+                            yield LLMResponse(context_id=context_id, text=tr.text)
+                        else:
+                            yield LLMResponse(context_id=context_id, tool_call=tc)
+                            if tr.is_final:
+                                tool_result = tr.data
+                                break
 
                 if self.debug:
                     logger.info(f"ToolCall result: {tool_result}")

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -240,10 +240,13 @@ class LiteLLMService(LLMService):
                 else:
                     async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"user_id": user_id}):
                         tc.result = tr
-                        yield LLMResponse(context_id=context_id, tool_call=tc)
-                        if tr.is_final:
-                            tool_result = tr.data
-                            break
+                        if tr.text:
+                            yield LLMResponse(context_id=context_id, text=tr.text)
+                        else:
+                            yield LLMResponse(context_id=context_id, tool_call=tc)
+                            if tr.is_final:
+                                tool_result = tr.data
+                                break
 
                 if self.debug:
                     logger.info(f"ToolCall result: {tool_result}")


### PR DESCRIPTION
Allow yielding string values in streaming tool calls to provide immediate voice feedback during processing, improving wait time experience in voice conversations.