### PR TITLE
Add user_id to LLM service methods

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -219,7 +219,7 @@ The list of tools is as follows:
     def replace_last_option_split_char(self, original):
         return re.sub(self.option_split_chars_regex, r"\1|", original)
 
-    def get_system_prompt(self, system_prompt_params: Dict[str, any]):
+    def get_system_prompt(self, context_id: str, user_id: str, system_prompt_params: Dict[str, any]):
         if not system_prompt_params:
             return self.system_prompt
         else:
@@ -231,11 +231,11 @@ The list of tools is as follows:
         pass
 
     @abstractmethod
-    async def compose_messages(self, context_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
+    async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
         pass
 
     @abstractmethod
-    async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
+    async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
         pass
 
     async def get_dynamic_tools_default(self, messages: List[dict], metadata: Dict[str, any] = None) -> List[Dict[str, any]]:
@@ -281,7 +281,7 @@ The list of tools is as follows:
         if not text and not files:
             return
 
-        messages = await self.compose_messages(context_id, text, files, system_prompt_params)
+        messages = await self.compose_messages(context_id, user_id, text, files, system_prompt_params)
         message_length_at_start = len(messages) - 1
 
         stream_buffer = ""
@@ -366,6 +366,7 @@ The list of tools is as follows:
         if len(messages) > message_length_at_start:
             await self.update_context(
                 context_id,
+                user_id,
                 messages[message_length_at_start - len(messages):],
                 response_text.strip(),
             )

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -90,10 +90,10 @@ class ChatGPTService(LLMService):
     def dynamic_tool_name(self) -> str:
         return self.dynamic_tool_spec["function"]["name"]
 
-    async def compose_messages(self, context_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
+    async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
         messages = []
         if self.system_prompt:
-            messages.append({"role": "system", "content": self.get_system_prompt(system_prompt_params)})
+            messages.append({"role": "system", "content": self.get_system_prompt(context_id, user_id, system_prompt_params)})
 
         # Add initial messages (e.g. few-shot)
         if self.initial_messages:
@@ -120,7 +120,7 @@ class ChatGPTService(LLMService):
 
         return messages
 
-    async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
+    async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
         if self._update_context_filter:
             if isinstance(messages[0]["content"], list):
                 if "text" in messages[0]["content"][-1]:

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -74,7 +74,7 @@ class ClaudeService(LLMService):
     def dynamic_tool_name(self) -> str:
         return self.dynamic_tool_spec["name"]
 
-    async def compose_messages(self, context_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
+    async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
         messages = []
 
         # Add initial messages (e.g. few-shot)
@@ -100,7 +100,7 @@ class ClaudeService(LLMService):
 
         return messages
 
-    async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
+    async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
         if self._update_context_filter:
             if "text" in messages[0]["content"][-1]:
                 messages[0]["content"][-1]["text"] = self._update_context_filter(messages[0]["content"][-1]["text"])
@@ -185,7 +185,7 @@ class ClaudeService(LLMService):
 
         async with self.anthropic_client.messages.stream(
             messages=messages,
-            system=self.get_system_prompt(system_prompt_params) + tool_instruction,
+            system=self.get_system_prompt(context_id, user_id, system_prompt_params) + tool_instruction,
             model=self.model,
             temperature=self.temperature,
             tools=filtered_tools,

--- a/aiavatar/sts/llm/dify.py
+++ b/aiavatar/sts/llm/dify.py
@@ -52,7 +52,7 @@ class DifyService(LLMService):
     def dynamic_tool_name(self) -> str:
         pass
 
-    async def compose_messages(self, context_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
+    async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
         if self.make_inputs:
             inputs = self.make_inputs(context_id, text, files, system_prompt_params)
         else:
@@ -74,7 +74,7 @@ class DifyService(LLMService):
         
         return [message]
 
-    async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
+    async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
         # Context is managed at Dify server
         pass
 

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -83,7 +83,7 @@ class GeminiService(LLMService):
     def dynamic_tool_name(self) -> str:
         return self.dynamic_tool_spec["functionDeclarations"][0]["name"]
 
-    async def compose_messages(self, context_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
+    async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
         messages = []
 
         # Add initial messages (e.g. few-shot)
@@ -118,7 +118,7 @@ class GeminiService(LLMService):
         messages.append(types.Content(role="user", parts=parts))
         return messages
 
-    async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
+    async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
         messages.append(types.Content(role="model", parts=[types.Part.from_text(text=response_text)]))
         dict_messages = []
         for m in messages:
@@ -252,7 +252,7 @@ class GeminiService(LLMService):
         else:
             filtered_tools = [t.spec for _, t in self.tools.items() if not t.is_dynamic] or None
 
-        system_instruction = self.get_system_prompt(system_prompt_params)
+        system_instruction = self.get_system_prompt(context_id, user_id, system_prompt_params)
         if tool_instruction:
             system_instruction = system_instruction + tool_instruction if system_instruction else tool_instruction
 
@@ -292,7 +292,7 @@ class GeminiService(LLMService):
                         logger.info("Get dynamic tool")
                         filtered_tools = await self._get_dynamic_tools(
                             messages,
-                            {"system_prompt": self.get_system_prompt(system_prompt_params)}
+                            {"system_prompt": self.get_system_prompt(context_id, user_id, system_prompt_params)}
                         )
                         logger.info(f"Dynamic tools: {filtered_tools}")
                         try_dynamic_tools = True

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -76,14 +76,14 @@ class LiteLLMService(LLMService):
     def dynamic_tool_name(self) -> str:
         return self.dynamic_tool_spec["function"]["name"]
 
-    async def compose_messages(self, context_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
+    async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
         messages = []
         if self.system_prompt:
             if self.system_prompt_by_user_prompt:
-                messages.append({"role": "user", "content": self.get_system_prompt(system_prompt_params)})
+                messages.append({"role": "user", "content": self.get_system_prompt(context_id, user_id, system_prompt_params)})
                 messages.append({"role": "assistant", "content": "ok"})
             else:
-                messages.append({"role": "system", "content": self.get_system_prompt(system_prompt_params)})
+                messages.append({"role": "system", "content": self.get_system_prompt(context_id, user_id, system_prompt_params)})
 
         # Add initial messages (e.g. few-shot)
         if self.initial_messages:
@@ -110,7 +110,7 @@ class LiteLLMService(LLMService):
 
         return messages
 
-    async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
+    async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
         if self._update_context_filter:
             if isinstance(messages[0]["content"], list):
                 if "text" in messages[0]["content"][-1]:

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -84,7 +84,8 @@ class STSPipeline:
                 user_id=self.vad.get_session_data(session_id, "user_id"),
                 context_id=self.vad.get_session_data(session_id, "context_id"),
                 audio_data=data,
-                audio_duration=recorded_duration
+                audio_duration=recorded_duration,
+                system_prompt_params=self.vad.get_session_data(session_id, "system_prompt_params")
             )):
                 if response.type == "start":
                     self.vad.set_session_data(session_id, "context_id", response.context_id)


### PR DESCRIPTION
Refactored LLM service interfaces and implementations to include user_id as a parameter in get_system_prompt, compose_messages, and update_context methods. This change enables user-specific context handling and prompt customization across all supported LLM backends.