### PR TITLE
Add `initial_messages` support to LLM services

### DIFF
--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -20,6 +20,7 @@ class ChatGPTService(LLMService):
         model: str = "gpt-4.1",
         temperature: float = 0.5,
         reasoning_effort: str = "minimal",
+        initial_messages: List[dict] = None,
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
@@ -33,6 +34,7 @@ class ChatGPTService(LLMService):
             system_prompt=system_prompt,
             model=model,
             temperature=temperature,
+            initial_messages=initial_messages,
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
@@ -84,6 +86,10 @@ class ChatGPTService(LLMService):
         messages = []
         if self.system_prompt:
             messages.append({"role": "system", "content": self.get_system_prompt(system_prompt_params)})
+
+        # Add initial messages (e.g. few-shot)
+        if self.initial_messages:
+            messages.extend(self.initial_messages)
 
         # Extract the history starting from the first message where the role is 'user'
         histories = await self.context_manager.get_histories(context_id)

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -19,6 +19,7 @@ class ClaudeService(LLMService):
         model: str = "claude-3-7-sonnet-latest",
         temperature: float = 0.5,
         max_tokens: int = 1024,
+        initial_messages: List[dict] = None,
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
@@ -32,6 +33,7 @@ class ClaudeService(LLMService):
             system_prompt=system_prompt or "",
             model=model,
             temperature=temperature,
+            initial_messages=initial_messages,
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
@@ -72,6 +74,10 @@ class ClaudeService(LLMService):
 
     async def compose_messages(self, context_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
         messages = []
+
+        # Add initial messages (e.g. few-shot)
+        if self.initial_messages:
+            messages.extend(self.initial_messages)
 
         # Extract the history starting from the first message where the role is 'user'
         histories = await self.context_manager.get_histories(context_id)

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -21,6 +21,7 @@ class GeminiService(LLMService):
         model: str = "gemini-2.5-flash",
         temperature: float = 0.5,
         thinking_budget: int = -1,
+        initial_messages: List[dict] = None,
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
@@ -34,6 +35,7 @@ class GeminiService(LLMService):
             system_prompt=system_prompt,
             model=model,
             temperature=temperature,
+            initial_messages=initial_messages,
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
@@ -81,6 +83,10 @@ class GeminiService(LLMService):
 
     async def compose_messages(self, context_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
         messages = []
+
+        # Add initial messages (e.g. few-shot)
+        if self.initial_messages:
+            messages.extend(self.initial_messages)
 
         # Extract the history starting from the first message where the role is 'user'
         histories = await self.context_manager.get_histories(context_id)

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -19,6 +19,7 @@ class LiteLLMService(LLMService):
         base_url: str = None,
         model: str = None,
         temperature: float = 0.5,
+        initial_messages: List[dict] = None,
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
@@ -32,6 +33,7 @@ class LiteLLMService(LLMService):
             system_prompt=system_prompt,
             model=model,
             temperature=temperature,
+            initial_messages=initial_messages,
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
@@ -80,6 +82,10 @@ class LiteLLMService(LLMService):
                 messages.append({"role": "assistant", "content": "ok"})
             else:
                 messages.append({"role": "system", "content": self.get_system_prompt(system_prompt_params)})
+
+        # Add initial messages (e.g. few-shot)
+        if self.initial_messages:
+            messages.extend(self.initial_messages)
 
         # Extract the history starting from the first message where the role is 'user'
         histories = await self.context_manager.get_histories(context_id)

--- a/tests/sts/llm/test_chatgpt.py
+++ b/tests/sts/llm/test_chatgpt.py
@@ -192,6 +192,53 @@ async def test_chatgpt_service_cot():
 
 
 @pytest.mark.asyncio
+async def test_chatgpt_service_with_initial_messages():
+    """
+    Test ChatGPTService with initial messages (few-shot examples).
+    This test actually calls OpenAI API, so it may cost tokens.
+    """
+    initial_messages = [
+        {"role": "user", "content": "今日のランチ、寿司かラーメンかで悩んでる。"},
+        {"role": "assistant", "content": "どちらも美味しいですね。"},
+    ]
+
+    service = ChatGPTService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="グルメアドバイザーとして振る舞ってください。",
+        model=MODEL,
+        temperature=0.5,
+        initial_messages=initial_messages
+    )
+    context_id = f"test_initial_context_{uuid4()}"
+
+    # Ask the recommendation for lunch
+    user_message = "おすすめは？"
+
+    collected_text = []
+
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        collected_text.append(resp.text)
+
+    full_text = "".join(collected_text)
+    assert len(full_text) > 0, "No text was returned from the LLM."
+
+    # Check if the response contains sushi or ramen
+    assert "寿司" in full_text or "ラーメン" in full_text, "Food name from initial messages not found in response."
+
+    # Check the context
+    messages = await service.context_manager.get_histories(context_id)
+    assert len(messages) == 2, "Expected 2 messages (1 user + 1 assistant, without system and initial 2 messages)"
+
+    # Verify messages
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == user_message
+    assert messages[1]["role"] == "assistant"
+    assert "寿司" in messages[1]["content"] or "ラーメン" in messages[1]["content"]
+
+    await service.openai_client.close()
+
+
+@pytest.mark.asyncio
 async def test_chatgpt_service_tool_calls():
     """
     Test ChatGPTService with a registered tool.

--- a/tests/sts/llm/test_claude.py
+++ b/tests/sts/llm/test_claude.py
@@ -187,6 +187,51 @@ async def test_claude_service_cot():
 
 
 @pytest.mark.asyncio
+async def test_claude_service_with_initial_messages():
+    """
+    Test ClaudeService with initial messages (few-shot examples).
+    This test actually calls Anthropic API, so it may cost tokens.
+    """
+    initial_messages = [
+        {"role": "user", "content": "今日のランチ、寿司かラーメンかで悩んでる。"},
+        {"role": "assistant", "content": "どちらも美味しいですね。"},
+    ]
+
+    service = ClaudeService(
+        anthropic_api_key=CLAUDE_API_KEY,
+        system_prompt="グルメアドバイザーとして振る舞ってください。",
+        model=MODEL,
+        temperature=0.5,
+        initial_messages=initial_messages
+    )
+    context_id = f"test_initial_context_{uuid4()}"
+
+    # Ask the recommendation for lunch
+    user_message = "おすすめは？"
+
+    collected_text = []
+
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        collected_text.append(resp.text)
+
+    full_text = "".join(collected_text)
+    assert len(full_text) > 0, "No text was returned from the LLM."
+
+    # Check if the response contains sushi or ramen
+    assert "寿司" in full_text or "ラーメン" in full_text, "Food name from initial messages not found in response."
+
+    # Check the context
+    messages = await service.context_manager.get_histories(context_id)
+    assert len(messages) == 2, "Expected 2 messages (1 user + 1 assistant, without system and initial 2 messages)"
+
+    # Verify messages
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"][0]["text"] == user_message
+    assert messages[1]["role"] == "assistant"
+    assert "寿司" in messages[1]["content"][0]["text"] or "ラーメン" in messages[1]["content"][0]["text"]
+
+
+@pytest.mark.asyncio
 async def test_claude_service_tool_calls():
     """
     Test ClaudeService with a registered tool.


### PR DESCRIPTION
Introduces an `initial_messages` parameter to LLMService and all derived services (ChatGPT, Claude, Gemini, LiteLLM) to allow injection of few-shot examples or custom message history at initialization.