### PR TITLE
Add unified db_connection_str for database configuration

### DIFF
--- a/aiavatar/adapter/http/server.py
+++ b/aiavatar/adapter/http/server.py
@@ -50,6 +50,7 @@ class AIAvatarHttpServer(Adapter):
         voicevox_speaker: int = 46,
         wakewords: List[str] = None,
         wakeword_timeout: float = 60.0,
+        db_connection_str: str = "aiavatar.db",
         performance_recorder: PerformanceRecorder = None,
         api_key: str = None,
         # Debug
@@ -72,6 +73,7 @@ class AIAvatarHttpServer(Adapter):
             tts_voicevox_speaker=voicevox_speaker,
             wakewords=wakewords,
             wakeword_timeout=wakeword_timeout,
+            db_connection_str=db_connection_str,
             performance_recorder=performance_recorder,
             debug=debug
         )

--- a/aiavatar/adapter/local/client.py
+++ b/aiavatar/adapter/local/client.py
@@ -37,6 +37,7 @@ class AIAvatar(AIAvatarClientBase):
         voicevox_speaker: int = 46,
         wakewords: List[str] = None,
         wakeword_timeout: float = 60.0,
+        db_connection_str: str = "aiavatar.db",
         performance_recorder: PerformanceRecorder = None,
         # Noise filter
         auto_noise_filter_threshold: bool = True,
@@ -89,6 +90,7 @@ class AIAvatar(AIAvatarClientBase):
             tts_voicevox_speaker=voicevox_speaker,
             wakewords=wakewords,
             wakeword_timeout=wakeword_timeout,
+            db_connection_str=db_connection_str,
             performance_recorder=performance_recorder,
             debug=debug
         )

--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -48,6 +48,7 @@ class AIAvatarWebSocketServer(Adapter):
         voicevox_speaker: int = 46,
         wakewords: List[str] = None,
         wakeword_timeout: float = 60.0,
+        db_connection_str: str = "aiavatar.db",
         performance_recorder: PerformanceRecorder = None,
         # WebSocket processing
         response_audio_chunk_size: int = 0, # 0 = Send whole audio data at once
@@ -74,6 +75,7 @@ class AIAvatarWebSocketServer(Adapter):
             tts_voicevox_speaker=voicevox_speaker,
             wakewords=wakewords,
             wakeword_timeout=wakeword_timeout,
+            db_connection_str=db_connection_str,
             performance_recorder=performance_recorder,
             debug=debug
         )

--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -108,6 +108,7 @@ class LLMService(ABC):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        db_connection_str: str = "aiavatar.db",
         debug: bool = False
     ):
         self.system_prompt = system_prompt
