### PR TITLE
Add SessionStateManager for persistent session state management

### DIFF
--- a/aiavatar/sts/session_state_manager/__init__.py
+++ b/aiavatar/sts/session_state_manager/__init__.py
@@ -1,0 +1,1 @@
+from .base import SessionState, SessionStateManager, SQLiteSessionStateManager

--- a/aiavatar/sts/session_state_manager/base.py
+++ b/aiavatar/sts/session_state_manager/base.py
@@ -1,0 +1,306 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+import json
+import logging
+import sqlite3
+from typing import Optional, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionState:
+    session_id: str
+    active_transaction_id: Optional[str] = None
+    previous_request_timestamp: Optional[datetime] = None
+    previous_request_text: Optional[str] = None
+    previous_request_files: Optional[Dict[str, Any]] = None
+    updated_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None
+
+
+class SessionStateManager(ABC):
+    @abstractmethod
+    async def get_session_state(self, session_id: str) -> SessionState:
+        pass
+
+    @abstractmethod
+    async def update_transaction(self, session_id: str, transaction_id: str) -> None:
+        pass
+
+    @abstractmethod
+    async def update_previous_request(
+        self, 
+        session_id: str, 
+        timestamp: datetime, 
+        text: Optional[str], 
+        files: Optional[Dict[str, Any]]
+    ) -> None:
+        pass
+
+    @abstractmethod
+    async def clear_session(self, session_id: str) -> None:
+        pass
+
+    @abstractmethod
+    async def cleanup_old_sessions(self, timeout_seconds: int = 3600) -> None:
+        pass
+
+
+class SQLiteSessionStateManager(SessionStateManager):
+    def __init__(self, db_path="session_state.db", session_timeout=3600, cache_ttl=60):
+        self.db_path = db_path
+        self.session_timeout = session_timeout
+        self.cache_ttl = cache_ttl  # Cache TTL in seconds
+        self.cache: Dict[str, SessionState] = {}  # In-memory cache
+        self.init_db()
+
+    def init_db(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS session_states (
+                        session_id TEXT PRIMARY KEY,
+                        active_transaction_id TEXT,
+                        previous_request_timestamp TIMESTAMP,
+                        previous_request_text TEXT,
+                        previous_request_files JSON,
+                        updated_at TIMESTAMP NOT NULL,
+                        created_at TIMESTAMP NOT NULL
+                    )
+                    """
+                )
+
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_session_states_updated_at
+                    ON session_states (updated_at)
+                    """
+                )
+
+        except Exception as ex:
+            logger.error(f"Error at init_db: {ex}")
+            raise
+        finally:
+            conn.close()
+
+    async def get_session_state(self, session_id: str) -> SessionState:
+        if not session_id:
+            raise ValueError("Error at get_session_state: session_id cannot be None or empty")
+
+        # Check cache first
+        if session_id in self.cache:
+            cached_state = self.cache[session_id]
+            if cached_state.updated_at:
+                cache_age = (datetime.now(timezone.utc) - cached_state.updated_at).total_seconds()
+                if cache_age < self.cache_ttl:
+                    return cached_state
+        
+        # Load from database if not in cache or cache expired
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT session_id, active_transaction_id, previous_request_timestamp,
+                       previous_request_text, previous_request_files, updated_at, created_at
+                FROM session_states
+                WHERE session_id = ?
+                """,
+                (session_id,)
+            )
+            row = cursor.fetchone()
+            
+            if row:
+                state = SessionState(
+                    session_id=row[0],
+                    active_transaction_id=row[1],
+                    previous_request_timestamp=datetime.fromisoformat(row[2]) if row[2] else None,
+                    previous_request_text=row[3],
+                    previous_request_files=json.loads(row[4]) if row[4] else None,
+                    updated_at=datetime.fromisoformat(row[5]),
+                    created_at=datetime.fromisoformat(row[6])
+                )
+                # Update cache
+                self.cache[session_id] = state
+                return state
+            
+            # Session doesn't exist - create new one (lazy initialization)
+            now_utc = datetime.now(timezone.utc)
+            new_state = SessionState(
+                session_id=session_id,
+                updated_at=now_utc,
+                created_at=now_utc
+            )
+            
+            # Save to database
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO session_states (session_id, active_transaction_id, previous_request_timestamp,
+                                               previous_request_text, previous_request_files, updated_at, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (session_id, None, None, None, None, now_utc, now_utc)
+                )
+            
+            # Update cache
+            self.cache[session_id] = new_state
+            return new_state
+            
+        except Exception as ex:
+            logger.error(f"Error at get_session_state: {ex}")
+            raise
+        finally:
+            conn.close()
+
+    async def update_transaction(self, session_id: str, transaction_id: str) -> None:
+        if not session_id:
+            raise ValueError("Error at update_transaction: session_id cannot be None or empty")
+        
+        conn = sqlite3.connect(self.db_path)
+        try:
+            now_utc = datetime.now(timezone.utc)
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO session_states (session_id, active_transaction_id, updated_at, created_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(session_id) DO UPDATE SET
+                        active_transaction_id = excluded.active_transaction_id,
+                        updated_at = excluded.updated_at
+                    """,
+                    (session_id, transaction_id, now_utc, now_utc)
+                )
+            
+            # Update cache
+            if session_id in self.cache:
+                self.cache[session_id].active_transaction_id = transaction_id
+                self.cache[session_id].updated_at = now_utc
+            else:
+                # Create new cache entry
+                self.cache[session_id] = SessionState(
+                    session_id=session_id,
+                    active_transaction_id=transaction_id,
+                    updated_at=now_utc,
+                    created_at=now_utc
+                )
+                
+        except Exception as ex:
+            logger.error(f"Error at update_transaction: {ex}")
+            raise
+        finally:
+            conn.close()
+
+    async def update_previous_request(
+        self, 
+        session_id: str, 
+        timestamp: datetime, 
+        text: Optional[str], 
+        files: Optional[Dict[str, Any]]
+    ) -> None:
+        if not session_id:
+            raise ValueError("Error at update_previous_request: session_id cannot be None or empty")
+        
+        conn = sqlite3.connect(self.db_path)
+        try:
+            now_utc = datetime.now(timezone.utc)
+            files_json = json.dumps(files, ensure_ascii=True) if files else None
+            
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO session_states (
+                        session_id, active_transaction_id, previous_request_timestamp, previous_request_text, 
+                        previous_request_files, updated_at, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(session_id) DO UPDATE SET
+                        previous_request_timestamp = excluded.previous_request_timestamp,
+                        previous_request_text = excluded.previous_request_text,
+                        previous_request_files = excluded.previous_request_files,
+                        updated_at = excluded.updated_at
+                    """,
+                    (session_id, None, timestamp, text, files_json, now_utc, now_utc)
+                )
+            
+            # Update cache
+            if session_id in self.cache:
+                self.cache[session_id].previous_request_timestamp = timestamp
+                self.cache[session_id].previous_request_text = text
+                self.cache[session_id].previous_request_files = files
+                self.cache[session_id].updated_at = now_utc
+            else:
+                # Create new cache entry
+                self.cache[session_id] = SessionState(
+                    session_id=session_id,
+                    previous_request_timestamp=timestamp,
+                    previous_request_text=text,
+                    previous_request_files=files,
+                    updated_at=now_utc,
+                    created_at=now_utc
+                )
+                
+        except Exception as ex:
+            logger.error(f"Error at update_previous_request: {ex}")
+            raise
+        finally:
+            conn.close()
+
+    async def clear_session(self, session_id: str) -> None:
+        if not session_id:
+            raise ValueError("Error at clear_session: session_id cannot be None or empty")
+        
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    "DELETE FROM session_states WHERE session_id = ?",
+                    (session_id,)
+                )
+            
+            # Remove from cache
+            if session_id in self.cache:
+                del self.cache[session_id]
+                
+        except Exception as ex:
+            logger.error(f"Error at clear_session: {ex}")
+            raise
+        finally:
+            conn.close()
+
+    async def cleanup_old_sessions(self, timeout_seconds: int = 3600) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cutoff_time = datetime.now(timezone.utc) - timedelta(seconds=timeout_seconds)
+            
+            # Get list of sessions to delete
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT session_id FROM session_states WHERE updated_at < ?",
+                (cutoff_time,)
+            )
+            sessions_to_delete = [row[0] for row in cursor.fetchall()]
+            
+            # Delete from database
+            with conn:
+                cursor = conn.execute(
+                    "DELETE FROM session_states WHERE updated_at < ?",
+                    (cutoff_time,)
+                )
+                if cursor.rowcount > 0:
+                    logger.info(f"Cleaned up {cursor.rowcount} old sessions")
+            
+            # Remove from cache
+            for session_id in sessions_to_delete:
+                if session_id in self.cache:
+                    del self.cache[session_id]
+                    
+        except Exception as ex:
+            logger.error(f"Error at cleanup_old_sessions: {ex}")
+            raise
+        finally:
+            conn.close()

--- a/aiavatar/sts/session_state_manager/postgres.py
+++ b/aiavatar/sts/session_state_manager/postgres.py
@@ -1,0 +1,307 @@
+from datetime import datetime, timezone, timedelta
+import json
+import logging
+from typing import Optional, Dict, Any
+import psycopg2
+import psycopg2.extras
+from .base import SessionState, SessionStateManager
+
+logger = logging.getLogger(__name__)
+
+
+class PostgreSQLSessionStateManager(SessionStateManager):
+    def __init__(
+        self,
+        *,
+        host: str = "localhost",
+        port: int = 5432,
+        dbname: str = "aiavatar",
+        user: str = "postgres",
+        password: str = None,
+        session_timeout: int = 3600,
+        cache_ttl: int = 60
+    ):
+        self.connection_params = {
+            "host": host,
+            "port": port,
+            "dbname": dbname,
+            "user": user,
+            "password": password,
+        }
+        self.session_timeout = session_timeout
+        self.cache_ttl = cache_ttl  # Cache TTL in seconds
+        self.cache: Dict[str, SessionState] = {}  # In-memory cache
+        self.init_db()
+
+    def connect_db(self):
+        return psycopg2.connect(**self.connection_params)
+
+    def init_db(self):
+        conn = self.connect_db()
+        try:
+            with conn.cursor() as cur:
+                # Create table
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS session_states (
+                        session_id TEXT PRIMARY KEY,
+                        active_transaction_id TEXT,
+                        previous_request_timestamp TIMESTAMP,
+                        previous_request_text TEXT,
+                        previous_request_files JSON,
+                        updated_at TIMESTAMP NOT NULL,
+                        created_at TIMESTAMP NOT NULL
+                    )
+                    """
+                )
+                # Create index for cleanup operations
+                cur.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_session_states_updated_at
+                    ON session_states (updated_at)
+                    """
+                )
+            conn.commit()
+        except Exception as ex:
+            logger.error(f"Error at init_db: {ex}")
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    async def get_session_state(self, session_id: str) -> SessionState:
+        if not session_id:
+            raise ValueError("Error at get_session_state: session_id cannot be None or empty")
+
+        # Check cache first
+        if session_id in self.cache:
+            cached_state = self.cache[session_id]
+            if cached_state.updated_at:
+                cache_age = (datetime.now(timezone.utc) - cached_state.updated_at).total_seconds()
+                if cache_age < self.cache_ttl:
+                    return cached_state
+        
+        # Load from database if not in cache or cache expired
+        conn = self.connect_db()
+        try:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT session_id, active_transaction_id, previous_request_timestamp,
+                           previous_request_text, previous_request_files, updated_at, created_at
+                    FROM session_states
+                    WHERE session_id = %s
+                    """,
+                    (session_id,)
+                )
+                row = cur.fetchone()
+            
+            if row:
+                state = SessionState(
+                    session_id=row["session_id"],
+                    active_transaction_id=row["active_transaction_id"],
+                    previous_request_timestamp=self._ensure_utc(row["previous_request_timestamp"]),
+                    previous_request_text=row["previous_request_text"],
+                    previous_request_files=row["previous_request_files"],
+                    updated_at=self._ensure_utc(row["updated_at"]),
+                    created_at=self._ensure_utc(row["created_at"])
+                )
+                # Update cache
+                self.cache[session_id] = state
+                return state
+            
+            # Session doesn't exist - create new one (lazy initialization)
+            now_utc = datetime.now(timezone.utc)
+            new_state = SessionState(
+                session_id=session_id,
+                updated_at=now_utc,
+                created_at=now_utc
+            )
+            
+            # Save to database
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO session_states (session_id, active_transaction_id, previous_request_timestamp,
+                                               previous_request_text, previous_request_files, updated_at, created_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (session_id, None, None, None, None, now_utc, now_utc)
+                )
+            conn.commit()
+            
+            # Update cache
+            self.cache[session_id] = new_state
+            return new_state
+            
+        except Exception as ex:
+            logger.error(f"Error at get_session_state: {ex}")
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    async def update_transaction(self, session_id: str, transaction_id: str) -> None:
+        if not session_id:
+            raise ValueError("Error at update_transaction: session_id cannot be None or empty")
+        
+        conn = self.connect_db()
+        try:
+            now_utc = datetime.now(timezone.utc)
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO session_states (session_id, active_transaction_id, updated_at, created_at)
+                    VALUES (%s, %s, %s, %s)
+                    ON CONFLICT(session_id) DO UPDATE SET
+                        active_transaction_id = EXCLUDED.active_transaction_id,
+                        updated_at = EXCLUDED.updated_at
+                    """,
+                    (session_id, transaction_id, now_utc, now_utc)
+                )
+            conn.commit()
+            
+            # Update cache
+            if session_id in self.cache:
+                self.cache[session_id].active_transaction_id = transaction_id
+                self.cache[session_id].updated_at = now_utc
+            else:
+                # Create new cache entry
+                self.cache[session_id] = SessionState(
+                    session_id=session_id,
+                    active_transaction_id=transaction_id,
+                    updated_at=now_utc,
+                    created_at=now_utc
+                )
+                
+        except Exception as ex:
+            logger.error(f"Error at update_transaction: {ex}")
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    async def update_previous_request(
+        self, 
+        session_id: str, 
+        timestamp: datetime, 
+        text: Optional[str], 
+        files: Optional[Dict[str, Any]]
+    ) -> None:
+        if not session_id:
+            raise ValueError("Error at update_previous_request: session_id cannot be None or empty")
+        
+        conn = self.connect_db()
+        try:
+            now_utc = datetime.now(timezone.utc)
+            files_json = json.dumps(files, ensure_ascii=False) if files else None
+            
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO session_states (
+                        session_id, active_transaction_id, previous_request_timestamp, previous_request_text, 
+                        previous_request_files, updated_at, created_at
+                    )
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT(session_id) DO UPDATE SET
+                        previous_request_timestamp = EXCLUDED.previous_request_timestamp,
+                        previous_request_text = EXCLUDED.previous_request_text,
+                        previous_request_files = EXCLUDED.previous_request_files,
+                        updated_at = EXCLUDED.updated_at
+                    """,
+                    (session_id, None, timestamp, text, files_json, now_utc, now_utc)
+                )
+            conn.commit()
+            
+            # Update cache
+            if session_id in self.cache:
+                self.cache[session_id].previous_request_timestamp = timestamp
+                self.cache[session_id].previous_request_text = text
+                self.cache[session_id].previous_request_files = files
+                self.cache[session_id].updated_at = now_utc
+            else:
+                # Create new cache entry
+                self.cache[session_id] = SessionState(
+                    session_id=session_id,
+                    previous_request_timestamp=timestamp,
+                    previous_request_text=text,
+                    previous_request_files=files,
+                    updated_at=now_utc,
+                    created_at=now_utc
+                )
+                
+        except Exception as ex:
+            logger.error(f"Error at update_previous_request: {ex}")
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    async def clear_session(self, session_id: str) -> None:
+        if not session_id:
+            raise ValueError("Error at clear_session: session_id cannot be None or empty")
+        
+        conn = self.connect_db()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM session_states WHERE session_id = %s",
+                    (session_id,)
+                )
+            conn.commit()
+            
+            # Remove from cache
+            if session_id in self.cache:
+                del self.cache[session_id]
+                
+        except Exception as ex:
+            logger.error(f"Error at clear_session: {ex}")
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    async def cleanup_old_sessions(self, timeout_seconds: int = 3600) -> None:
+        conn = self.connect_db()
+        try:
+            cutoff_time = datetime.now(timezone.utc) - timedelta(seconds=timeout_seconds)
+            
+            # Get list of sessions to delete
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT session_id FROM session_states WHERE updated_at < %s",
+                    (cutoff_time,)
+                )
+                sessions_to_delete = [row[0] for row in cur.fetchall()]
+            
+            # Delete from database
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM session_states WHERE updated_at < %s",
+                    (cutoff_time,)
+                )
+                if cur.rowcount > 0:
+                    logger.info(f"Cleaned up {cur.rowcount} old sessions")
+            conn.commit()
+            
+            # Remove from cache
+            for session_id in sessions_to_delete:
+                if session_id in self.cache:
+                    del self.cache[session_id]
+                    
+        except Exception as ex:
+            logger.error(f"Error at cleanup_old_sessions: {ex}")
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _ensure_utc(self, dt: datetime) -> Optional[datetime]:
+        """Ensure datetime has UTC timezone"""
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        else:
+            return dt.astimezone(timezone.utc)

