### PR TITLE
Add voice recorder directory support to adapters and pipeline

### DIFF
--- a/aiavatar/adapter/http/server.py
+++ b/aiavatar/adapter/http/server.py
@@ -15,6 +15,7 @@ from ...sts.stt.openai import OpenAISpeechRecognizer
 from ...sts.llm import LLMService
 from ...sts.tts import SpeechSynthesizer
 from ...sts.performance_recorder import PerformanceRecorder
+from ...sts.voice_recorder import VoiceRecorder
 from ..models import AvatarControlRequest, AIAvatarRequest, AIAvatarResponse
 from .. import Adapter
 
@@ -54,6 +55,8 @@ class AIAvatarHttpServer(Adapter):
         wakeword_timeout: float = 60.0,
         db_connection_str: str = "aiavatar.db",
         performance_recorder: PerformanceRecorder = None,
+        voice_recorder: VoiceRecorder = None,
+        voice_recorder_dir: str = "recorded_voices",
         api_key: str = None,
         # Debug
         debug: bool = False            
@@ -77,6 +80,8 @@ class AIAvatarHttpServer(Adapter):
             wakeword_timeout=wakeword_timeout,
             db_connection_str=db_connection_str,
             performance_recorder=performance_recorder,
+            voice_recorder=voice_recorder,
+            voice_recorder_dir=voice_recorder_dir,
             debug=debug
         )
 

--- a/aiavatar/adapter/local/client.py
+++ b/aiavatar/adapter/local/client.py
@@ -9,6 +9,7 @@ from ...sts.stt.openai import OpenAISpeechRecognizer
 from ...sts.llm import LLMService
 from ...sts.tts import SpeechSynthesizer
 from ...sts.performance_recorder import PerformanceRecorder
+from ...sts.voice_recorder import VoiceRecorder
 from ...device import NoiseLevelDetector
 from ..models import AvatarControlRequest, AIAvatarResponse, AIAvatarException
 from ..client import AIAvatarClientBase
@@ -39,6 +40,8 @@ class AIAvatar(AIAvatarClientBase):
         wakeword_timeout: float = 60.0,
         db_connection_str: str = "aiavatar.db",
         performance_recorder: PerformanceRecorder = None,
+        voice_recorder: VoiceRecorder = None,
+        voice_recorder_dir: str = "recorded_voices",
         # Noise filter
         auto_noise_filter_threshold: bool = True,
         noise_margin: float = 20.0,
@@ -92,6 +95,8 @@ class AIAvatar(AIAvatarClientBase):
             wakeword_timeout=wakeword_timeout,
             db_connection_str=db_connection_str,
             performance_recorder=performance_recorder,
+            voice_recorder=voice_recorder,
+            voice_recorder_dir=voice_recorder_dir,
             debug=debug
         )
         self.sts.handle_response = self.handle_response

--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -14,6 +14,7 @@ from ...sts.stt.openai import OpenAISpeechRecognizer
 from ...sts.llm import LLMService
 from ...sts.tts import SpeechSynthesizer
 from ...sts.performance_recorder import PerformanceRecorder
+from ...sts.voice_recorder import VoiceRecorder
 from ..models import AvatarControlRequest, AIAvatarRequest, AIAvatarResponse
 from ..base import Adapter
 
@@ -50,6 +51,8 @@ class AIAvatarWebSocketServer(Adapter):
         wakeword_timeout: float = 60.0,
         db_connection_str: str = "aiavatar.db",
         performance_recorder: PerformanceRecorder = None,
+        voice_recorder: VoiceRecorder = None,
+        voice_recorder_dir: str = "recorded_voices",
         # WebSocket processing
         response_audio_chunk_size: int = 0, # 0 = Send whole audio data at once
         # Debug
@@ -77,6 +80,8 @@ class AIAvatarWebSocketServer(Adapter):
             wakeword_timeout=wakeword_timeout,
             db_connection_str=db_connection_str,
             performance_recorder=performance_recorder,
+            voice_recorder=voice_recorder,
+            voice_recorder_dir=voice_recorder_dir,
             debug=debug
         )
 

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -54,6 +54,7 @@ class STSPipeline:
         performance_recorder: PerformanceRecorder = None,
         voice_recorder: VoiceRecorder = None,
         voice_recorder_enabled: bool = True,
+        voice_recorder_dir: str = "recorded_voices",
         debug: bool = False
     ):
         self.debug = debug
@@ -142,6 +143,7 @@ class STSPipeline:
 
         # Voice recorder
         self.voice_recorder = voice_recorder or FileVoiceRecorder(
+            record_dir=voice_recorder_dir,
             sample_rate=stt_sample_rate
         )
         self.voice_recorder_enabled = voice_recorder_enabled


### PR DESCRIPTION
Introduces a new `voice_recorder_dir` parameter to HTTP, local, and WebSocket adapters, as well as the STSPipeline. This allows specifying the directory where recorded voices are stored, improving configurability for voice recording features.