### PR TITLE
Add on_recording_started callback to VAD detectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,25 @@ vad = SileroSpeechDetector(
 
 You can also make custom VAD components by implementing `SpeechDetector` interface.
 
+### Speech Detection Callback
+
+SpeechDetectors supports an `on_recording_started` callback that gets triggered when speech recording starts and meets the minimum duration threshold. The callback will be executed asynchronously as a background task.
+
+```python
+from aiavatar.sts.vad.standard import StandardSpeechDetector
+
+async def my_recording_started_handler(session_id: str):
+    print(f"Recording started for session: {session_id}")
+    # Add your custom logic here
+
+detector = StandardSpeechDetector(
+    on_recording_started=my_recording_started_handler,
+    volume_db_threshold=-30.0,
+    silence_duration_threshold=0.5,
+    # other parameters...
+)
+```
+
 
 ## 🥰 Face expression
 

--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -322,8 +322,9 @@ The list of tools is as follows:
 
             stream_buffer += chunk.text
 
-            for spc in self.split_chars:
-                stream_buffer = stream_buffer.replace(spc, spc + "|")
+            # Replace consecutive punctuation with the same punctuation followed by delimiter
+            split_chars_escaped = [re.escape(char) for char in self.split_chars]
+            stream_buffer = re.sub("([" + "".join(split_chars_escaped) + "]+)", r"\1|", stream_buffer)
 
             if len(stream_buffer) > self.option_split_threshold:
                 stream_buffer = self.replace_last_option_split_char(stream_buffer)


### PR DESCRIPTION
Introduces an on_recording_started callback to both SileroSpeechDetector and StandardSpeechDetector, triggered when a recording exceeds min_duration.
Also improve consecutive punctuation handling in LLM streaming.

