### PR TITLE
Add ChannelSessionManager for per-user context persistence and cross-channel context sharing

### DIFF
--- a/aiavatar/adapter/session_manager/__init__.py
+++ b/aiavatar/adapter/session_manager/__init__.py
@@ -1,0 +1,1 @@
+from .base import ChannelSession, ChannelSessionManager, SQLiteChannelSessionManager

--- a/aiavatar/adapter/session_manager/base.py
+++ b/aiavatar/adapter/session_manager/base.py
@@ -1,0 +1,179 @@
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+import logging
+import json
+import sqlite3
+from typing import Dict, Optional
+from uuid import uuid4
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelSession(BaseModel):
+    channel_id: str
+    channel_user_id: str
+    session_id: str = Field(default_factory=lambda: f"ch_sess_{uuid4()}")
+    user_id: str = ""
+    context_id: Optional[str] = None
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    data: Dict = Field(default_factory=dict)
+
+
+class ChannelSessionManager(ABC):
+    @abstractmethod
+    async def get_session(self, channel_id: str, channel_user_id: str) -> ChannelSession:
+        pass
+
+    @abstractmethod
+    async def upsert_session(self, session: ChannelSession):
+        pass
+
+    @abstractmethod
+    async def update_context_id(self, channel_id: str, channel_user_id: str, context_id: str):
+        pass
+
+    @abstractmethod
+    async def delete_session(self, channel_id: str, channel_user_id: str):
+        pass
+
+
+class SQLiteChannelSessionManager(ChannelSessionManager):
+    def __init__(self, db_path: str = "channel_sessions.db", timeout: float = 3600):
+        self.db_path = db_path
+        self.timeout = timeout
+        self.init_db()
+
+    def init_db(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS channel_sessions (
+                        channel_id TEXT NOT NULL,
+                        channel_user_id TEXT NOT NULL,
+                        session_id TEXT NOT NULL,
+                        user_id TEXT NOT NULL,
+                        context_id TEXT,
+                        updated_at TEXT NOT NULL,
+                        data TEXT,
+                        PRIMARY KEY (channel_id, channel_user_id)
+                    )
+                    """
+                )
+        except:
+            logger.exception("Error at init_db.")
+            raise
+        finally:
+            conn.close()
+
+    async def get_session(self, channel_id: str, channel_user_id: str) -> ChannelSession:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.execute(
+                """
+                SELECT channel_id, channel_user_id, session_id, user_id, context_id, updated_at, data
+                FROM channel_sessions
+                WHERE channel_id = ? AND channel_user_id = ?
+                """,
+                (channel_id, channel_user_id)
+            )
+            row = cursor.fetchone()
+            if row:
+                updated_at = datetime.fromisoformat(row[5])
+                if (datetime.now(timezone.utc) - updated_at).total_seconds() <= self.timeout:
+                    return ChannelSession(
+                        channel_id=row[0],
+                        channel_user_id=row[1],
+                        session_id=row[2],
+                        user_id=row[3],
+                        context_id=row[4],
+                        updated_at=updated_at,
+                        data=json.loads(row[6]) if row[6] else {},
+                    )
+
+            # Create new session when not found or expired
+            session = ChannelSession(
+                channel_id=channel_id,
+                channel_user_id=channel_user_id,
+                user_id=channel_user_id,
+            )
+            await self.upsert_session(session)
+            return session
+
+        except Exception as ex:
+            logger.error(f"Error at get_session: {ex}")
+            raise
+
+        finally:
+            conn.close()
+
+    async def upsert_session(self, session: ChannelSession):
+        session.updated_at = session.updated_at or datetime.now(timezone.utc)
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO channel_sessions (channel_id, channel_user_id, session_id, user_id, context_id, updated_at, data)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(channel_id, channel_user_id) DO UPDATE SET
+                        session_id = excluded.session_id,
+                        user_id = excluded.user_id,
+                        context_id = excluded.context_id,
+                        updated_at = excluded.updated_at,
+                        data = excluded.data
+                    """,
+                    (
+                        session.channel_id,
+                        session.channel_user_id,
+                        session.session_id,
+                        session.user_id,
+                        session.context_id,
+                        session.updated_at.isoformat(),
+                        json.dumps(session.data) if session.data else None,
+                    )
+                )
+
+        except:
+            logger.exception("Error at upsert_session.")
+            raise
+
+        finally:
+            conn.close()
+
+    async def update_context_id(self, channel_id: str, channel_user_id: str, context_id: str):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    UPDATE channel_sessions
+                    SET context_id = ?, updated_at = ?
+                    WHERE channel_id = ? AND channel_user_id = ?
+                    """,
+                    (context_id, datetime.now(timezone.utc).isoformat(), channel_id, channel_user_id)
+                )
+        except:
+            logger.exception("Error at update_context_id.")
+            raise
+        finally:
+            conn.close()
+
+    async def delete_session(self, channel_id: str, channel_user_id: str):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    "DELETE FROM channel_sessions WHERE channel_id = ? AND channel_user_id = ?",
+                    (channel_id, channel_user_id)
+                )
+
+        except:
+            logger.exception("Error at delete_session.")
+            raise
+
+        finally:
+            conn.close()

--- a/aiavatar/adapter/session_manager/postgres.py
+++ b/aiavatar/adapter/session_manager/postgres.py
@@ -1,0 +1,204 @@
+import asyncio
+from datetime import datetime, timezone
+import logging
+import json
+from typing import Dict, Callable, Awaitable
+import asyncpg
+from .base import ChannelSession, ChannelSessionManager
+
+logger = logging.getLogger(__name__)
+
+
+class PostgreSQLChannelSessionManager(ChannelSessionManager):
+    def __init__(
+        self,
+        *,
+        get_pool: Callable[[], Awaitable[asyncpg.Pool]] = None,
+        host: str = "localhost",
+        port: int = 5432,
+        dbname: str = "aiavatar",
+        user: str = "postgres",
+        password: str = None,
+        connection_str: str = None,
+        timeout: float = 3600,
+        db_pool_min_size: int = 1,
+        db_pool_max_size: int = 5
+    ):
+        self._get_pool_func = get_pool
+        self.host = host
+        self.port = port
+        self.dbname = dbname
+        self.user = user
+        self.password = password
+        self.connection_str = connection_str
+        self.timeout = timeout
+        self.db_pool_min_size = db_pool_min_size
+        self.db_pool_max_size = db_pool_max_size
+        self._pool: asyncpg.Pool = None
+        self._pool_lock = asyncio.Lock()
+        self._db_initialized = False
+
+    async def get_pool(self) -> asyncpg.Pool:
+        # Use shared pool if provided
+        if self._get_pool_func is not None:
+            pool = await self._get_pool_func()
+            if not self._db_initialized:
+                async with self._pool_lock:
+                    if not self._db_initialized:
+                        await self.init_db(pool)
+                        self._db_initialized = True
+            return pool
+
+        # Otherwise, create own pool (backward compatible)
+        if self._pool is not None:
+            return self._pool
+
+        async with self._pool_lock:
+            if self._pool is not None:
+                return self._pool
+
+            if self.connection_str:
+                self._pool = await asyncpg.create_pool(
+                    dsn=self.connection_str,
+                    min_size=self.db_pool_min_size,
+                    max_size=self.db_pool_max_size,
+                )
+            else:
+                self._pool = await asyncpg.create_pool(
+                    host=self.host,
+                    port=self.port,
+                    database=self.dbname,
+                    user=self.user,
+                    password=self.password,
+                    min_size=self.db_pool_min_size,
+                    max_size=self.db_pool_max_size,
+                )
+            await self.init_db(self._pool)
+            self._db_initialized = True
+
+        return self._pool
+
+    async def init_db(self, pool: asyncpg.Pool):
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS channel_sessions (
+                        channel_id TEXT NOT NULL,
+                        channel_user_id TEXT NOT NULL,
+                        session_id TEXT NOT NULL,
+                        user_id TEXT NOT NULL,
+                        context_id TEXT,
+                        updated_at TIMESTAMP NOT NULL,
+                        data JSON,
+                        PRIMARY KEY (channel_id, channel_user_id)
+                    )
+                    """
+                )
+            except Exception as ex:
+                logger.error(f"Error at init_db: {ex}")
+                raise
+
+    async def get_session(self, channel_id: str, channel_user_id: str) -> ChannelSession:
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                row = await conn.fetchrow(
+                    """
+                    SELECT channel_id, channel_user_id, session_id, user_id, context_id, updated_at, data
+                    FROM channel_sessions
+                    WHERE channel_id = $1 AND channel_user_id = $2
+                    """,
+                    channel_id, channel_user_id
+                )
+
+                if row:
+                    updated_at = row["updated_at"] or datetime.min.replace(tzinfo=timezone.utc)
+                    if updated_at.tzinfo is None:
+                        updated_at = updated_at.replace(tzinfo=timezone.utc)
+                    data: Dict = row["data"] or {}
+                    if isinstance(data, str):
+                        data = json.loads(data)
+                    if (datetime.now(timezone.utc) - updated_at).total_seconds() <= self.timeout:
+                        return ChannelSession(
+                            channel_id=row["channel_id"],
+                            channel_user_id=row["channel_user_id"],
+                            session_id=row["session_id"],
+                            user_id=row["user_id"],
+                            context_id=row["context_id"],
+                            updated_at=updated_at,
+                            data=data,
+                        )
+
+                session = ChannelSession(
+                    channel_id=channel_id,
+                    channel_user_id=channel_user_id,
+                    user_id=channel_user_id,
+                )
+                await self.upsert_session(session)
+                return session
+
+            except Exception as ex:
+                logger.error(f"Error at get_session: {ex}")
+                raise
+
+    async def upsert_session(self, session: ChannelSession):
+        session.updated_at = session.updated_at or datetime.now(timezone.utc)
+        updated_at_naive = session.updated_at.replace(tzinfo=None) if session.updated_at.tzinfo else session.updated_at
+
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                data_json = json.dumps(session.data, ensure_ascii=False) if session.data else None
+                await conn.execute(
+                    """
+                    INSERT INTO channel_sessions (channel_id, channel_user_id, session_id, user_id, context_id, updated_at, data)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    ON CONFLICT(channel_id, channel_user_id) DO UPDATE SET
+                        session_id = EXCLUDED.session_id,
+                        user_id = EXCLUDED.user_id,
+                        context_id = EXCLUDED.context_id,
+                        updated_at = EXCLUDED.updated_at,
+                        data = EXCLUDED.data
+                    """,
+                    session.channel_id,
+                    session.channel_user_id,
+                    session.session_id,
+                    session.user_id,
+                    session.context_id,
+                    updated_at_naive,
+                    data_json,
+                )
+
+            except Exception as ex:
+                logger.error(f"Error at upsert_session: {ex}")
+                raise
+
+    async def update_context_id(self, channel_id: str, channel_user_id: str, context_id: str):
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    """
+                    UPDATE channel_sessions
+                    SET context_id = $1, updated_at = $2
+                    WHERE channel_id = $3 AND channel_user_id = $4
+                    """,
+                    context_id, datetime.now(timezone.utc).replace(tzinfo=None), channel_id, channel_user_id
+                )
+            except Exception as ex:
+                logger.error(f"Error at update_context_id: {ex}")
+                raise
+
+    async def delete_session(self, channel_id: str, channel_user_id: str):
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    "DELETE FROM channel_sessions WHERE channel_id = $1 AND channel_user_id = $2",
+                    channel_id, channel_user_id
+                )
+
+            except Exception as ex:
+                logger.error(f"Error at delete_session: {ex}")
+                raise