--- a/tests/sts/session_state_manager/test_postgres_session_state_manager.py
+++ b/tests/sts/session_state_manager/test_postgres_session_state_manager.py
@@ -1,0 +1,310 @@
+from datetime import datetime, timezone
+import asyncio
+import os
+from uuid import uuid4
+import pytest
+from aiavatar.sts.session_state_manager import PostgreSQLSessionStateManager
+
+# Environment variables for PostgreSQL connection
+AIAVATAR_DB_HOST = os.getenv("AIAVATAR_DB_HOST", "localhost")
+AIAVATAR_DB_PORT = os.getenv("AIAVATAR_DB_PORT", 5432)
+AIAVATAR_DB_NAME = os.getenv("AIAVATAR_DB_NAME", "aiavatar")
+AIAVATAR_DB_USER = os.getenv("AIAVATAR_DB_USER", "postgres")
+AIAVATAR_DB_PASSWORD = os.getenv("AIAVATAR_DB_PASSWORD")
+
+# Skip tests if PostgreSQL is not available
+pytestmark = pytest.mark.skipif(
+    not AIAVATAR_DB_PASSWORD,
+    reason="PostgreSQL credentials not configured"
+)
+
+
+@pytest.fixture
+def session_manager() -> PostgreSQLSessionStateManager:
+    return PostgreSQLSessionStateManager(
+        host=AIAVATAR_DB_HOST,
+        port=AIAVATAR_DB_PORT,
+        dbname=AIAVATAR_DB_NAME,
+        user=AIAVATAR_DB_USER,
+        password=AIAVATAR_DB_PASSWORD,
+        session_timeout=3600,
+        cache_ttl=2
+    )
+
+
+@pytest.fixture
+def unique_session_id():
+    """Generate unique session ID for each test to avoid conflicts"""
+    return f"test_session_{uuid4()}"
+
+
+@pytest.mark.asyncio
+async def test_get_session_state_empty_creates_new(session_manager, unique_session_id):
+    state = await session_manager.get_session_state(unique_session_id)
+    
+    # Should create new session state with lazy initialization
+    assert state is not None
+    assert state.session_id == unique_session_id
+    assert state.active_transaction_id is None
+    assert state.previous_request_timestamp is None
+    assert state.previous_request_text is None
+    assert state.previous_request_files is None
+    assert state.updated_at is not None
+    assert state.created_at is not None
+    
+    # Should be saved to database and cached
+    assert unique_session_id in session_manager.cache
+
+
+@pytest.mark.asyncio
+async def test_update_and_get_transaction(session_manager, unique_session_id):
+    transaction_id = f"txn_{uuid4()}"
+    
+    await session_manager.update_transaction(unique_session_id, transaction_id)
+    
+    state = await session_manager.get_session_state(unique_session_id)
+    assert state is not None
+    assert state.session_id == unique_session_id
+    assert state.active_transaction_id == transaction_id
+    assert state.previous_request_timestamp is None
+    assert state.previous_request_text is None
+    assert state.previous_request_files is None
+
+
+@pytest.mark.asyncio
+async def test_update_and_get_previous_request(session_manager, unique_session_id):
+    timestamp = datetime.now(timezone.utc)
+    text = "Hello, world!"
+    files = {"file1": "content1", "file2": "content2"}
+    
+    await session_manager.update_previous_request(unique_session_id, timestamp, text, files)
+    
+    state = await session_manager.get_session_state(unique_session_id)
+    assert state is not None
+    assert state.session_id == unique_session_id
+    assert state.active_transaction_id is None
+    assert state.previous_request_timestamp is not None
+    # Compare timestamps with small tolerance for PostgreSQL timestamp precision
+    assert abs((state.previous_request_timestamp - timestamp).total_seconds()) < 1
+    assert state.previous_request_text == text
+    assert state.previous_request_files == files
+
+
+@pytest.mark.asyncio
+async def test_update_both_transaction_and_request(session_manager, unique_session_id):
+    transaction_id = f"txn_{uuid4()}"
+    timestamp = datetime.now(timezone.utc)
+    text = "Test request"
+    files = {"file": "data"}
+    
+    # Update transaction first
+    await session_manager.update_transaction(unique_session_id, transaction_id)
+    
+    # Then update previous request
+    await session_manager.update_previous_request(unique_session_id, timestamp, text, files)
+    
+    state = await session_manager.get_session_state(unique_session_id)
+    assert state is not None
+    assert state.active_transaction_id == transaction_id
+    assert state.previous_request_text == text
+    assert state.previous_request_files == files
+
+
+@pytest.mark.asyncio
+async def test_cache_functionality(session_manager, unique_session_id):
+    transaction_id = f"txn_cache_{uuid4()}"
+    
+    # First update - will be written to DB and cache
+    await session_manager.update_transaction(unique_session_id, transaction_id)
+    
+    # First get - should come from cache
+    state1 = await session_manager.get_session_state(unique_session_id)
+    assert state1.active_transaction_id == transaction_id
+    
+    # Verify it's from cache by checking cache directly
+    assert unique_session_id in session_manager.cache
+    assert session_manager.cache[unique_session_id].active_transaction_id == transaction_id
+    
+    # Second get - should still come from cache (within TTL)
+    state2 = await session_manager.get_session_state(unique_session_id)
+    assert state2.active_transaction_id == transaction_id
+    
+    # Wait for cache to expire (cache_ttl is 2 seconds in fixture)
+    await asyncio.sleep(2.5)
+    
+    # Third get - should reload from DB
+    state3 = await session_manager.get_session_state(unique_session_id)
+    assert state3.active_transaction_id == transaction_id
+
+
+@pytest.mark.asyncio
+async def test_cache_update_consistency(session_manager, unique_session_id):
+    # Initial transaction
+    await session_manager.update_transaction(unique_session_id, f"txn_1_{uuid4()}")
+    state1 = await session_manager.get_session_state(unique_session_id)
+    assert state1.active_transaction_id.startswith("txn_1_")
+    
+    # Update transaction - cache should be updated too
+    await session_manager.update_transaction(unique_session_id, f"txn_2_{uuid4()}")
+    
+    # Get from cache (should reflect the update)
+    state2 = await session_manager.get_session_state(unique_session_id)
+    assert state2.active_transaction_id.startswith("txn_2_")
+    
+    # Update previous request
+    timestamp = datetime.now(timezone.utc)
+    await session_manager.update_previous_request(unique_session_id, timestamp, "request text", None)
+    
+    # Cache should have both updates
+    state3 = await session_manager.get_session_state(unique_session_id)
+    assert state3.active_transaction_id.startswith("txn_2_")
+    assert state3.previous_request_text == "request text"
+
+
+@pytest.mark.asyncio
+async def test_clear_session(session_manager, unique_session_id):
+    transaction_id = f"txn_clear_{uuid4()}"
+    
+    await session_manager.update_transaction(unique_session_id, transaction_id)
+    
+    # Verify session exists with transaction
+    state = await session_manager.get_session_state(unique_session_id)
+    assert state is not None
+    assert state.active_transaction_id == transaction_id
+    
+    # Clear session
+    await session_manager.clear_session(unique_session_id)
+    
+    # Verify cache is cleared
+    assert unique_session_id not in session_manager.cache
+    
+    # After clear, get_session_state should create new empty session (lazy initialization)
+    state = await session_manager.get_session_state(unique_session_id)
+    assert state is not None
+    assert state.active_transaction_id is None  # Should be empty/new session
+    assert state.session_id == unique_session_id
+
+
+@pytest.mark.asyncio
+async def test_cleanup_old_sessions(session_manager):
+    # Create sessions with unique IDs
+    session_ids = [f"cleanup_test_{uuid4()}" for _ in range(3)]
+    
+    # Create sessions with transactions
+    for i, session_id in enumerate(session_ids):
+        await session_manager.update_transaction(session_id, f"txn_{i}")
+    
+    # Verify all sessions exist with transactions
+    for i, session_id in enumerate(session_ids):
+        state = await session_manager.get_session_state(session_id)
+        assert state.active_transaction_id == f"txn_{i}"
+    
+    # Clean up sessions older than 0 seconds (should delete all)
+    await session_manager.cleanup_old_sessions(timeout_seconds=0)
+    
+    # Verify cache is cleared
+    for session_id in session_ids:
+        assert session_id not in session_manager.cache
+    
+    # After cleanup, get_session_state should create new empty sessions (lazy initialization)
+    for session_id in session_ids:
+        state = await session_manager.get_session_state(session_id)
+        assert state.active_transaction_id is None  # Should be newly created empty sessions
+
+
+@pytest.mark.asyncio
+async def test_multiple_sessions(session_manager):
+    sessions = [
+        (f"session_a_{uuid4()}", f"txn_a_{uuid4()}", "Request A"),
+        (f"session_b_{uuid4()}", f"txn_b_{uuid4()}", "Request B"),
+        (f"session_c_{uuid4()}", f"txn_c_{uuid4()}", "Request C"),
+    ]
+    
+    # Create multiple sessions
+    for session_id, transaction_id, text in sessions:
+        await session_manager.update_transaction(session_id, transaction_id)
+        await session_manager.update_previous_request(
+            session_id, 
+            datetime.now(timezone.utc), 
+            text, 
+            None
+        )
+    
+    # Verify each session independently
+    for session_id, transaction_id, text in sessions:
+        state = await session_manager.get_session_state(session_id)
+        assert state is not None
+        assert state.active_transaction_id == transaction_id
+        assert state.previous_request_text == text
+
+
+@pytest.mark.asyncio
+async def test_overwrite_transaction(session_manager, unique_session_id):
+    # Set initial transaction
+    await session_manager.update_transaction(unique_session_id, f"txn_old_{uuid4()}")
+    state1 = await session_manager.get_session_state(unique_session_id)
+    assert state1.active_transaction_id.startswith("txn_old_")
+    
+    # Overwrite with new transaction
+    await session_manager.update_transaction(unique_session_id, f"txn_new_{uuid4()}")
+    state2 = await session_manager.get_session_state(unique_session_id)
+    assert state2.active_transaction_id.startswith("txn_new_")
+
+
+@pytest.mark.asyncio
+async def test_none_values_handling(session_manager, unique_session_id):
+    # Update with None values
+    await session_manager.update_previous_request(
+        unique_session_id,
+        datetime.now(timezone.utc),
+        None,  # text is None
+        None   # files is None
+    )
+    
+    state = await session_manager.get_session_state(unique_session_id)
+    assert state is not None
+    assert state.previous_request_text is None
+    assert state.previous_request_files is None
+
+
+@pytest.mark.asyncio
+async def test_timezone_handling(session_manager, unique_session_id):
+    """Test that timestamps are properly handled with timezone information"""
+    # Create timestamp with timezone
+    timestamp_with_tz = datetime.now(timezone.utc)
+    
+    await session_manager.update_previous_request(
+        unique_session_id,
+        timestamp_with_tz,
+        "Test with timezone",
+        None
+    )
+    
+    state = await session_manager.get_session_state(unique_session_id)
+    assert state.previous_request_timestamp is not None
+    assert state.previous_request_timestamp.tzinfo is not None
+    assert state.previous_request_timestamp.tzinfo == timezone.utc
+    
+    # Verify updated_at and created_at also have timezone
+    assert state.updated_at.tzinfo == timezone.utc
+    assert state.created_at.tzinfo == timezone.utc
+
+
+@pytest.mark.asyncio
+async def test_error_handling_invalid_session_id(session_manager):
+    """Test that proper error is raised for invalid session_id"""
+    with pytest.raises(ValueError) as exc_info:
+        await session_manager.get_session_state(None)
+    assert "session_id cannot be None or empty" in str(exc_info.value)
+    
+    with pytest.raises(ValueError) as exc_info:
+        await session_manager.update_transaction(None, "txn_123")
+    assert "session_id cannot be None or empty" in str(exc_info.value)
+    
+    with pytest.raises(ValueError) as exc_info:
+        await session_manager.update_previous_request(None, datetime.now(timezone.utc), "text", None)
+    assert "session_id cannot be None or empty" in str(exc_info.value)
+    
+    with pytest.raises(ValueError) as exc_info:
+        await session_manager.clear_session(None)
+    assert "session_id cannot be None or empty" in str(exc_info.value)

