### PR TITLE
Add update_context_filter hook to LLM services

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -124,6 +124,7 @@ class LLMService(ABC):
                 self.split_patterns.append(f"{re.escape(char)}\s?")
         self.option_split_chars_regex = f"({'|'.join(self.split_patterns)})\s*(?!.*({'|'.join(self.split_patterns)}))"
         self._request_filter = self.request_filter_default
+        self._update_context_filter = None
         self.voice_text_tag = voice_text_tag
         self.tools: Dict[str, Tool] = {}
         self.use_dynamic_tools = use_dynamic_tools
@@ -170,6 +171,10 @@ The list of tools is as follows:
 
     def request_filter_default(self, text: str) -> str:
         return text
+
+    def update_context_filter(self, func):
+        self._update_context_filter = func
+        return func
 
     def tool(self, spec):
         def decorator(func):

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -100,6 +100,12 @@ class ChatGPTService(LLMService):
         return messages
 
     async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
+        if self._update_context_filter:
+            if isinstance(messages[0]["content"], list):
+                if "text" in messages[0]["content"][-1]:
+                    messages[0]["content"][-1]["text"] = self._update_context_filter(messages[0]["content"][-1]["text"])
+            elif isinstance(messages[0]["content"], str):
+                messages[0]["content"] = self._update_context_filter(messages[0]["content"])
         messages.append({"role": "assistant", "content": response_text})
         await self.context_manager.add_histories(context_id, messages, "chatgpt")
 

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -89,6 +89,9 @@ class ClaudeService(LLMService):
         return messages
 
     async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
+        if self._update_context_filter:
+            if "text" in messages[0]["content"][-1]:
+                messages[0]["content"][-1]["text"] = self._update_context_filter(messages[0]["content"][-1]["text"])
         messages.append({"role": "assistant", "content": [{"type": "text", "text": response_text}]})
         await self.context_manager.add_histories(context_id, messages, "claude")
 

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -116,6 +116,10 @@ class GeminiService(LLMService):
                 if inline_data and "data" in inline_data:
                     inline_data["data"] = base64.b64encode(inline_data["data"]).decode("utf-8")
             dict_messages.append(dumped)
+
+        if self._update_context_filter:
+            if "text" in dict_messages[0]["parts"][-1]:
+                dict_messages[0]["parts"][-1]["text"] = self._update_context_filter(dict_messages[0]["parts"][-1]["text"])
         await self.context_manager.add_histories(context_id, dict_messages, "gemini")
 
     async def preflight(self):

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -99,6 +99,12 @@ class LiteLLMService(LLMService):
         return messages
 
     async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
+        if self._update_context_filter:
+            if isinstance(messages[0]["content"], list):
+                if "text" in messages[0]["content"][-1]:
+                    messages[0]["content"][-1]["text"] = self._update_context_filter(messages[0]["content"][-1]["text"])
+            elif isinstance(messages[0]["content"], str):
+                messages[0]["content"] = self._update_context_filter(messages[0]["content"])
         messages.append({"role": "assistant", "content": response_text})
         await self.context_manager.add_histories(context_id, messages, "chatgpt")
 


### PR DESCRIPTION
Introduces an optional _update_context_filter attribute and update_context_filter decorator to LLMService, allowing custom filtering of context updates in ChatGPT, Claude, Gemini, and LiteLLM services. This enables preprocessing or modification of message content before saving context histories.