### PR TITLE
Add create_instant_synthesizer for HTTP-based TTS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,28 @@ from aiavatar.sts.tts.openai import OpenAISpeechSynthesizer
 from aiavatar.sts.tts.speech_gateway import SpeechGatewaySpeechSynthesizer
 ```
 
+### Instant TTS Synthesizer
+
+For quick setup of custom TTS services with HTTP API endpoints, use `create_instant_synthesizer`. This allows you to create a TTS synthesizer with just HTTP request parameters.
+
+```python
+from aiavatar.sts.tts.base import create_instant_synthesizer
+
+# Example: Style-Bert-VITS2 API
+sbv2_tts = create_instant_synthesizer(
+    method="POST",
+    url="http://127.0.0.1:5000/voice",
+    json={
+        "model_id": "0",
+        "speaker_id": "0",
+        "text": "{text}"  # Placeholder for processed text
+    }
+)
+```
+
+The `{text}` and `{language}` placeholders in params, headers, and json will be automatically replaced with the processed text and language values during synthesis.
+
+
 You can also make custom tts components by impelemting `SpeechSynthesizer` interface.
 
 ### Preprocessing

--- a/aiavatar/sts/tts/__init__.py
+++ b/aiavatar/sts/tts/__init__.py
@@ -1,1 +1,1 @@
-from .base import SpeechSynthesizer, SpeechSynthesizerDummy
+from .base import SpeechSynthesizer, SpeechSynthesizerDummy, create_instant_synthesizer

--- a/aiavatar/sts/tts/base.py
+++ b/aiavatar/sts/tts/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from typing import Dict, List, Callable, Optional
 import httpx
 import logging
 from .preprocessor import TTSPreprocessor
@@ -57,3 +57,62 @@ class SpeechSynthesizer(ABC):
 class SpeechSynthesizerDummy(SpeechSynthesizer):
     async def synthesize(self, text: str, style_info: dict = None, language: str = None) -> bytes:
         return None
+
+
+def create_instant_synthesizer(
+    *,
+    method: str, url: str, params: dict = None, headers: dict = None, json: dict = None,
+    request_maker: Callable[[str, Optional[dict], Optional[str]], httpx.Request] = None,
+    response_parser: Callable[[httpx.Response], bytes] = None,
+    style_mapper = None,
+    max_connections = 100,
+    max_keepalive_connections = 20,
+    timeout = 10,
+    preprocessors = None,
+    debug = False
+) -> SpeechSynthesizer:
+    class InstantSynthesizer(SpeechSynthesizer):
+        async def synthesize(self, text: str, style_info: dict = None, language: str = None) -> bytes:
+            if not text or not text.strip():
+                return bytes()
+
+            logger.info(f"Speech synthesize: {text}")
+
+            # Preprocess
+            processed_text = await self.preprocess(text, style_info, language)
+
+            # Make HTTP request
+            if request_maker:
+                http_request = request_maker(processed_text, style_info, language)
+            else:
+                # Replace placeholders with processed_text and language
+                def replace_placeholders(obj: dict, text: str, lang: str):
+                    return {k: v.format(text=text, language=lang or "") if isinstance(v, str) else v for k, v in obj.items()}
+
+                dynamic_params = replace_placeholders(params, processed_text, language) if params else None
+                dynamic_headers = replace_placeholders(headers, processed_text, language) if headers else None
+                dynamic_json = replace_placeholders(json, processed_text, language) if json else None
+
+                http_request = httpx.Request(
+                    method=method,
+                    url=url,
+                    params=dynamic_params,
+                    headers=dynamic_headers,
+                    json=dynamic_json
+                )
+
+            # Synthesize
+            http_response = await self.http_client.send(http_request)
+            http_response.raise_for_status()
+
+            # Parse HTTP response and return audio bytes
+            return response_parser(http_response) if response_parser else http_response.content
+
+    return InstantSynthesizer(
+        style_mapper=style_mapper,
+        max_connections=max_connections,
+        max_keepalive_connections=max_keepalive_connections,
+        timeout=timeout,
+        preprocessors=preprocessors,
+        debug=debug
+    )


### PR DESCRIPTION
Introduces `create_instant_synthesizer` factory function for quick setup of HTTP-based TTS services with dynamic `{text}` and `{language}` placeholder replacement in request parameters.

Coded during flight from Asahikawa to Haneda ✈️