### PR TITLE
Add cross-channel context sharing via user_id-to-context_id mapping

### DIFF
--- a/aiavatar/sts/llm/context_manager/base.py
+++ b/aiavatar/sts/llm/context_manager/base.py
@@ -3,12 +3,15 @@ import json
 import logging
 from datetime import datetime, timezone, timedelta
 from abc import ABC, abstractmethod
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Optional, Callable, Awaitable
 
 logger = logging.getLogger(__name__)
 
 
 class ContextManager(ABC):
+    def __init__(self):
+        self._on_merge_context: Optional[Callable[[str, str, "ContextManager"], Awaitable[None]]] = None
+
     @abstractmethod
     async def get_histories(self, context_id: Union[str, List[str]], limit: int = 100) -> List[Dict]:
         pass
@@ -21,9 +24,31 @@ class ContextManager(ABC):
     async def get_last_created_at(self, context_id: str) -> datetime:
         pass
 
+    @abstractmethod
+    async def get_context_id_by_user_id(self, user_id: str) -> Optional[str]:
+        pass
+
+    @abstractmethod
+    async def set_context_id_for_user_id(self, user_id: str, context_id: str):
+        pass
+
+    async def merge_context(self, from_context_id: str, to_context_id: str):
+        if self._on_merge_context:
+            await self._on_merge_context(from_context_id, to_context_id, self)
+        await self._merge_context(from_context_id, to_context_id)
+
+    @abstractmethod
+    async def _merge_context(self, from_context_id: str, to_context_id: str):
+        pass
+
+    def on_merge_context(self, func: Callable[[str, str, "ContextManager"], Awaitable[None]]):
+        self._on_merge_context = func
+        return func
+
 
 class SQLiteContextManager(ContextManager):
     def __init__(self, db_path="aiavatar.db", context_timeout=3600):
+        super().__init__()
         self.db_path = db_path
         self.context_timeout = context_timeout
         self.init_db()
@@ -51,6 +76,17 @@ class SQLiteContextManager(ContextManager):
                     """
                     CREATE INDEX IF NOT EXISTS idx_chat_histories_context_id_created_at
                     ON chat_histories (context_id, created_at)
+                    """
+                )
+
+                # Create user_contexts table for user_id -> context_id mapping
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS user_contexts (
+                        user_id TEXT PRIMARY KEY,
+                        context_id TEXT NOT NULL,
+                        updated_at TIMESTAMP NOT NULL
+                    )
                     """
                 )
 
@@ -168,6 +204,67 @@ class SQLiteContextManager(ContextManager):
         except Exception as ex:
             logger.exception(f"Error at get_last_created_at: {ex}")
             return datetime.min.replace(tzinfo=timezone.utc)
+
+        finally:
+            conn.close()
+
+    async def get_context_id_by_user_id(self, user_id: str) -> Optional[str]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT context_id FROM user_contexts WHERE user_id = ?",
+                (user_id,)
+            )
+            row = cursor.fetchone()
+            return row[0] if row else None
+
+        except Exception as ex:
+            logger.exception(f"Error at get_context_id_by_user_id: {ex}")
+            return None
+
+        finally:
+            conn.close()
+
+    async def set_context_id_for_user_id(self, user_id: str, context_id: str):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            now_utc = datetime.now(timezone.utc)
+            conn.execute(
+                """
+                INSERT INTO user_contexts (user_id, context_id, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(user_id) DO UPDATE SET
+                    context_id = excluded.context_id,
+                    updated_at = excluded.updated_at
+                """,
+                (user_id, context_id, now_utc)
+            )
+            conn.commit()
+
+        except Exception as ex:
+            logger.exception(f"Error at set_context_id_for_user_id: {ex}")
+            conn.rollback()
+
+        finally:
+            conn.close()
+
+    async def _merge_context(self, from_context_id: str, to_context_id: str):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute(
+                "UPDATE chat_histories SET context_id = ? WHERE context_id = ?",
+                (to_context_id, from_context_id)
+            )
+            conn.execute(
+                "UPDATE user_contexts SET context_id = ? WHERE context_id = ?",
+                (to_context_id, from_context_id)
+            )
+            conn.commit()
+
+        except Exception as ex:
+            logger.exception(f"Error at _merge_context: {ex}")
+            conn.rollback()
 
         finally:
             conn.close()

--- a/aiavatar/sts/llm/context_manager/postgres.py
+++ b/aiavatar/sts/llm/context_manager/postgres.py
@@ -2,7 +2,7 @@ import asyncio
 from datetime import datetime, timezone, timedelta
 import json
 import logging
-from typing import List, Dict, Union, Callable, Awaitable
+from typing import List, Dict, Optional, Union, Callable, Awaitable
 import asyncpg
 from ..base import ContextManager
 
@@ -24,6 +24,7 @@ class PostgreSQLContextManager(ContextManager):
         db_pool_min_size: int = 1,
         db_pool_max_size: int = 5
     ):
+        super().__init__()
         self._get_pool_func = get_pool
         self.host = host
         self.port = port
@@ -98,6 +99,17 @@ class PostgreSQLContextManager(ContextManager):
                     """
                     CREATE INDEX IF NOT EXISTS idx_chat_histories_context_id_created_at
                     ON chat_histories (context_id, created_at)
+                    """
+                )
+
+                # Create user_contexts table for user_id -> context_id mapping
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS user_contexts (
+                        user_id TEXT PRIMARY KEY,
+                        context_id TEXT NOT NULL,
+                        updated_at TIMESTAMP NOT NULL
+                    )
                     """
                 )
             except Exception as ex:
