### PR TITLE
Add speed parameter to SpeechGatewaySpeechSynthesizer

### DIFF
--- a/aiavatar/sts/tts/speech_gateway.py
+++ b/aiavatar/sts/tts/speech_gateway.py
@@ -10,8 +10,9 @@ class SpeechGatewaySpeechSynthesizer(SpeechSynthesizer):
     def __init__(
         self,
         *,
-        service_name: str,
-        speaker: str,
+        service_name: str = None,
+        speaker: str = None,
+        speed: float = None,
         style_mapper: Dict[str, str] = None,
         tts_url: str = "http://127.0.0.1:8000/tts",
         audio_format: str = None,
@@ -31,6 +32,7 @@ class SpeechGatewaySpeechSynthesizer(SpeechSynthesizer):
         )
         self.service_name = service_name
         self.speaker = speaker
+        self.speed = speed
         self.tts_url = tts_url
         self.audio_format = audio_format
 
@@ -46,8 +48,16 @@ class SpeechGatewaySpeechSynthesizer(SpeechSynthesizer):
         # Audio format
         query_params = {"x_audio_format": self.audio_format} if self.audio_format else {}
 
+        # Make basic params
+        request_json = {"text": processed_text}
+        if self.service_name:
+            request_json["service_name"] = self.service_name
+        if self.speaker:
+            request_json["speaker"] = self.speaker
+        if self.speed:
+            request_json["speed"] = self.speed
+
         # Apply style
-        request_json = {"text": processed_text, "service_name": self.service_name, "speaker": self.speaker}
         if style := self.parse_style(style_info):
             request_json["style"] = style
             logger.info(f"Apply style: {style}")


### PR DESCRIPTION
Introduces an optional 'speed' parameter to the SpeechGatewaySpeechSynthesizer class and includes it in the TTS request payload if provided. Also makes 'service_name' and 'speaker' parameters optional for greater flexibility.