--- a/tests/adapter/session_manager/test_pg_session_manager.py
+++ b/tests/adapter/session_manager/test_pg_session_manager.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+import os
+
+import pytest
+
+from aiavatar.adapter.session_manager.postgres import PostgreSQLChannelSessionManager, ChannelSession
+
+AIAVATAR_DB_HOST = os.getenv("AIAVATAR_DB_HOST", "localhost")
+AIAVATAR_DB_PORT = int(os.getenv("AIAVATAR_DB_PORT", 5432))
+AIAVATAR_DB_NAME = os.getenv("AIAVATAR_DB_NAME", "aiavatar")
+AIAVATAR_DB_USER = os.getenv("AIAVATAR_DB_USER", "postgres")
+AIAVATAR_DB_PASSWORD = os.getenv("AIAVATAR_DB_PASSWORD")
+
+pytestmark = pytest.mark.skipif(
+    not AIAVATAR_DB_PASSWORD,
+    reason="PostgreSQL credentials not configured",
+)
+
+
+@pytest.fixture
+def session_manager() -> PostgreSQLChannelSessionManager:
+    return PostgreSQLChannelSessionManager(
+        host=AIAVATAR_DB_HOST,
+        port=AIAVATAR_DB_PORT,
+        dbname=AIAVATAR_DB_NAME,
+        user=AIAVATAR_DB_USER,
+        password=AIAVATAR_DB_PASSWORD,
+        timeout=1,
+    )
+
+
+@pytest.fixture
+def unique_user():
+    return f"user_{uuid4()}"
+
+
+@pytest.mark.asyncio
+async def test_get_session_creates_new(session_manager, unique_user):
+    session = await session_manager.get_session("line", unique_user)
+    assert session.channel_id == "line"
+    assert session.channel_user_id == unique_user
+    assert session.user_id == unique_user
+    assert session.session_id.startswith("ch_sess_")
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get(session_manager, unique_user):
+    session = ChannelSession(
+        channel_id="twilio",
+        channel_user_id=unique_user,
+        session_id=f"ch_sess_{uuid4()}",
+        user_id="app_user",
+        context_id="ctx_pg",
+        data={"hello": "world"},
+    )
+    await session_manager.upsert_session(session)
+
+    loaded = await session_manager.get_session("twilio", unique_user)
+    assert loaded.session_id == session.session_id
+    assert loaded.user_id == "app_user"
+    assert loaded.context_id == "ctx_pg"
+    assert loaded.data == {"hello": "world"}
+
+
+@pytest.mark.asyncio
+async def test_timeout_creates_new(session_manager, unique_user):
+    session = await session_manager.get_session("websocket", unique_user)
+    session.updated_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+    await session_manager.upsert_session(session)
+
+    refreshed = await session_manager.get_session("websocket", unique_user)
+    assert refreshed.session_id != session.session_id
+    assert refreshed.updated_at > session.updated_at
+
+
+@pytest.mark.asyncio
+async def test_update_context_id(session_manager, unique_user):
+    session = await session_manager.get_session("line", unique_user)
+    assert session.context_id is None
+
+    await session_manager.update_context_id("line", unique_user, "ctx_new")
+
+    loaded = await session_manager.get_session("line", unique_user)
+    assert loaded.context_id == "ctx_new"
+    assert loaded.session_id == session.session_id
+    assert loaded.updated_at >= session.updated_at
+
+
+@pytest.mark.asyncio
+async def test_delete_session(session_manager, unique_user):
+    await session_manager.get_session("line", unique_user)
+    await session_manager.delete_session("line", unique_user)
+
+    new_session = await session_manager.get_session("line", unique_user)
+    assert new_session.channel_user_id == unique_user
+    assert new_session.session_id.startswith("ch_sess_")