@@ -212,3 +224,53 @@ class PostgreSQLContextManager(ContextManager):
             except Exception as ex:
                 logger.exception(f"Error at get_last_created_at: {ex}")
                 return datetime.min.replace(tzinfo=timezone.utc)
+
+    async def get_context_id_by_user_id(self, user_id: str) -> Optional[str]:
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                row = await conn.fetchrow(
+                    "SELECT context_id FROM user_contexts WHERE user_id = $1",
+                    user_id
+                )
+                return row["context_id"] if row else None
+
+            except Exception as ex:
+                logger.exception(f"Error at get_context_id_by_user_id: {ex}")
+                return None
+
+    async def set_context_id_for_user_id(self, user_id: str, context_id: str):
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+                await conn.execute(
+                    """
+                    INSERT INTO user_contexts (user_id, context_id, updated_at)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT(user_id) DO UPDATE SET
+                        context_id = EXCLUDED.context_id,
+                        updated_at = EXCLUDED.updated_at
+                    """,
+                    user_id, context_id, now_utc
+                )
+
+            except Exception as ex:
+                logger.exception(f"Error at set_context_id_for_user_id: {ex}")
+
+    async def _merge_context(self, from_context_id: str, to_context_id: str):
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                async with conn.transaction():
+                    await conn.execute(
+                        "UPDATE chat_histories SET context_id = $1 WHERE context_id = $2",
+                        to_context_id, from_context_id
+                    )
+                    await conn.execute(
+                        "UPDATE user_contexts SET context_id = $1 WHERE context_id = $2",
+                        to_context_id, from_context_id
+                    )
+
+            except Exception as ex:
+                logger.exception(f"Error at _merge_context: {ex}")

--- a/tests/sts/llm/context_manager/test_context_manager.py
+++ b/tests/sts/llm/context_manager/test_context_manager.py
@@ -114,3 +114,72 @@ async def test_get_histories_timeout(context_manager):
     histories = await context_manager.get_histories(context_id)
     assert len(histories) == 1
     assert histories[0]["message"] == "New data"
+
+
+@pytest.mark.asyncio
+async def test_get_context_id_by_user_id_not_found(context_manager):
+    result = await context_manager.get_context_id_by_user_id("unknown_user")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_context_id_by_user_id(context_manager):
+    await context_manager.set_context_id_for_user_id("user_1", "ctx_aaa")
+    result = await context_manager.get_context_id_by_user_id("user_1")
+    assert result == "ctx_aaa"
+
+
+@pytest.mark.asyncio
+async def test_set_context_id_for_user_id_update(context_manager):
+    await context_manager.set_context_id_for_user_id("user_1", "ctx_aaa")
+    await context_manager.set_context_id_for_user_id("user_1", "ctx_bbb")
+    result = await context_manager.get_context_id_by_user_id("user_1")
+    assert result == "ctx_bbb"
+
+
+@pytest.mark.asyncio
+async def test_merge_context(context_manager):
+    await context_manager.add_histories("ctx_from", [{"message": "Hello from phone"}])
+    await context_manager.add_histories("ctx_to", [{"message": "Hello from web"}])
+    await context_manager.set_context_id_for_user_id("user_phone", "ctx_from")
+    await context_manager.set_context_id_for_user_id("user_web", "ctx_to")
+
+    await context_manager.merge_context("ctx_from", "ctx_to")
+
+    # All histories merged into ctx_to
+    histories = await context_manager.get_histories("ctx_to")
+    assert len(histories) == 2
+
+    # ctx_from has no histories left
+    histories_from = await context_manager.get_histories("ctx_from")
+    assert len(histories_from) == 0
+
+    # user_phone now points to ctx_to
+    assert await context_manager.get_context_id_by_user_id("user_phone") == "ctx_to"
+    assert await context_manager.get_context_id_by_user_id("user_web") == "ctx_to"
+
+
+@pytest.mark.asyncio
+async def test_merge_context_with_hook(context_manager):
+    hook_called = {}
+
+    @context_manager.on_merge_context
+    async def my_hook(from_id, to_id, cm):
+        hook_called["from"] = from_id
+        hook_called["to"] = to_id
+        # Can read histories before merge
+        hook_called["histories"] = await cm.get_histories(from_id)
+
+    await context_manager.add_histories("ctx_src", [{"message": "Source message"}])
+    await context_manager.add_histories("ctx_dst", [{"message": "Dest message"}])
+
+    await context_manager.merge_context("ctx_src", "ctx_dst")
+
+    assert hook_called["from"] == "ctx_src"
+    assert hook_called["to"] == "ctx_dst"
+    assert len(hook_called["histories"]) == 1
+    assert hook_called["histories"][0]["message"] == "Source message"
+
+    # After merge, all in ctx_dst
+    histories = await context_manager.get_histories("ctx_dst")
+    assert len(histories) == 2


### PR DESCRIPTION
- Resolve and persist context_id by user_id to maintain conversation across channels
- Merge conversation histories between contexts with customizable `on_merge_context` hook