### PR TITLE
Add support for shared context histories in LLM services

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -116,6 +116,7 @@ class LLMService(ABC):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        shared_context_ids: List[str] = None,
         db_connection_str: str = "aiavatar.db",
         debug: bool = False
     ):
@@ -179,6 +180,7 @@ The list of tools is as follows:
                 self.context_manager = PostgreSQLContextManager(connection_str=db_connection_str)
             else:
                 self.context_manager = SQLiteContextManager(db_path=db_connection_str)
+        self.shared_context_ids = shared_context_ids
         self.debug = debug
 
     # Decorators

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -31,6 +31,7 @@ class ChatGPTService(LLMService):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        shared_context_ids: List[str] = None,
         db_connection_str: str = "aiavatar.db",
         custom_openai_module: OpenAICompatibleModule = None,
         debug: bool = False
@@ -46,6 +47,7 @@ class ChatGPTService(LLMService):
             voice_text_tag=voice_text_tag,
             use_dynamic_tools=use_dynamic_tools,
             context_manager=context_manager,
+            shared_context_ids=shared_context_ids,
             db_connection_str=db_connection_str,
             debug=debug
         )
@@ -98,7 +100,9 @@ class ChatGPTService(LLMService):
             messages.extend(self.initial_messages)
 
         # Extract the history starting from the first message where the role is 'user'
-        histories = await self.context_manager.get_histories(context_id)
+        histories = await self.context_manager.get_histories(
+            context_id=[context_id] + self.shared_context_ids if self.shared_context_ids else context_id
+        )
         while histories and histories[0]["role"] != "user":
             histories.pop(0)
         messages.extend(histories)

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -26,6 +26,7 @@ class ClaudeService(LLMService):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        shared_context_ids: List[str] = None,
         db_connection_str: str = "aiavatar.db",
         debug: bool = False
     ):
@@ -40,6 +41,7 @@ class ClaudeService(LLMService):
             voice_text_tag=voice_text_tag,
             use_dynamic_tools=use_dynamic_tools,
             context_manager=context_manager,
+            shared_context_ids=shared_context_ids,
             db_connection_str=db_connection_str,
             debug=debug
         )
@@ -80,7 +82,9 @@ class ClaudeService(LLMService):
             messages.extend(self.initial_messages)
 
         # Extract the history starting from the first message where the role is 'user'
-        histories = await self.context_manager.get_histories(context_id)
+        histories = await self.context_manager.get_histories(
+            context_id=[context_id] + self.shared_context_ids if self.shared_context_ids else context_id
+        )
         while histories and histories[0]["role"] != "user":
             histories.pop(0)
         messages.extend(histories)

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -28,6 +28,7 @@ class GeminiService(LLMService):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        shared_context_ids: List[str] = None,
         db_connection_str: str = "aiavatar.db",
         debug: bool = False
     ):
@@ -42,6 +43,7 @@ class GeminiService(LLMService):
             voice_text_tag=voice_text_tag,
             use_dynamic_tools=use_dynamic_tools,
             context_manager=context_manager,
+            shared_context_ids=shared_context_ids,
             db_connection_str=db_connection_str,
             debug=debug
         )
@@ -89,7 +91,9 @@ class GeminiService(LLMService):
             messages.extend(self.initial_messages)
 
         # Extract the history starting from the first message where the role is 'user'
-        histories = await self.context_manager.get_histories(context_id)
+        histories = await self.context_manager.get_histories(
+            context_id=[context_id] + self.shared_context_ids if self.shared_context_ids else context_id
+        )
         while histories and histories[0]["role"] != "user":
             histories.pop(0)
         messages.extend(histories)

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -26,6 +26,7 @@ class LiteLLMService(LLMService):
         voice_text_tag: str = None,
         use_dynamic_tools: bool = False,
         context_manager: ContextManager = None,
+        shared_context_ids: List[str] = None,
         db_connection_str: str = "aiavatar.db",
         debug: bool = False
     ):
