### PR TITLE
Prevent errors with Azure OpenAI content filter streaming

### DIFF
--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -200,7 +200,7 @@ class ChatGPTService(LLMService):
         tool_calls: List[ToolCall] = []
         try_dynamic_tools = False
         async for chunk in stream_resp:
-            if not chunk.choices:
+            if not chunk.choices or not chunk.choices[0].delta: # Azure OpenAI with content filter (streaming mode) returns choices without delta
                 continue
 
             if chunk.choices[0].delta.tool_calls:


### PR DESCRIPTION
Azure OpenAI Content Filter in streaming mode returns chunks without delta field when sending filter results. Added null check to prevent errors when processing these chunks.