### PR TITLE
Add OpenAI Responses API support with REST and WebSocket modes

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -173,6 +173,8 @@ A component that generates conversation responses.
 | Implementation | Provider | Characteristics |
 |----------------|----------|-----------------|
 | **ChatGPTService** | OpenAI / Azure OpenAI | Tool calling, o1/o3 reasoning model support |
+| **OpenAIResponsesService** | OpenAI (Responses API) | Server-side conversation history via `previous_response_id` |
+| **OpenAIResponsesWebSocketService** | OpenAI (Responses API, WebSocket) | Persistent connection pooling for lower latency. No `temperature` support |
 | **ClaudeService** | Anthropic | Content block streaming |
 | **GeminiService** | Google | Extended thinking mode, image download support |
 | **LiteLLMService** | Multiple providers | Model-agnostic unified interface |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - **🧩 Modular architecture**: Components such as VAD, STT, LLM, and TTS are modular and easy to integrate via lightweight interfaces. Supported modules include:
     - VAD: Built-in standard VAD (silence-based end-of-turn detection), SileroVAD
     - STT: Google, Azure, OpenAI, AmiVoice
-    - LLM: ChatGPT, Gemini, Claude, and any model supported by LiteLLM or Dify
+    - LLM: ChatGPT, OpenAI Responses API (REST / WebSocket), Gemini, Claude, and any model supported by LiteLLM or Dify
     - TTS: VOICEVOX / AivisSpeech, OpenAI, SpeechGateway (including Style-Bert-VITS2 and Aivis Cloud API)
 - **⚡️ AI Agent native**: Designed to support agentic systems. In addition to standard tool calls, it offers Dynamic Tool Calls for extensibility and supports progress feedback for high-latency operations.
 