--- a/tests/sts/session_state_manager/test_session_state_manager.py
+++ b/tests/sts/session_state_manager/test_session_state_manager.py
@@ -1,0 +1,260 @@
+from datetime import datetime, timezone, timedelta
+import asyncio
+import os
+import pytest
+from aiavatar.sts.session_state_manager import SessionState, SQLiteSessionStateManager
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return os.path.join(tmp_path, "test_session_state.db")
+
+
+@pytest.fixture
+def session_manager(db_path) -> SQLiteSessionStateManager:
+    return SQLiteSessionStateManager(db_path=db_path, session_timeout=3600, cache_ttl=2)
+
+
+@pytest.mark.asyncio
+async def test_get_session_state_empty_creates_new(session_manager):
+    session_id = "non_existent_session"
+    state = await session_manager.get_session_state(session_id)
+    
+    # Should create new session state with lazy initialization
+    assert state is not None
+    assert state.session_id == session_id
+    assert state.active_transaction_id is None
+    assert state.previous_request_timestamp is None
+    assert state.previous_request_text is None
+    assert state.previous_request_files is None
+    assert state.updated_at is not None
+    assert state.created_at is not None
+    
+    # Should be saved to database and cached
+    assert session_id in session_manager.cache
+
+
+@pytest.mark.asyncio
+async def test_update_and_get_transaction(session_manager):
+    session_id = "test_session_1"
+    transaction_id = "txn_123"
+    
+    await session_manager.update_transaction(session_id, transaction_id)
+    
+    state = await session_manager.get_session_state(session_id)
+    assert state is not None
+    assert state.session_id == session_id
+    assert state.active_transaction_id == transaction_id
+    assert state.previous_request_timestamp is None
+    assert state.previous_request_text is None
+    assert state.previous_request_files is None
+
+
+@pytest.mark.asyncio
+async def test_update_and_get_previous_request(session_manager):
+    session_id = "test_session_2"
+    timestamp = datetime.now(timezone.utc)
+    text = "Hello, world!"
+    files = {"file1": "content1", "file2": "content2"}
+    
+    await session_manager.update_previous_request(session_id, timestamp, text, files)
+    
+    state = await session_manager.get_session_state(session_id)
+    assert state is not None
+    assert state.session_id == session_id
+    assert state.active_transaction_id is None
+    assert state.previous_request_timestamp is not None
+    assert state.previous_request_text == text
+    assert state.previous_request_files == files
+
+
+@pytest.mark.asyncio
+async def test_update_both_transaction_and_request(session_manager):
+    session_id = "test_session_3"
+    transaction_id = "txn_456"
+    timestamp = datetime.now(timezone.utc)
+    text = "Test request"
+    files = {"file": "data"}
+    
+    # Update transaction first
+    await session_manager.update_transaction(session_id, transaction_id)
+    
+    # Then update previous request
+    await session_manager.update_previous_request(session_id, timestamp, text, files)
+    
+    state = await session_manager.get_session_state(session_id)
+    assert state is not None
+    assert state.active_transaction_id == transaction_id
+    assert state.previous_request_text == text
+    assert state.previous_request_files == files
+
+
+@pytest.mark.asyncio
+async def test_cache_functionality(session_manager):
+    session_id = "test_cache"
+    transaction_id = "txn_cache"
+    
+    # First update - will be written to DB and cache
+    await session_manager.update_transaction(session_id, transaction_id)
+    
+    # First get - should come from cache
+    state1 = await session_manager.get_session_state(session_id)
+    assert state1.active_transaction_id == transaction_id
+    
+    # Verify it's from cache by checking cache directly
+    assert session_id in session_manager.cache
+    assert session_manager.cache[session_id].active_transaction_id == transaction_id
+    
+    # Second get - should still come from cache (within TTL)
+    state2 = await session_manager.get_session_state(session_id)
+    assert state2.active_transaction_id == transaction_id
+    
+    # Wait for cache to expire (cache_ttl is 2 seconds in fixture)
+    await asyncio.sleep(2.5)
+    
+    # Third get - should reload from DB
+    state3 = await session_manager.get_session_state(session_id)
+    assert state3.active_transaction_id == transaction_id
+
+
+@pytest.mark.asyncio
+async def test_cache_update_consistency(session_manager):
+    session_id = "test_consistency"
+    
+    # Initial transaction
+    await session_manager.update_transaction(session_id, "txn_1")
+    state1 = await session_manager.get_session_state(session_id)
+    assert state1.active_transaction_id == "txn_1"
+    
+    # Update transaction - cache should be updated too
+    await session_manager.update_transaction(session_id, "txn_2")
+    
+    # Get from cache (should reflect the update)
+    state2 = await session_manager.get_session_state(session_id)
+    assert state2.active_transaction_id == "txn_2"
+    
+    # Update previous request
+    timestamp = datetime.now(timezone.utc)
+    await session_manager.update_previous_request(session_id, timestamp, "request text", None)
+    
+    # Cache should have both updates
+    state3 = await session_manager.get_session_state(session_id)
+    assert state3.active_transaction_id == "txn_2"
+    assert state3.previous_request_text == "request text"
+
+
+@pytest.mark.asyncio
+async def test_clear_session(session_manager):
+    session_id = "test_clear"
+    
+    await session_manager.update_transaction(session_id, "txn_clear")
+    
+    # Verify session exists with transaction
+    state = await session_manager.get_session_state(session_id)
+    assert state is not None
+    assert state.active_transaction_id == "txn_clear"
+    
+    # Clear session
+    await session_manager.clear_session(session_id)
+    
+    # Verify cache is cleared
+    assert session_id not in session_manager.cache
+    
+    # After clear, get_session_state should create new empty session (lazy initialization)
+    state = await session_manager.get_session_state(session_id)
+    assert state is not None
+    assert state.active_transaction_id is None  # Should be empty/new session
+    assert state.session_id == session_id
+
+
+@pytest.mark.asyncio
+async def test_cleanup_old_sessions(session_manager):
+    # Create sessions with transactions
+    await session_manager.update_transaction("session_1", "txn_1")
+    await session_manager.update_transaction("session_2", "txn_2")
+    await session_manager.update_transaction("session_3", "txn_3")
+    
+    # Verify all sessions exist with transactions
+    state1 = await session_manager.get_session_state("session_1")
+    state2 = await session_manager.get_session_state("session_2")
+    state3 = await session_manager.get_session_state("session_3")
+    assert state1.active_transaction_id == "txn_1"
+    assert state2.active_transaction_id == "txn_2"
+    assert state3.active_transaction_id == "txn_3"
+    
+    # Clean up sessions older than 0 seconds (should delete all)
+    await session_manager.cleanup_old_sessions(timeout_seconds=0)
+    
+    # Verify cache is cleared
+    assert "session_1" not in session_manager.cache
+    assert "session_2" not in session_manager.cache
+    assert "session_3" not in session_manager.cache
+    
+    # After cleanup, get_session_state should create new empty sessions (lazy initialization)
+    state1_new = await session_manager.get_session_state("session_1")
+    state2_new = await session_manager.get_session_state("session_2")
+    state3_new = await session_manager.get_session_state("session_3")
+    
+    # These should be newly created empty sessions
+    assert state1_new.active_transaction_id is None
+    assert state2_new.active_transaction_id is None
+    assert state3_new.active_transaction_id is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_sessions(session_manager):
+    sessions = [
+        ("session_a", "txn_a", "Request A"),
+        ("session_b", "txn_b", "Request B"),
+        ("session_c", "txn_c", "Request C"),
+    ]
+    
+    # Create multiple sessions
+    for session_id, transaction_id, text in sessions:
+        await session_manager.update_transaction(session_id, transaction_id)
+        await session_manager.update_previous_request(
+            session_id, 
+            datetime.now(timezone.utc), 
+            text, 
+            None
+        )
+    
+    # Verify each session independently
+    for session_id, transaction_id, text in sessions:
+        state = await session_manager.get_session_state(session_id)
+        assert state is not None
+        assert state.active_transaction_id == transaction_id
+        assert state.previous_request_text == text
+
+
+@pytest.mark.asyncio
+async def test_overwrite_transaction(session_manager):
+    session_id = "test_overwrite"
+    
+    # Set initial transaction
+    await session_manager.update_transaction(session_id, "txn_old")
+    state1 = await session_manager.get_session_state(session_id)
+    assert state1.active_transaction_id == "txn_old"
+    
+    # Overwrite with new transaction
+    await session_manager.update_transaction(session_id, "txn_new")
+    state2 = await session_manager.get_session_state(session_id)
+    assert state2.active_transaction_id == "txn_new"
+
+
+@pytest.mark.asyncio
+async def test_none_values_handling(session_manager):
+    session_id = "test_none"
+    
+    # Update with None values
+    await session_manager.update_previous_request(
+        session_id,
+        datetime.now(timezone.utc),
+        None,  # text is None
+        None   # files is None
+    )
+    
+    state = await session_manager.get_session_state(session_id)
+    assert state is not None
+    assert state.previous_request_text is None
+    assert state.previous_request_files is None


### PR DESCRIPTION
Replace in-memory dictionaries with persistent SessionStateManager to handle active transactions and previous request data across the STS pipeline.

This change addresses memory growth issues in long-running pipeline instances. Previously, active_transactions and previous_requests dictionaries would accumulate data indefinitely, causing memory usage to increase over time with no cleanup mechanism. The persistent SessionStateManager provides automatic cleanup of old sessions and prevents memory leaks in production environments.