--- a/tests/adapter/session_manager/test_session_manager.py
+++ b/tests/adapter/session_manager/test_session_manager.py
@@ -1,0 +1,101 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from aiavatar.adapter.session_manager.base import (
+    ChannelSession,
+    SQLiteChannelSessionManager,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    return tmp_path / "channel_sessions.db"
+
+
+@pytest.fixture
+def session_manager(db_path) -> SQLiteChannelSessionManager:
+    return SQLiteChannelSessionManager(db_path=str(db_path), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_get_session_creates_new(session_manager):
+    user_id = f"user_{uuid4()}"
+    session = await session_manager.get_session("line", user_id)
+    assert session.channel_id == "line"
+    assert session.channel_user_id == user_id
+    assert session.user_id == user_id
+    assert session.session_id.startswith("ch_sess_")
+    assert session.data == {}
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get(session_manager):
+    user_id = f"user_{uuid4()}"
+    session = ChannelSession(
+        channel_id="twilio",
+        channel_user_id=user_id,
+        session_id=f"ch_sess_{uuid4()}",
+        user_id="app_user",
+        context_id="ctx_123",
+        data={"foo": "bar"},
+    )
+    await session_manager.upsert_session(session)
+
+    loaded = await session_manager.get_session("twilio", user_id)
+    assert loaded.session_id == session.session_id
+    assert loaded.user_id == "app_user"
+    assert loaded.context_id == "ctx_123"
+    assert loaded.data == {"foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_timeout_creates_new(session_manager):
+    user_id = f"user_{uuid4()}"
+    session = await session_manager.get_session("websocket", user_id)
+    session.updated_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+    await session_manager.upsert_session(session)
+
+    refreshed = await session_manager.get_session("websocket", user_id)
+    assert refreshed.session_id != session.session_id
+    assert refreshed.updated_at > session.updated_at
+    assert refreshed.user_id == user_id
+
+
+@pytest.mark.asyncio
+async def test_delete_session(session_manager):
+    user_id = f"user_{uuid4()}"
+    await session_manager.get_session("line", user_id)
+    await session_manager.delete_session("line", user_id)
+
+    new_session = await session_manager.get_session("line", user_id)
+    assert new_session.channel_user_id == user_id
+    assert new_session.session_id.startswith("ch_sess_")
+
+
+@pytest.mark.asyncio
+async def test_update_context_id(session_manager):
+    user_id = f"user_{uuid4()}"
+    session = await session_manager.get_session("line", user_id)
+    assert session.context_id is None
+
+    await session_manager.update_context_id("line", user_id, "ctx_new")
+
+    loaded = await session_manager.get_session("line", user_id)
+    assert loaded.context_id == "ctx_new"
+    assert loaded.session_id == session.session_id
+    assert loaded.updated_at >= session.updated_at
+
+
+@pytest.mark.asyncio
+async def test_different_channels_same_user(session_manager):
+    """Same channel_user_id on different channels should be independent sessions."""
+    user_id = f"user_{uuid4()}"
+    line_session = await session_manager.get_session("line", user_id)
+    twilio_session = await session_manager.get_session("twilio", user_id)
+
+    assert line_session.session_id != twilio_session.session_id
+    assert line_session.channel_id == "line"
+    assert twilio_session.channel_id == "twilio"


### PR DESCRIPTION
Maintain conversation context per user within a channel and share context across channels (e.g. WebSocket, Twilio, LINE) via unified session management with composite key (channel_id, channel_user_id).