@@ -110,6 +110,7 @@ You can also access the Admin Panel at http://127.0.0.1:8000/admin.
 
 - [🎓 Generative AI](#-generative-ai)
     - [ChatGPT](#chatgpt)
+    - [OpenAI Responses API](#openai-responses-api)
     - [Claude](#claude)
     - [Gemini](#gemini)
     - [Dify](#dify)
@@ -222,6 +223,40 @@ aiavatar_app = AIAvatar(
     openai_api_key=OPENAI_API_KEY   # API Key for STT
 )
 ```
+
+### OpenAI Responses API
+
+Use `OpenAIResponsesService` to leverage the OpenAI Responses API. Conversation history is managed server-side via `previous_response_id`, eliminating the need for client-side context management.
+
+```python
+from aiavatar.sts.llm.openai_responses import OpenAIResponsesService
+llm = OpenAIResponsesService(
+    openai_api_key=OPENAI_API_KEY,
+    model="gpt-5.4",
+    system_prompt="You are my cat."
+)
+
+aiavatar_app = AIAvatar(
+    llm=llm,
+    openai_api_key=OPENAI_API_KEY   # API Key for STT
+)
+```
+
+For lower latency, use the WebSocket variant. This maintains persistent connections via a connection pool, which can reduce latency by up to 40%, especially in tool-call-heavy workflows.
+
+```python
+# pip install websockets
+from aiavatar.sts.llm.openai_responses_websocket import OpenAIResponsesWebSocketService
+llm = OpenAIResponsesWebSocketService(
+    openai_api_key=OPENAI_API_KEY,
+    model="gpt-5.4",
+    reasoning_effort="low",
+    system_prompt="You are my cat."
+)
+```
+
+NOTE: The WebSocket variant does not support the `temperature` parameter. Use `reasoning_effort` ("none", "low", "medium", "high") instead to control response behavior. Dynamic Tool Calls are not supported in either variant, as the server-side history management via `previous_response_id` is incompatible with the pre-flight tool filtering calls.
+
 
 ### Claude
 

--- a/aiavatar/sts/llm/openai_responses.py
+++ b/aiavatar/sts/llm/openai_responses.py
@@ -1,0 +1,266 @@
+import copy
+import json
+from logging import getLogger
+from typing import AsyncGenerator, Dict, List, Union
+import openai as openai_module
+from . import LLMService, LLMResponse, ToolCall, Tool
+from .context_manager import ContextManager
+
+logger = getLogger(__name__)
+
+
+class OpenAIResponsesService(LLMService):
+    def __init__(
+        self,
+        *,
+        openai_api_key: str = None,
+        system_prompt: str = None,
+        base_url: str = None,
+        model: str = "gpt-5.4",
+        temperature: float = None,
+        reasoning_effort: str = None,
+        extra_body: dict = None,
+        initial_messages: List[dict] = None,
+        split_chars: List[str] = None,
+        option_split_chars: List[str] = None,
+        option_split_threshold: int = 50,
+        split_on_control_tags: bool = True,
+        voice_text_tag: Union[str, List[str]] = None,
+        context_manager: ContextManager = None,
+        shared_context_ids: List[str] = None,
+        db_connection_str: str = "aiavatar.db",
+        debug: bool = False
+    ):
+        super().__init__(
+            system_prompt=system_prompt,
+            model=model,
+            temperature=temperature,
+            initial_messages=initial_messages,
+            split_chars=split_chars,
+            option_split_chars=option_split_chars,
+            option_split_threshold=option_split_threshold,
+            split_on_control_tags=split_on_control_tags,
+            voice_text_tag=voice_text_tag,
+            context_manager=context_manager,
+            shared_context_ids=shared_context_ids,
+            db_connection_str=db_connection_str,
+            debug=debug
+        )
+        self.reasoning_effort = reasoning_effort
+        self.extra_body = extra_body
+        self.response_ids: Dict[str, str] = {}
+        self._edit_response_params = None
+
+        self.openai_client = openai_module.AsyncClient(
+            api_key=openai_api_key, base_url=base_url
+        )
+
+    def get_config(self) -> dict:
+        config = super().get_config()
+        config["reasoning_effort"] = self.reasoning_effort
+        config["extra_body"] = self.extra_body
+        return config
+
+    @property
+    def dynamic_tool_name(self) -> str:
+        return None
+
+    def edit_response_params(self, func):
+        self._edit_response_params = func
+        return func
+
+    async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
+        messages = []
+
+        # Add initial messages for the first call only (no server-side history yet)
+        if not self.response_ids.get(context_id):
+            initial_msgs = await self._get_initial_messages(context_id, user_id, system_prompt_params)
+            if initial_msgs:
+                messages.extend(initial_msgs)
+
+        # Build user message
+        if files:
+            content = []
+            for f in files:
+                if url := f.get("url"):
+                    content.append({"type": "input_image", "image_url": url})
+            if text:
+                content.append({"type": "input_text", "text": text})
+        else:
+            content = text
+        messages.append({"role": "user", "content": content})
+
+        return messages
+
+    async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
+        # Context is managed at OpenAI server via previous_response_id
+        await self.context_manager.add_histories(context_id, [{}], "openai_responses")
+
+    def tool(self, spec: Dict):
+        def decorator(func):
+            # Accept Chat Completions format and convert to Responses API format
+            if spec.get("type") == "function" and "function" in spec:
+                tool_name = spec["function"]["name"]
+                responses_spec = {
+                    "type": "function",
+                    "name": spec["function"]["name"],
+                    "description": spec["function"]["description"],
+                    "parameters": spec["function"]["parameters"],
+                }
+            else:
+                tool_name = spec.get("name", func.__name__)
+                responses_spec = spec
+
+            self.tools[tool_name] = Tool(
+                name=tool_name,
+                spec=responses_spec,
+                func=func
+            )
+            return func
+        return decorator
+
+    def add_tool(self, tool: Tool, is_dynamic: bool = False, use_original: bool = False):
+        if use_original:
+            tool_to_add = tool
+        else:
+            tool_to_add = copy.copy(tool)
+            n, d, p = tool.parse_spec(tool.spec)
+            tool_to_add.spec = {
+                "type": "function",
+                "name": n,
+                "description": d,
+                "parameters": p,
+            }
+            tool_to_add.is_dynamic = is_dynamic
+        self.tools[tool_to_add.name] = tool_to_add
+
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+        # Build tools list
+        all_tools = [t.spec for _, t in self.tools.items()]
+
+        # Build params
+        response_params = {
+            "model": self.model,
+            "input": messages,
+            "stream": True,
+        }
+
+        # Instructions (system prompt)
+        if system_prompt := await self._get_system_prompt(context_id, user_id, system_prompt_params):
+            response_params["instructions"] = system_prompt
+
+        # Previous response for conversation continuity
+        if previous_response_id := self.response_ids.get(context_id):
+            response_params["previous_response_id"] = previous_response_id
+
+        # Temperature and reasoning effort
+        if self.reasoning_effort is not None:
+            response_params["reasoning"] = {"effort": self.reasoning_effort}
+        if self.temperature is not None:
+            response_params["temperature"] = self.temperature
+
+        if self.extra_body:
+            response_params["extra_body"] = self.extra_body
+
+        # Tools
+        if all_tools:
+            response_params["tools"] = all_tools
+
+        # Inline params
+        if inline_llm_params:
+            for k, v in inline_llm_params.items():
+                response_params[k] = v
+
+        # Edit params callback
+        if self._edit_response_params:
+            self._edit_response_params(response_params, context_id, user_id)
+
+        if self.debug:
+            logger.info(f"Request to OpenAI Responses API: {response_params}")
+
+        # Send request
+        try:
+            stream_resp = await self.openai_client.responses.create(**response_params)
+
+        except openai_module.APIStatusError as aserr:
+            response_json = None
+            try:
+                response_json = aserr.response.json()
+            except:
+                pass
+            logger.warning(f"APIStatusError from OpenAI Responses API: {aserr}")
+            yield LLMResponse(context_id=context_id, error_info={"exception": aserr, "response_json": response_json})
+            return
+
+        except Exception as ex:
+            logger.warning(f"Error from OpenAI Responses API: {ex}")
+            yield LLMResponse(context_id=context_id, error_info={"exception": ex, "response_json": None})
+            return
+
+        # Process streaming events
+        tool_calls: List[ToolCall] = []
+        tool_call_map: Dict[int, int] = {}  # output_index -> tool_calls list index
+
+        async for event in stream_resp:
+            if event.type == "response.output_text.delta":
+                yield LLMResponse(context_id=context_id, text=event.delta)
+
+            elif event.type == "response.output_item.added":
+                if event.item.type == "function_call":
+                    tc = ToolCall(event.item.call_id, event.item.name, "")
+                    tool_call_map[event.output_index] = len(tool_calls)
+                    tool_calls.append(tc)
+
+            elif event.type == "response.function_call_arguments.delta":
+                idx = tool_call_map.get(event.output_index)
+                if idx is not None:
+                    tool_calls[idx].arguments += event.delta
+
+            elif event.type == "response.completed":
+                self.response_ids[context_id] = event.response.id
+
+        # Execute tool calls
+        if tool_calls:
+            await self._on_before_tool_calls(tool_calls)
+
+            tool_outputs = []
+            has_direct_response = False
+            for tc in tool_calls:
+                if self.debug:
+                    logger.info(f"ToolCall: {tc.name}")
+                yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
+
+                tool_result = None
+                async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id}):
+                    tc.result = tr
+                    if tr.text:
+                        yield LLMResponse(context_id=context_id, text=tr.text)
+                    else:
+                        yield LLMResponse(context_id=context_id, tool_call=tc)
+                        if tr.is_final:
+                            tool_result = tr.data
+                            break
+
+                if self.debug:
+                    logger.info(f"ToolCall result: {tool_result}")
+
+                if tool_result:
+                    # Use response_formatter for direct response if available
+                    tool_obj = self.tools.get(tc.name)
+                    if tool_obj and tool_obj._response_formatter:
+                        direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
+                        yield LLMResponse(context_id=context_id, text=direct_text)
+                        has_direct_response = True
+
+                    tool_outputs.append({
+                        "type": "function_call_output",
+                        "call_id": tc.id,
+                        "output": json.dumps(tool_result),
+                    })
+
+            if not has_direct_response and tool_outputs:
+                # Send tool results back via recursive call with previous_response_id
+                async for llm_response in self.get_llm_stream_response(
+                    context_id, user_id, tool_outputs, system_prompt_params=system_prompt_params
+                ):
+                    yield llm_response

--- a/aiavatar/sts/llm/openai_responses_websocket.py
+++ b/aiavatar/sts/llm/openai_responses_websocket.py
@@ -1,0 +1,370 @@
+import asyncio
+import copy
+import json
+from contextlib import asynccontextmanager
+from logging import getLogger
+from time import time
+from typing import AsyncGenerator, Dict, List, Union
+import websockets
+from . import LLMService, LLMResponse, ToolCall, Tool
+from .context_manager import ContextManager
+
+logger = getLogger(__name__)
+
+
+class WebSocketPool:
+    """Async WebSocket connection pool with semaphore-based concurrency control."""
+
+    def __init__(self, url: str, api_key: str, max_size: int = 5, max_age: float = 3300):
+        self._url = url
+        self._api_key = api_key
+        self._max_size = max_size
+        self._max_age = max_age  # seconds (default 55 min, before OpenAI's 60 min limit)
+        self._idle: asyncio.Queue = asyncio.Queue()
+        self._semaphore = asyncio.Semaphore(max_size)
+
+    @staticmethod
+    def _is_closed(ws) -> bool:
+        # websockets >= 13 (ClientConnection): no .closed attr, use .close_code
+        # websockets < 13 (WebSocketClientProtocol): has .closed bool
+        if hasattr(ws, "closed"):
+            return ws.closed
+        return ws.close_code is not None
+
+    async def _connect(self):
+        ws = await websockets.connect(
+            self._url,
+            additional_headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+        return ws, time()
+
+    @asynccontextmanager
+    async def connection(self):
+        """Acquire a WebSocket connection, yield it, then release back to pool."""
+        await self._semaphore.acquire()
+        ws = None
+        created_at = 0.0
+        error_occurred = False
+        try:
+            # Try to reuse an idle connection
+            while not self._idle.empty():
+                try:
+                    ws, created_at = self._idle.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if not self._is_closed(ws) and (time() - created_at) < self._max_age:
+                    break
+                try:
+                    await ws.close()
+                except Exception:
+                    pass
+                ws = None
+
+            # Create new connection if needed
+            if ws is None or self._is_closed(ws):
+                ws, created_at = await self._connect()
+
+            yield ws
+
+        except Exception:
+            error_occurred = True
+            raise
+        finally:
+            if ws is not None:
+                if not error_occurred and not self._is_closed(ws) and (time() - created_at) < self._max_age:
+                    self._idle.put_nowait((ws, created_at))
+                else:
+                    try:
+                        await ws.close()
+                    except Exception:
+                        pass
+            self._semaphore.release()
+
+    async def close(self):
+        """Close all idle connections in the pool."""
+        while not self._idle.empty():
+            try:
+                ws, _ = self._idle.get_nowait()
+                await ws.close()
+            except Exception:
+                pass
+
+
+class OpenAIResponsesWebSocketService(LLMService):
+    def __init__(
+        self,
+        *,
+        openai_api_key: str = None,
+        system_prompt: str = None,
+        ws_url: str = None,
+        model: str = "gpt-5.4",
+        reasoning_effort: str = None,
+        extra_body: dict = None,
+        initial_messages: List[dict] = None,
+        split_chars: List[str] = None,
+        option_split_chars: List[str] = None,
+        option_split_threshold: int = 50,
+        split_on_control_tags: bool = True,
+        voice_text_tag: Union[str, List[str]] = None,
+        max_connections: int = 100,  # Max concurrent WebSocket connections (= max parallel requests)
+        max_connection_age: float = 3300,
+        context_manager: ContextManager = None,
+        shared_context_ids: List[str] = None,
+        db_connection_str: str = "aiavatar.db",
+        debug: bool = False
+    ):
+        super().__init__(
+            system_prompt=system_prompt,
+            model=model,
+            initial_messages=initial_messages,
+            split_chars=split_chars,
+            option_split_chars=option_split_chars,
+            option_split_threshold=option_split_threshold,
+            split_on_control_tags=split_on_control_tags,
+            voice_text_tag=voice_text_tag,
+            context_manager=context_manager,
+            shared_context_ids=shared_context_ids,
+            db_connection_str=db_connection_str,
+            debug=debug
+        )
+        self.reasoning_effort = reasoning_effort
+        self.extra_body = extra_body
+        self.response_ids: Dict[str, str] = {}
+        self._edit_response_params = None
+
+        base = ws_url or "wss://api.openai.com"
+        self._ws_pool = WebSocketPool(
+            url=f"{base.rstrip('/')}/v1/responses",
+            api_key=openai_api_key,
+            max_size=max_connections,
+            max_age=max_connection_age,
+        )
+
+    def get_config(self) -> dict:
+        config = super().get_config()
+        config["reasoning_effort"] = self.reasoning_effort
+        config["extra_body"] = self.extra_body
+        return config
+
+    @property
+    def dynamic_tool_name(self) -> str:
+        return None
+
+    def edit_response_params(self, func):
+        self._edit_response_params = func
+        return func
+
+    async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None) -> List[Dict]:
+        messages = []
+
+        # Add initial messages for the first call only (no server-side history yet)
+        if not self.response_ids.get(context_id):
+            initial_msgs = await self._get_initial_messages(context_id, user_id, system_prompt_params)
+            if initial_msgs:
+                messages.extend(initial_msgs)
+
+        # Build user message
+        if files:
+            content = []
+            for f in files:
+                if url := f.get("url"):
+                    content.append({"type": "input_image", "image_url": url})
+            if text:
+                content.append({"type": "input_text", "text": text})
+        else:
+            content = text
+        messages.append({"role": "user", "content": content})
+
+        return messages
+
+    async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
+        # Context is managed at OpenAI server via previous_response_id
+        await self.context_manager.add_histories(context_id, [{}], "openai_responses_ws")
+
+    def tool(self, spec: Dict):
+        def decorator(func):
+            # Accept Chat Completions format and convert to Responses API format
+            if spec.get("type") == "function" and "function" in spec:
+                tool_name = spec["function"]["name"]
+                responses_spec = {
+                    "type": "function",
+                    "name": spec["function"]["name"],
+                    "description": spec["function"]["description"],
+                    "parameters": spec["function"]["parameters"],
+                }
+            else:
+                tool_name = spec.get("name", func.__name__)
+                responses_spec = spec
+
+            self.tools[tool_name] = Tool(
+                name=tool_name,
+                spec=responses_spec,
+                func=func
+            )
+            return func
+        return decorator
+
+    def add_tool(self, tool: Tool, is_dynamic: bool = False, use_original: bool = False):
+        if use_original:
+            tool_to_add = tool
+        else:
+            tool_to_add = copy.copy(tool)
+            n, d, p = tool.parse_spec(tool.spec)
+            tool_to_add.spec = {
+                "type": "function",
+                "name": n,
+                "description": d,
+                "parameters": p,
+            }
+            tool_to_add.is_dynamic = is_dynamic
+        self.tools[tool_to_add.name] = tool_to_add
+
+    def _build_response_create(self, context_id: str, input_data: list, system_prompt: str = None) -> dict:
+        """Build a response.create message for WebSocket."""
+        message = {
+            "type": "response.create",
+            "model": self.model,
+            "input": input_data,
+        }
+
+        if system_prompt:
+            message["instructions"] = system_prompt
+
+        if previous_response_id := self.response_ids.get(context_id):
+            message["previous_response_id"] = previous_response_id
+
+        # Temperature and reasoning effort
+        if self.reasoning_effort is not None:
+            message["reasoning"] = {"effort": self.reasoning_effort}
+
+        # Tools
+        all_tools = [t.spec for _, t in self.tools.items()]
+        if all_tools:
+            message["tools"] = all_tools
+
+        return message
+
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+        # System prompt
+        system_prompt = await self._get_system_prompt(context_id, user_id, system_prompt_params)
+
+        try:
+            async with self._ws_pool.connection() as ws:
+                current_input = messages
+
+                while True:
+                    # Build response.create message
+                    ws_message = self._build_response_create(context_id, current_input, system_prompt)
+
+                    if self.extra_body:
+                        ws_message["extra_body"] = self.extra_body
+
+                    if inline_llm_params:
+                        for k, v in inline_llm_params.items():
+                            ws_message[k] = v
+
+                    if self._edit_response_params:
+                        self._edit_response_params(ws_message, context_id, user_id)
+
+                    if self.debug:
+                        logger.info(f"Request to OpenAI Responses API (WebSocket): {ws_message}")
+
+                    await ws.send(json.dumps(ws_message))
+
+                    # Receive and process events until response completes
+                    tool_calls: List[ToolCall] = []
+                    tool_call_map: Dict[int, int] = {}
+
+                    while True:
+                        raw = await ws.recv()
+                        event = json.loads(raw)
+                        event_type = event.get("type")
+
+                        if event_type == "response.output_text.delta":
+                            yield LLMResponse(context_id=context_id, text=event.get("delta", ""))
+
+                        elif event_type == "response.output_item.added":
+                            item = event.get("item", {})
+                            if item.get("type") == "function_call":
+                                tc = ToolCall(item.get("call_id"), item.get("name"), "")
+                                tool_call_map[event.get("output_index")] = len(tool_calls)
+                                tool_calls.append(tc)
+
+                        elif event_type == "response.function_call_arguments.delta":
+                            idx = tool_call_map.get(event.get("output_index"))
+                            if idx is not None:
+                                tool_calls[idx].arguments += event.get("delta", "")
+
+                        elif event_type == "response.completed":
+                            resp = event.get("response", {})
+                            if resp_id := resp.get("id"):
+                                self.response_ids[context_id] = resp_id
+                            break
+
+                        elif event_type == "response.failed":
+                            resp = event.get("response", {})
+                            error = resp.get("error", {})
+                            logger.warning(f"Response failed from OpenAI Responses API (WebSocket): {error}")
+                            yield LLMResponse(context_id=context_id, error_info={"exception": Exception(error.get("message", "Unknown error")), "response_json": resp})
+                            return
+
+                        elif event_type == "error":
+                            error = event.get("error", {})
+                            logger.warning(f"Error from OpenAI Responses API (WebSocket): {error}")
+                            yield LLMResponse(context_id=context_id, error_info={"exception": Exception(error.get("message", "Unknown error")), "response_json": event})
+                            return
+
+                    # No tool calls — done
+                    if not tool_calls:
+                        break
+
+                    # Execute tool calls
+                    await self._on_before_tool_calls(tool_calls)
+
+                    tool_outputs = []
+                    has_direct_response = False
+                    for tc in tool_calls:
+                        if self.debug:
+                            logger.info(f"ToolCall: {tc.name}")
+                        yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
+
+                        tool_result = None
+                        async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id}):
+                            tc.result = tr
+                            if tr.text:
+                                yield LLMResponse(context_id=context_id, text=tr.text)
+                            else:
+                                yield LLMResponse(context_id=context_id, tool_call=tc)
+                                if tr.is_final:
+                                    tool_result = tr.data
+                                    break
+
+                        if self.debug:
+                            logger.info(f"ToolCall result: {tool_result}")
+
+                        if tool_result:
+                            tool_obj = self.tools.get(tc.name)
+                            if tool_obj and tool_obj._response_formatter:
+                                direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
+                                yield LLMResponse(context_id=context_id, text=direct_text)
+                                has_direct_response = True
+
+                            tool_outputs.append({
+                                "type": "function_call_output",
+                                "call_id": tc.id,
+                                "output": json.dumps(tool_result),
+                            })
+
+                    if has_direct_response or not tool_outputs:
+                        break
+
+                    # Continue on the same connection with tool outputs
+                    current_input = tool_outputs
+
+        except websockets.ConnectionClosed as ex:
+            logger.warning(f"WebSocket connection closed: {ex}")
+            yield LLMResponse(context_id=context_id, error_info={"exception": ex, "response_json": None})
+
+        except Exception as ex:
+            logger.warning(f"Error from OpenAI Responses API (WebSocket): {ex}")
+            yield LLMResponse(context_id=context_id, error_info={"exception": ex, "response_json": None})

--- a/tests/sts/llm/test_openai_responses.py
+++ b/tests/sts/llm/test_openai_responses.py
@@ -1,0 +1,300 @@
+import asyncio
+import json
+import os
+import pytest
+from typing import Any, Dict
+from uuid import uuid4
+from aiavatar.sts.llm.openai_responses import OpenAIResponsesService
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+IMAGE_URL = os.getenv("IMAGE_URL")
+MODEL = "gpt-4.1"
+
+SYSTEM_PROMPT = """
+## 基本設定
+
+あなたはユーザーの妹として、感情表現豊かに振る舞ってください。
+
+## 表情について
+
+あなたは以下のようなタグで表情を表現することができます。
+
+[face:Angry]はあ？何言ってるのか全然わからないんですけど。
+
+表情のバリエーションは以下の通りです。
+
+- Joy
+- Angry
+"""
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_service_simple():
+    """
+    Test OpenAIResponsesService with a basic prompt to check if it can stream responses.
+    This test actually calls OpenAI Responses API, so it may cost tokens.
+    """
+    service = OpenAIResponsesService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt=SYSTEM_PROMPT,
+        model=MODEL,
+        temperature=0.5
+    )
+    context_id = f"test_context_{uuid4()}"
+
+    user_message = "君が大切にしていたプリンは、私が勝手に食べておいた。"
+
+    collected_text = []
+    collected_voice = []
+
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        collected_text.append(resp.text)
+        collected_voice.append(resp.voice_text)
+
+    full_text = "".join(collected_text)
+    full_voice = "".join(filter(None, collected_voice))
+    assert len(full_text) > 0, "No text was returned from the LLM."
+
+    # Check the response content
+    assert "[face:Angry]" in full_text, "Control tag doesn't appear in text."
+    assert "[face:Angry]" not in full_voice, "Control tag was not removed from voice_text."
+
+    # Check server-side context management (response_id should be stored)
+    assert context_id in service.response_ids, "response_id not stored for context."
+
+    # Check context marker was saved
+    histories = await service.context_manager.get_histories(context_id)
+    assert len(histories) > 0, "No context marker was saved."
+
+    await service.openai_client.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_service_context_continuity():
+    """
+    Test that the service maintains conversation context across multiple calls
+    via previous_response_id (server-side history).
+    This test actually calls OpenAI Responses API, so it may cost tokens.
+    """
+    service = OpenAIResponsesService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="あなたは親切なアシスタントです。短く回答してください。",
+        model=MODEL,
+        temperature=0.0
+    )
+    context_id = f"test_continuity_{uuid4()}"
+
+    # First call: tell the model something specific
+    async for resp in service.chat_stream(context_id, "test_user", "私の好きな果物はマンゴーです。覚えておいてください。"):
+        pass
+
+    first_response_id = service.response_ids.get(context_id)
+    assert first_response_id is not None, "response_id should be set after first call."
+
+    # Second call: ask about what was said before
+    collected_text = []
+    async for resp in service.chat_stream(context_id, "test_user", "私の好きな果物は何ですか？"):
+        if resp.text:
+            collected_text.append(resp.text)
+
+    full_text = "".join(collected_text)
+    assert "マンゴー" in full_text, f"Context was not maintained. Response: {full_text}"
+
+    # response_id should have been updated
+    second_response_id = service.response_ids.get(context_id)
+    assert second_response_id != first_response_id, "response_id should be updated after second call."
+
+    await service.openai_client.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_service_tool_calls():
+    """
+    Test OpenAIResponsesService with a registered tool.
+    This test actually calls OpenAI Responses API, so it may cost tokens.
+    """
+    service = OpenAIResponsesService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="You can call a tool to solve math problems if necessary.",
+        model=MODEL,
+        temperature=0.5
+    )
+    context_id = f"test_tool_context_{uuid4()}"
+
+    # Register tool using Chat Completions format (should be auto-converted)
+    tool_spec = {
+        "type": "function",
+        "function": {
+            "name": "solve_math",
+            "description": "Solve simple math problems",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "problem": {"type": "string"}
+                },
+                "required": ["problem"]
+            }
+        }
+    }
+
+    @service.tool(tool_spec)
+    async def solve_math(problem: str) -> Dict[str, Any]:
+        if problem.strip() == "1+1":
+            return {"answer": 2}
+        else:
+            return {"answer": "unknown"}
+
+    user_message = "次の問題を解いて: 1+1"
+    collected_text = []
+    tool_called = False
+
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        if resp.text:
+            collected_text.append(resp.text)
+        if resp.tool_call:
+            tool_called = True
+
+    full_text = "".join(collected_text)
+    assert tool_called, "Tool was not called."
+    assert "2" in full_text, f"Answer '2' not found in response: {full_text}"
+
+    await service.openai_client.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_service_tool_calls_response_formatter():
+    """
+    Test OpenAIResponsesService with a registered tool that has response_formatter.
+    The tool result should be formatted directly without a 2nd LLM call.
+    This test actually calls OpenAI Responses API, so it may cost tokens.
+    """
+    service = OpenAIResponsesService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="You can call a tool to solve math problems if necessary.",
+        model=MODEL,
+        temperature=0.5
+    )
+    context_id = f"test_tool_rf_context_{uuid4()}"
+
+    tool_spec = {
+        "type": "function",
+        "function": {
+            "name": "solve_math",
+            "description": "Solve simple math problems",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "problem": {"type": "string"}
+                },
+                "required": ["problem"]
+            }
+        }
+    }
+
+    @service.tool(tool_spec)
+    async def solve_math(problem: str) -> Dict[str, Any]:
+        if problem.strip() == "1+1":
+            return {"answer": 2}
+        else:
+            return {"answer": "unknown"}
+
+    @service.tools["solve_math"].response_formatter
+    def format_result(result, arguments):
+        return f"Formatter: {arguments['problem']}の計算結果は{result['answer']}です。"
+
+    user_message = "次の問題を解いて: 1+1"
+    collected_text = []
+
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        if resp.text:
+            collected_text.append(resp.text)
+
+    full_text = "".join(collected_text)
+    assert "Formatter: 1+1の計算結果は2です。" in full_text, f"Direct response not found in text: {full_text}"
+
+    await service.openai_client.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_service_context_isolation():
+    """
+    Test that conversations with different context_ids are properly isolated
+    when called concurrently. This verifies that one user's conversation
+    does not leak into another's.
+    This test actually calls OpenAI Responses API, so it may cost tokens.
+    """
+    service = OpenAIResponsesService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="あなたは親切なアシスタントです。短く回答してください。",
+        model=MODEL,
+        temperature=0.0
+    )
+
+    context_a = f"test_isolation_a_{uuid4()}"
+    context_b = f"test_isolation_b_{uuid4()}"
+
+    # First round: give each context different information
+    async def setup_context(ctx_id, message):
+        async for _ in service.chat_stream(ctx_id, "test_user", message):
+            pass
+
+    await asyncio.gather(
+        setup_context(context_a, "私の名前は太郎です。覚えておいてください。"),
+        setup_context(context_b, "私の名前は花子です。覚えておいてください。"),
+    )
+
+    # Verify each context has its own response_id
+    assert context_a in service.response_ids
+    assert context_b in service.response_ids
+    assert service.response_ids[context_a] != service.response_ids[context_b], \
+        "Different contexts should have different response_ids."
+
+    # Second round: ask each context about the stored information concurrently
+    results = {}
+
+    async def ask_name(ctx_id):
+        texts = []
+        async for resp in service.chat_stream(ctx_id, "test_user", "私の名前は何ですか？"):
+            if resp.text:
+                texts.append(resp.text)
+        results[ctx_id] = "".join(texts)
+
+    await asyncio.gather(
+        ask_name(context_a),
+        ask_name(context_b),
+    )
+
+    assert "太郎" in results[context_a], f"Context A should remember '太郎'. Got: {results[context_a]}"
+    assert "花子" in results[context_b], f"Context B should remember '花子'. Got: {results[context_b]}"
+
+    # Cross-check: ensure no leakage
+    assert "花子" not in results[context_a], f"Context A should NOT contain '花子'. Got: {results[context_a]}"
+    assert "太郎" not in results[context_b], f"Context B should NOT contain '太郎'. Got: {results[context_b]}"
+
+    await service.openai_client.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_service_image():
+    """
+    Test OpenAIResponsesService with image input.
+    This test actually calls OpenAI Responses API, so it may cost tokens.
+    """
+    service = OpenAIResponsesService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt=SYSTEM_PROMPT,
+        model=MODEL,
+        temperature=0.5
+    )
+    context_id = f"test_image_context_{uuid4()}"
+
+    collected_text = []
+
+    async for resp in service.chat_stream(context_id, "test_user", "これは何ですか？漢字で答えてください。", files=[{"type": "image", "url": IMAGE_URL}]):
+        collected_text.append(resp.text)
+
+    full_text = "".join(collected_text)
+    assert len(full_text) > 0, "No text was returned from the LLM."
+    assert "寿司" in full_text, f"寿司 is not in text: {full_text}"
+
+    await service.openai_client.close()

--- a/tests/sts/llm/test_openai_responses_websocket.py
+++ b/tests/sts/llm/test_openai_responses_websocket.py
@@ -1,0 +1,362 @@
+import asyncio
+import json
+import os
+import pytest
+from typing import Any, Dict
+from uuid import uuid4
+from aiavatar.sts.llm.openai_responses_websocket import OpenAIResponsesWebSocketService
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+IMAGE_URL = os.getenv("IMAGE_URL")
+MODEL = "gpt-5.4-mini"
+
+SYSTEM_PROMPT = """
+## 基本設定
+
+あなたはユーザーの妹として、感情表現豊かに振る舞ってください。
+
+## 表情について
+
+あなたは以下のようなタグで表情を表現することができます。
+
+[face:Angry]はあ？何言ってるのか全然わからないんですけど。
+
+表情のバリエーションは以下の通りです。
+
+- Joy
+- Angry
+"""
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_ws_service_simple():
+    """
+    Test OpenAIResponsesWebSocketService with a basic prompt to check if it can stream responses.
+    This test actually calls OpenAI Responses API via WebSocket, so it may cost tokens.
+    """
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt=SYSTEM_PROMPT,
+        model=MODEL,
+        reasoning_effort="none",
+    )
+    context_id = f"test_ws_context_{uuid4()}"
+
+    user_message = "君が大切にしていたプリンは、私が勝手に食べておいた。"
+
+    collected_text = []
+    collected_voice = []
+
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        if resp.error_info:
+            pytest.fail(f"Error from WebSocket service: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+        if resp.voice_text:
+            collected_voice.append(resp.voice_text)
+
+    full_text = "".join(collected_text)
+    full_voice = "".join(collected_voice)
+    assert len(full_text) > 0, "No text was returned from the LLM."
+
+    # Check the response content
+    assert "[face:Angry]" in full_text, "Control tag doesn't appear in text."
+    assert "[face:Angry]" not in full_voice, "Control tag was not removed from voice_text."
+
+    # Check server-side context management (response_id should be stored)
+    assert context_id in service.response_ids, "response_id not stored for context."
+
+    # Check context marker was saved
+    histories = await service.context_manager.get_histories(context_id)
+    assert len(histories) > 0, "No context marker was saved."
+
+    await service._ws_pool.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_ws_service_context_continuity():
+    """
+    Test that the WebSocket service maintains conversation context across multiple calls
+    via previous_response_id (server-side history).
+    This test actually calls OpenAI Responses API via WebSocket, so it may cost tokens.
+    """
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="あなたは親切なアシスタントです。短く回答してください。",
+        model=MODEL,
+        reasoning_effort="none",
+    )
+    context_id = f"test_ws_continuity_{uuid4()}"
+
+    # First call: tell the model something specific
+    async for resp in service.chat_stream(context_id, "test_user", "私の好きな果物はマンゴーです。覚えておいてください。"):
+        if resp.error_info:
+            pytest.fail(f"Error in first call: {resp.error_info}")
+
+    first_response_id = service.response_ids.get(context_id)
+    assert first_response_id is not None, "response_id should be set after first call."
+
+    # Second call: ask about what was said before
+    collected_text = []
+    async for resp in service.chat_stream(context_id, "test_user", "私の好きな果物は何ですか？"):
+        if resp.error_info:
+            pytest.fail(f"Error in second call: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+
+    full_text = "".join(collected_text)
+    assert "マンゴー" in full_text, f"Context was not maintained. Response: {full_text}"
+
+    # response_id should have been updated
+    second_response_id = service.response_ids.get(context_id)
+    assert second_response_id != first_response_id, "response_id should be updated after second call."
+
+    await service._ws_pool.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_ws_service_tool_calls():
+    """
+    Test OpenAIResponsesWebSocketService with a registered tool.
+    This test actually calls OpenAI Responses API via WebSocket, so it may cost tokens.
+    """
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="You MUST always use the solve_math tool to solve any math problem. Never calculate manually.",
+        model=MODEL,
+        reasoning_effort="none",
+    )
+    context_id = f"test_ws_tool_context_{uuid4()}"
+
+    # Register tool using Chat Completions format (should be auto-converted)
+    tool_spec = {
+        "type": "function",
+        "function": {
+            "name": "solve_math",
+            "description": "Solve simple math problems",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "problem": {"type": "string"}
+                },
+                "required": ["problem"]
+            }
+        }
+    }
+
+    @service.tool(tool_spec)
+    async def solve_math(problem: str) -> Dict[str, Any]:
+        if problem.strip() == "1+1":
+            return {"answer": 2}
+        else:
+            return {"answer": "unknown"}
+
+    user_message = "次の問題を解いて: 1+1"
+    collected_text = []
+    tool_called = False
+
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        if resp.error_info:
+            pytest.fail(f"Error from WebSocket service: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+        if resp.tool_call:
+            tool_called = True
+
+    full_text = "".join(collected_text)
+    assert tool_called, "Tool was not called."
+    assert "2" in full_text, f"Answer '2' not found in response: {full_text}"
+
+    await service._ws_pool.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_ws_service_tool_calls_response_formatter():
+    """
+    Test OpenAIResponsesWebSocketService with a registered tool that has response_formatter.
+    The tool result should be formatted directly without a 2nd LLM call.
+    This test actually calls OpenAI Responses API via WebSocket, so it may cost tokens.
+    """
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="You MUST always use the solve_math tool to solve any math problem. Never calculate manually.",
+        model=MODEL,
+        reasoning_effort="none",
+    )
+    context_id = f"test_ws_tool_rf_context_{uuid4()}"
+
+    tool_spec = {
+        "type": "function",
+        "function": {
+            "name": "solve_math",
+            "description": "Solve simple math problems",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "problem": {"type": "string"}
+                },
+                "required": ["problem"]
+            }
+        }
+    }
+
+    @service.tool(tool_spec)
+    async def solve_math(problem: str) -> Dict[str, Any]:
+        if problem.strip() == "1+1":
+            return {"answer": 2}
+        else:
+            return {"answer": "unknown"}
+
+    @service.tools["solve_math"].response_formatter
+    def format_result(result, arguments):
+        return f"Formatter: {arguments['problem']}の計算結果は{result['answer']}です。"
+
+    user_message = "次の問題を解いて: 1+1"
+    collected_text = []
+
+    async for resp in service.chat_stream(context_id, "test_user", user_message):
+        if resp.error_info:
+            pytest.fail(f"Error from WebSocket service: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+
+    full_text = "".join(collected_text)
+    assert "Formatter: 1+1の計算結果は2です。" in full_text, f"Direct response not found in text: {full_text}"
+
+    await service._ws_pool.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_ws_service_context_isolation():
+    """
+    Test that conversations with different context_ids are properly isolated
+    when called concurrently over WebSocket. This verifies that one user's
+    conversation does not leak into another's — the bug that was found during development.
+    This test actually calls OpenAI Responses API via WebSocket, so it may cost tokens.
+    """
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="あなたは親切なアシスタントです。短く回答してください。",
+        model=MODEL,
+        reasoning_effort="none",
+    )
+
+    context_a = f"test_ws_isolation_a_{uuid4()}"
+    context_b = f"test_ws_isolation_b_{uuid4()}"
+
+    errors = []
+
+    # First round: give each context different information
+    async def setup_context(ctx_id, message):
+        async for resp in service.chat_stream(ctx_id, "test_user", message):
+            if resp.error_info:
+                errors.append(f"{ctx_id}: {resp.error_info}")
+
+    await asyncio.gather(
+        setup_context(context_a, "私の名前は太郎です。覚えておいてください。"),
+        setup_context(context_b, "私の名前は花子です。覚えておいてください。"),
+    )
+
+    assert not errors, f"Errors during setup: {errors}"
+
+    # Verify each context has its own response_id
+    assert context_a in service.response_ids, f"response_id not set for context_a. response_ids={service.response_ids}"
+    assert context_b in service.response_ids, f"response_id not set for context_b. response_ids={service.response_ids}"
+    assert service.response_ids[context_a] != service.response_ids[context_b], \
+        "Different contexts should have different response_ids."
+
+    # Second round: ask each context about the stored information concurrently
+    results = {}
+
+    async def ask_name(ctx_id):
+        texts = []
+        async for resp in service.chat_stream(ctx_id, "test_user", "私の名前は何ですか？"):
+            if resp.error_info:
+                errors.append(f"{ctx_id}: {resp.error_info}")
+            if resp.text:
+                texts.append(resp.text)
+        results[ctx_id] = "".join(texts)
+
+    await asyncio.gather(
+        ask_name(context_a),
+        ask_name(context_b),
+    )
+
+    assert not errors, f"Errors during ask: {errors}"
+
+    assert "太郎" in results[context_a], f"Context A should remember '太郎'. Got: {results[context_a]}"
+    assert "花子" in results[context_b], f"Context B should remember '花子'. Got: {results[context_b]}"
+
+    # Cross-check: ensure no leakage
+    assert "花子" not in results[context_a], f"Context A should NOT contain '花子'. Got: {results[context_a]}"
+    assert "太郎" not in results[context_b], f"Context B should NOT contain '太郎'. Got: {results[context_b]}"
+
+    await service._ws_pool.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_ws_service_image():
+    """
+    Test OpenAIResponsesWebSocketService with image input.
+    This test actually calls OpenAI Responses API via WebSocket, so it may cost tokens.
+    """
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt=SYSTEM_PROMPT,
+        model=MODEL,
+        reasoning_effort="none",
+    )
+    context_id = f"test_ws_image_context_{uuid4()}"
+
+    collected_text = []
+
+    async for resp in service.chat_stream(context_id, "test_user", "これは何ですか？漢字で答えてください。", files=[{"type": "image", "url": IMAGE_URL}]):
+        if resp.error_info:
+            pytest.fail(f"Error from WebSocket service: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+
+    full_text = "".join(collected_text)
+    assert len(full_text) > 0, "No text was returned from the LLM."
+    assert "寿司" in full_text, f"寿司 is not in text: {full_text}"
+
+    await service._ws_pool.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_ws_service_connection_pool_reuse():
+    """
+    Test that the WebSocket connection pool properly reuses connections.
+    After one request, the connection should be returned to the pool and
+    reused for the next request.
+    This test actually calls OpenAI Responses API via WebSocket, so it may cost tokens.
+    """
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="あなたは親切なアシスタントです。短く回答してください。",
+        model=MODEL,
+        reasoning_effort="none",
+    )
+
+    context_id = f"test_ws_pool_reuse_{uuid4()}"
+
+    # First call
+    async for resp in service.chat_stream(context_id, "test_user", "こんにちは"):
+        if resp.error_info:
+            pytest.fail(f"Error in first call: {resp.error_info}")
+
+    # After first call, pool should have one idle connection
+    assert not service._ws_pool._idle.empty(), "Pool should have an idle connection after first call."
+
+    # Second call should reuse the pooled connection
+    async for resp in service.chat_stream(context_id, "test_user", "元気ですか？"):
+        if resp.error_info:
+            pytest.fail(f"Error in second call: {resp.error_info}")
+
+    # Pool should still have an idle connection
+    assert not service._ws_pool._idle.empty(), "Pool should still have an idle connection after second call."
+
+    await service._ws_pool.close()
+
+    # After close, pool should be empty
+    assert service._ws_pool._idle.empty(), "Pool should be empty after close."


### PR DESCRIPTION
Enable server-side conversation management via OpenAI's Responses API, eliminating client-side history tracking overhead. The WebSocket mode provides persistent connection pooling for lower latency in tool-call-heavy workflows.