@@ -40,6 +41,7 @@ class LiteLLMService(LLMService):
             voice_text_tag=voice_text_tag,
             use_dynamic_tools=use_dynamic_tools,
             context_manager=context_manager,
+            shared_context_ids=shared_context_ids,
             db_connection_str=db_connection_str,
             debug=debug
         )
@@ -88,7 +90,9 @@ class LiteLLMService(LLMService):
             messages.extend(self.initial_messages)
 
         # Extract the history starting from the first message where the role is 'user'
-        histories = await self.context_manager.get_histories(context_id)
+        histories = await self.context_manager.get_histories(
+            context_id=[context_id] + self.shared_context_ids if self.shared_context_ids else context_id
+        )
         while histories and histories[0]["role"] != "user":
             histories.pop(0)
         messages.extend(histories)

--- a/tests/sts/llm/context_manager/test_context_manager.py
+++ b/tests/sts/llm/context_manager/test_context_manager.py
@@ -43,6 +43,35 @@ async def test_add_and_get_histories(context_manager):
 
 
 @pytest.mark.asyncio
+async def test_add_and_get_histories_with_shared(context_manager):
+    context_id = "test_specific_context"
+    data_list = [
+        {"message": "Hello, world!", "role": "user"},
+        {"message": "Hi! How can I help you today?", "role": "assistant"}
+    ]
+    await context_manager.add_histories(context_id, data_list)
+
+    shared_context_id = "test_shared_context"
+    shared_data_list = [
+        {"message": "Shared Request", "role": "user"},
+        {"message": "Shared Answer", "role": "assistant"}
+    ]
+    await context_manager.add_histories(shared_context_id, shared_data_list)
+
+    histories = await context_manager.get_histories(context_id=[context_id, shared_context_id])
+    assert len(histories) == 4
+
+    assert histories[0]["message"] == "Hello, world!"
+    assert histories[0]["role"] == "user"
+    assert histories[1]["message"] == "Hi! How can I help you today?"
+    assert histories[1]["role"] == "assistant"
+    assert histories[2]["message"] == "Shared Request"
+    assert histories[2]["role"] == "user"
+    assert histories[3]["message"] == "Shared Answer"
+    assert histories[3]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
 async def test_get_histories_limit(context_manager):
     context_id = "test_limit"
     data_list = [

--- a/tests/sts/llm/context_manager/test_pg_context_manager.py
+++ b/tests/sts/llm/context_manager/test_pg_context_manager.py
@@ -47,6 +47,36 @@ async def test_add_and_get_histories(context_manager):
 
 
 @pytest.mark.asyncio
+async def test_add_and_get_histories_with_shared(context_manager):
+    test_id = str(uuid4())
+    context_id = f"test_specific_context_{test_id}"
+    data_list = [
+        {"message": "Hello, world!", "role": "user"},
+        {"message": "Hi! How can I help you today?", "role": "assistant"}
+    ]
+    await context_manager.add_histories(context_id, data_list)
+
+    shared_context_id = f"test_shared_context_{test_id}"
+    shared_data_list = [
+        {"message": "Shared Request", "role": "user"},
+        {"message": "Shared Answer", "role": "assistant"}
+    ]
+    await context_manager.add_histories(shared_context_id, shared_data_list)
+
+    histories = await context_manager.get_histories(context_id=[context_id, shared_context_id])
+    assert len(histories) == 4
+
+    assert histories[0]["message"] == "Hello, world!"
+    assert histories[0]["role"] == "user"
+    assert histories[1]["message"] == "Hi! How can I help you today?"
+    assert histories[1]["role"] == "assistant"
+    assert histories[2]["message"] == "Shared Request"
+    assert histories[2]["role"] == "user"
+    assert histories[3]["message"] == "Shared Answer"
+    assert histories[3]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
 async def test_get_histories_limit(context_manager):
     context_id = f"test_context_limit_{uuid4()}"
     data_list = [


### PR DESCRIPTION
Introduces the shared_context_ids parameter to LLMService and its subclasses, allowing retrieval of chat histories from multiple context IDs.