@@ -161,7 +162,14 @@ The list of tools is as follows:
 """
         self._get_dynamic_tools = self.get_dynamic_tools_default
         self._on_before_tool_calls = self.on_before_tool_calls_default
-        self.context_manager = context_manager or SQLiteContextManager()
+        if context_manager:
+            self.context_manager = context_manager
+        else:
+            if db_connection_str.startswith("postgresql://"):
+                from .context_manager.postgres import PostgreSQLContextManager
+                self.context_manager = PostgreSQLContextManager(connection_str=db_connection_str)
+            else:
+                self.context_manager = SQLiteContextManager(db_path=db_connection_str)
         self.debug = debug
 
     # Decorators

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -25,6 +25,7 @@ class ChatGPTService(LLMService):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        db_connection_str: str = "aiavatar.db",
         debug: bool = False
     ):
         super().__init__(
@@ -37,6 +38,7 @@ class ChatGPTService(LLMService):
             voice_text_tag=voice_text_tag,
             use_dynamic_tools=use_dynamic_tools,
             context_manager=context_manager,
+            db_connection_str=db_connection_str,
             debug=debug
         )
         if "azure" in model:

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -25,6 +25,7 @@ class ClaudeService(LLMService):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        db_connection_str: str = "aiavatar.db",
         debug: bool = False
     ):
         super().__init__(
@@ -37,6 +38,7 @@ class ClaudeService(LLMService):
             voice_text_tag=voice_text_tag,
             use_dynamic_tools=use_dynamic_tools,
             context_manager=context_manager,
+            db_connection_str=db_connection_str,
             debug=debug
         )
         self.anthropic_client = AsyncAnthropic(

--- a/aiavatar/sts/llm/context_manager/postgres.py
+++ b/aiavatar/sts/llm/context_manager/postgres.py
@@ -18,6 +18,7 @@ class PostgreSQLContextManager(ContextManager):
         dbname: str = "aiavatar",
         user: str = "postgres",
         password: str = None,
+        connection_str: str = None,
         context_timeout: int = 3600
     ):
         self.connection_params = {
@@ -27,11 +28,15 @@ class PostgreSQLContextManager(ContextManager):
             "user": user,
             "password": password,
         }
+        self.connection_str = connection_str
         self.context_timeout = context_timeout
         self.init_db()
 
     def connect_db(self):
-        return psycopg2.connect(**self.connection_params)
+        if self.connection_str:
+            return psycopg2.connect(self.connection_str)
+        else:
+            return psycopg2.connect(**self.connection_params)
 
     def init_db(self):
         conn = self.connect_db()

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -27,6 +27,7 @@ class GeminiService(LLMService):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        db_connection_str: str = "aiavatar.db",
         debug: bool = False
     ):
         super().__init__(
@@ -39,6 +40,7 @@ class GeminiService(LLMService):
             voice_text_tag=voice_text_tag,
             use_dynamic_tools=use_dynamic_tools,
             context_manager=context_manager,
+            db_connection_str=db_connection_str,
             debug=debug
         )
         self.gemini_client = genai.Client(

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -25,6 +25,7 @@ class LiteLLMService(LLMService):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        db_connection_str: str = "aiavatar.db",
         debug: bool = False
     ):
         super().__init__(
@@ -37,6 +38,7 @@ class LiteLLMService(LLMService):
             voice_text_tag=voice_text_tag,
             use_dynamic_tools=use_dynamic_tools,
             context_manager=context_manager,
+            db_connection_str=db_connection_str,
             debug=debug
         )
         self.api_key = api_key

--- a/aiavatar/sts/performance_recorder/postgres.py
+++ b/aiavatar/sts/performance_recorder/postgres.py
@@ -19,6 +19,7 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
         dbname: str = "aiavatar",
         user: str = "postgres",
         password: str = None,
+        connection_str: str = None
     ):
         self.connection_params = {
             "host": host,
@@ -27,6 +28,7 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
             "user": user,
             "password": password,
         }
+        self.connection_str = connection_str
         self.record_queue = queue.Queue()
         self.stop_event = threading.Event()
 
@@ -36,7 +38,10 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
         self.worker_thread.start()
 
     def connect_db(self):
-        return psycopg2.connect(**self.connection_params)
+        if self.connection_str:
+            return psycopg2.connect(self.connection_str)
+        else:
+            return psycopg2.connect(**self.connection_params)
 
     def add_column_if_not_exist(self, cur, column_name):
         cur.execute(

--- a/aiavatar/sts/session_state_manager/postgres.py
+++ b/aiavatar/sts/session_state_manager/postgres.py
@@ -18,6 +18,7 @@ class PostgreSQLSessionStateManager(SessionStateManager):
         dbname: str = "aiavatar",
         user: str = "postgres",
         password: str = None,
+        connection_str: str = None,
         session_timeout: int = 3600,
         cache_ttl: int = 60
     ):
@@ -28,13 +29,17 @@ class PostgreSQLSessionStateManager(SessionStateManager):
             "user": user,
             "password": password,
         }
+        self.connection_str = connection_str
         self.session_timeout = session_timeout
         self.cache_ttl = cache_ttl  # Cache TTL in seconds
         self.cache: Dict[str, SessionState] = {}  # In-memory cache
         self.init_db()
 
     def connect_db(self):
-        return psycopg2.connect(**self.connection_params)
+        if self.connection_str:
+            return psycopg2.connect(self.connection_str)
+        else:
+            return psycopg2.connect(**self.connection_params)
 
     def init_db(self):
         conn = self.connect_db()

--- a/tests/sts/session_state_manager/test_postgres_session_state_manager.py
+++ b/tests/sts/session_state_manager/test_postgres_session_state_manager.py
@@ -3,7 +3,7 @@ import asyncio
 import os
 from uuid import uuid4
 import pytest
-from aiavatar.sts.session_state_manager import PostgreSQLSessionStateManager
+from aiavatar.sts.session_state_manager.postgres import PostgreSQLSessionStateManager
 
 # Environment variables for PostgreSQL connection
 AIAVATAR_DB_HOST = os.getenv("AIAVATAR_DB_HOST", "localhost")


### PR DESCRIPTION
Introduces a `db_connection_str` parameter to adapters, LLM services and the STSPipeline, allowing unified configuration for SQLite and PostgreSQL backends. Updates context manager, performance recorder, and session state manager to support connection strings, enabling easier switching between database types based on the connection string format.