### PR TITLE
Add ChannelContextBridge for per-user context persistence

### DIFF
--- a/aiavatar/adapter/channel_context_bridge/__init__.py
+++ b/aiavatar/adapter/channel_context_bridge/__init__.py
@@ -1,0 +1,1 @@
+from .base import ChannelUser, UserContext, ChannelContextBridge, SQLiteChannelContextBridge

--- a/aiavatar/adapter/channel_context_bridge/base.py
+++ b/aiavatar/adapter/channel_context_bridge/base.py
@@ -1,0 +1,293 @@
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+import logging
+import json
+import sqlite3
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelUser(BaseModel):
+    channel_id: str
+    channel_user_id: str
+    user_id: str = ""
+    data: Dict = Field(default_factory=dict)
+
+
+class UserContext(BaseModel):
+    user_id: str
+    context_id: Optional[str] = None
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class ChannelContextBridge(ABC):
+    # Channel User operations
+
+    @abstractmethod
+    async def get_channel_user(self, channel_id: str, channel_user_id: str, auto_create: bool = False) -> Optional[ChannelUser]:
+        pass
+
+    @abstractmethod
+    async def upsert_channel_user(self, channel_user: ChannelUser):
+        pass
+
+    @abstractmethod
+    async def delete_channel_user(self, channel_id: str, channel_user_id: str):
+        pass
+
+    @abstractmethod
+    async def find_channel_users(self, user_id: str) -> List[ChannelUser]:
+        pass
+
+    # User Context operations
+
+    @abstractmethod
+    async def get_context(self, user_id: str) -> Optional[UserContext]:
+        pass
+
+    @abstractmethod
+    async def upsert_context(self, context: UserContext):
+        pass
+
+    # Composite operations
+    async def link_channel_user(self, channel_id: str, channel_user_id: str, user_id: str) -> Optional[UserContext]:
+        """Link a channel user to an app user and return their context."""
+        cu = await self.get_channel_user(channel_id, channel_user_id, auto_create=True)
+        cu.user_id = user_id
+        await self.upsert_channel_user(cu)
+        return await self.get_context(user_id)
+
+    # Hook registration
+    def bind(self, adapter, channel_id: str, auto_create_channel_user: bool = True):
+        """Register on_session_start and on_response hooks to sync context_id
+        between the adapter and user_contexts automatically."""
+
+        @adapter.on_session_start
+        async def on_session_start(request, session_data):
+            if not request.user_id:
+                return
+
+            # Resolve channel_user_id → user_id
+            channel_user = await self.get_channel_user(
+                channel_id, request.user_id,
+                auto_create=auto_create_channel_user
+            )
+            if channel_user and channel_user.user_id != request.user_id:
+                request.user_id = channel_user.user_id
+
+            # Get context_id for user
+
+            ctx = await self.get_context(request.user_id)
+            if ctx and ctx.context_id:
+                request.context_id = ctx.context_id
+
+        @adapter.on_response
+        async def on_response(response, _):
+            if response.type == "start" and response.user_id and response.context_id:
+                await self.upsert_context(UserContext(
+                    user_id=response.user_id,
+                    context_id=response.context_id,
+                ))
+
+
+class SQLiteChannelContextBridge(ChannelContextBridge):
+    def __init__(self, db_path: str = "channel_context_bridge.db", timeout: float = 3600):
+        self.db_path = db_path
+        self.timeout = timeout
+        self.init_db()
+
+    def init_db(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS channel_users (
+                        channel_id TEXT NOT NULL,
+                        channel_user_id TEXT NOT NULL,
+                        user_id TEXT NOT NULL,
+                        data TEXT,
+                        PRIMARY KEY (channel_id, channel_user_id)
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_channel_users_user_id
+                    ON channel_users (user_id)
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS user_contexts (
+                        user_id TEXT NOT NULL PRIMARY KEY,
+                        context_id TEXT,
+                        updated_at TEXT NOT NULL
+                    )
+                    """
+                )
+        except:
+            logger.exception("Error at init_db.")
+            raise
+        finally:
+            conn.close()
+
+    # Channel User operations
+    async def get_channel_user(self, channel_id: str, channel_user_id: str, auto_create: bool = False) -> Optional[ChannelUser]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.execute(
+                """
+                SELECT channel_id, channel_user_id, user_id, data
+                FROM channel_users
+                WHERE channel_id = ? AND channel_user_id = ?
+                """,
+                (channel_id, channel_user_id)
+            )
+            row = cursor.fetchone()
+            if row:
+                return ChannelUser(
+                    channel_id=row[0],
+                    channel_user_id=row[1],
+                    user_id=row[2],
+                    data=json.loads(row[3]) if row[3] else {},
+                )
+
+            if auto_create:
+                channel_user = ChannelUser(
+                    channel_id=channel_id,
+                    channel_user_id=channel_user_id,
+                    user_id=channel_user_id,
+                )
+                await self.upsert_channel_user(channel_user)
+                return channel_user
+
+            return None
+
+        except Exception as ex:
+            logger.error(f"Error at get_channel_user: {ex}")
+            raise
+        finally:
+            conn.close()
+
+    async def upsert_channel_user(self, channel_user: ChannelUser):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO channel_users (channel_id, channel_user_id, user_id, data)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(channel_id, channel_user_id) DO UPDATE SET
+                        user_id = excluded.user_id,
+                        data = excluded.data
+                    """,
+                    (
+                        channel_user.channel_id,
+                        channel_user.channel_user_id,
+                        channel_user.user_id,
+                        json.dumps(channel_user.data) if channel_user.data else None,
+                    )
+                )
+        except:
+            logger.exception("Error at upsert_channel_user.")
+            raise
+        finally:
+            conn.close()
+
+    async def delete_channel_user(self, channel_id: str, channel_user_id: str):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    "DELETE FROM channel_users WHERE channel_id = ? AND channel_user_id = ?",
+                    (channel_id, channel_user_id)
+                )
+        except:
+            logger.exception("Error at delete_channel_user.")
+            raise
+        finally:
+            conn.close()
+
+    async def find_channel_users(self, user_id: str) -> List[ChannelUser]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.execute(
+                """
+                SELECT channel_id, channel_user_id, user_id, data
+                FROM channel_users
+                WHERE user_id = ?
+                """,
+                (user_id,)
+            )
+            return [
+                ChannelUser(
+                    channel_id=row[0],
+                    channel_user_id=row[1],
+                    user_id=row[2],
+                    data=json.loads(row[3]) if row[3] else {},
+                )
+                for row in cursor.fetchall()
+            ]
+        except Exception as ex:
+            logger.error(f"Error at find_channel_users: {ex}")
+            raise
+        finally:
+            conn.close()
+
+    # User Context operations
+    async def get_context(self, user_id: str) -> Optional[UserContext]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.execute(
+                """
+                SELECT user_id, context_id, updated_at
+                FROM user_contexts
+                WHERE user_id = ?
+                """,
+                (user_id,)
+            )
+            row = cursor.fetchone()
+            if row:
+                updated_at = datetime.fromisoformat(row[2])
+                if (datetime.now(timezone.utc) - updated_at).total_seconds() <= self.timeout:
+                    return UserContext(
+                        user_id=row[0],
+                        context_id=row[1],
+                        updated_at=updated_at,
+                    )
+            return None
+
+        except Exception as ex:
+            logger.error(f"Error at get_context: {ex}")
+            raise
+        finally:
+            conn.close()
+
+    async def upsert_context(self, context: UserContext):
+        context.updated_at = context.updated_at or datetime.now(timezone.utc)
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO user_contexts (user_id, context_id, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(user_id) DO UPDATE SET
+                        context_id = excluded.context_id,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        context.user_id,
+                        context.context_id,
+                        context.updated_at.isoformat(),
+                    )
+                )
+        except:
+            logger.exception("Error at upsert_context.")
+            raise
+        finally:
+            conn.close()

--- a/aiavatar/adapter/channel_context_bridge/postgres.py
+++ b/aiavatar/adapter/channel_context_bridge/postgres.py
@@ -1,0 +1,266 @@
+import asyncio
+from datetime import datetime, timezone
+import logging
+import json
+from typing import Callable, Awaitable, Dict, List, Optional
+import asyncpg
+from .base import ChannelUser, UserContext, ChannelContextBridge
+
+logger = logging.getLogger(__name__)
+
+
+class PostgreSQLChannelContextBridge(ChannelContextBridge):
+    def __init__(
+        self,
+        *,
+        get_pool: Callable[[], Awaitable[asyncpg.Pool]] = None,
+        host: str = "localhost",
+        port: int = 5432,
+        dbname: str = "aiavatar",
+        user: str = "postgres",
+        password: str = None,
+        connection_str: str = None,
+        timeout: float = 3600,
+        db_pool_min_size: int = 1,
+        db_pool_max_size: int = 5
+    ):
+        self._get_pool_func = get_pool
+        self.host = host
+        self.port = port
+        self.dbname = dbname
+        self.user = user
+        self.password = password
+        self.connection_str = connection_str
+        self.timeout = timeout
+        self.db_pool_min_size = db_pool_min_size
+        self.db_pool_max_size = db_pool_max_size
+        self._pool: asyncpg.Pool = None
+        self._pool_lock = asyncio.Lock()
+        self._db_initialized = False
+
+    async def get_pool(self) -> asyncpg.Pool:
+        if self._get_pool_func is not None:
+            pool = await self._get_pool_func()
+            if not self._db_initialized:
+                async with self._pool_lock:
+                    if not self._db_initialized:
+                        await self.init_db(pool)
+            return pool
+
+        if self._pool is not None and self._db_initialized:
+            return self._pool
+
+        async with self._pool_lock:
+            if self._pool is not None and self._db_initialized:
+                return self._pool
+
+            if self._pool is None:
+                if self.connection_str:
+                    self._pool = await asyncpg.create_pool(
+                        dsn=self.connection_str,
+                        min_size=self.db_pool_min_size,
+                        max_size=self.db_pool_max_size,
+                    )
+                else:
+                    self._pool = await asyncpg.create_pool(
+                        host=self.host,
+                        port=self.port,
+                        database=self.dbname,
+                        user=self.user,
+                        password=self.password,
+                        min_size=self.db_pool_min_size,
+                        max_size=self.db_pool_max_size,
+                    )
+
+            await self.init_db(self._pool)
+
+        return self._pool
+
+    async def init_db(self, pool: asyncpg.Pool):
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS channel_users (
+                        channel_id TEXT NOT NULL,
+                        channel_user_id TEXT NOT NULL,
+                        user_id TEXT NOT NULL,
+                        data JSON,
+                        PRIMARY KEY (channel_id, channel_user_id)
+                    )
+                    """
+                )
+                await conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_channel_users_user_id
+                    ON channel_users (user_id)
+                    """
+                )
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS user_contexts (
+                        user_id TEXT NOT NULL PRIMARY KEY,
+                        context_id TEXT,
+                        updated_at TIMESTAMP NOT NULL
+                    )
+                    """
+                )
+                self._db_initialized = True
+
+            except Exception:
+                logger.exception("Error at init_db")
+
+    # Channel User operations
+    async def get_channel_user(self, channel_id: str, channel_user_id: str, auto_create: bool = False) -> Optional[ChannelUser]:
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                row = await conn.fetchrow(
+                    """
+                    SELECT channel_id, channel_user_id, user_id, data
+                    FROM channel_users
+                    WHERE channel_id = $1 AND channel_user_id = $2
+                    """,
+                    channel_id, channel_user_id
+                )
+
+                if row:
+                    data: Dict = row["data"] or {}
+                    if isinstance(data, str):
+                        data = json.loads(data)
+                    return ChannelUser(
+                        channel_id=row["channel_id"],
+                        channel_user_id=row["channel_user_id"],
+                        user_id=row["user_id"],
+                        data=data,
+                    )
+
+                if auto_create:
+                    channel_user = ChannelUser(
+                        channel_id=channel_id,
+                        channel_user_id=channel_user_id,
+                        user_id=channel_user_id,
+                    )
+                    await self.upsert_channel_user(channel_user)
+                    return channel_user
+
+                return None
+
+            except Exception as ex:
+                logger.error(f"Error at get_channel_user: {ex}")
+                raise
+
+    async def upsert_channel_user(self, channel_user: ChannelUser):
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                data_json = json.dumps(channel_user.data, ensure_ascii=False) if channel_user.data else None
+                await conn.execute(
+                    """
+                    INSERT INTO channel_users (channel_id, channel_user_id, user_id, data)
+                    VALUES ($1, $2, $3, $4)
+                    ON CONFLICT(channel_id, channel_user_id) DO UPDATE SET
+                        user_id = EXCLUDED.user_id,
+                        data = EXCLUDED.data
+                    """,
+                    channel_user.channel_id,
+                    channel_user.channel_user_id,
+                    channel_user.user_id,
+                    data_json,
+                )
+            except Exception as ex:
+                logger.error(f"Error at upsert_channel_user: {ex}")
+                raise
+
+    async def delete_channel_user(self, channel_id: str, channel_user_id: str):
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    "DELETE FROM channel_users WHERE channel_id = $1 AND channel_user_id = $2",
+                    channel_id, channel_user_id
+                )
+            except Exception as ex:
+                logger.error(f"Error at delete_channel_user: {ex}")
+                raise
+
+    async def find_channel_users(self, user_id: str) -> List[ChannelUser]:
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                rows = await conn.fetch(
+                    """
+                    SELECT channel_id, channel_user_id, user_id, data
+                    FROM channel_users
+                    WHERE user_id = $1
+                    """,
+                    user_id
+                )
+                result = []
+                for row in rows:
+                    data: Dict = row["data"] or {}
+                    if isinstance(data, str):
+                        data = json.loads(data)
+                    result.append(ChannelUser(
+                        channel_id=row["channel_id"],
+                        channel_user_id=row["channel_user_id"],
+                        user_id=row["user_id"],
+                        data=data,
+                    ))
+                return result
+            except Exception as ex:
+                logger.error(f"Error at find_channel_users: {ex}")
+                raise
+
+    # User Context operations
+    async def get_context(self, user_id: str) -> Optional[UserContext]:
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                row = await conn.fetchrow(
+                    """
+                    SELECT user_id, context_id, updated_at
+                    FROM user_contexts
+                    WHERE user_id = $1
+                    """,
+                    user_id
+                )
+
+                if row:
+                    updated_at = row["updated_at"] or datetime.min.replace(tzinfo=timezone.utc)
+                    if updated_at.tzinfo is None:
+                        updated_at = updated_at.replace(tzinfo=timezone.utc)
+                    if (datetime.now(timezone.utc) - updated_at).total_seconds() <= self.timeout:
+                        return UserContext(
+                            user_id=row["user_id"],
+                            context_id=row["context_id"],
+                            updated_at=updated_at,
+                        )
+                return None
+
+            except Exception as ex:
+                logger.error(f"Error at get_context: {ex}")
+                raise
+
+    async def upsert_context(self, context: UserContext):
+        context.updated_at = context.updated_at or datetime.now(timezone.utc)
+        updated_at_naive = context.updated_at.replace(tzinfo=None) if context.updated_at.tzinfo else context.updated_at
+
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    """
+                    INSERT INTO user_contexts (user_id, context_id, updated_at)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT(user_id) DO UPDATE SET
+                        context_id = EXCLUDED.context_id,
+                        updated_at = EXCLUDED.updated_at
+                    """,
+                    context.user_id,
+                    context.context_id,
+                    updated_at_naive,
+                )
+            except Exception as ex:
+                logger.error(f"Error at upsert_context: {ex}")
+                raise

--- a/tests/adapter/channel_context_bridge/test_channel_context_bridge.py
+++ b/tests/adapter/channel_context_bridge/test_channel_context_bridge.py
@@ -1,0 +1,223 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from aiavatar.adapter.channel_context_bridge.base import (
+    ChannelUser,
+    UserContext,
+    SQLiteChannelContextBridge,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    return tmp_path / "channel_context_bridge.db"
+
+
+@pytest.fixture
+def bridge(db_path) -> SQLiteChannelContextBridge:
+    return SQLiteChannelContextBridge(db_path=str(db_path), timeout=1)
+
+
+# --- Channel User tests ---
+
+@pytest.mark.asyncio
+async def test_get_channel_user_not_found(bridge):
+    result = await bridge.get_channel_user("linebot", "user_1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_channel_user_auto_create(bridge):
+    user = await bridge.get_channel_user("linebot", "user_1", auto_create=True)
+    assert user.channel_id == "linebot"
+    assert user.channel_user_id == "user_1"
+    assert user.user_id == "user_1"
+    assert user.data == {}
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get_channel_user(bridge):
+    cu = ChannelUser(
+        channel_id="twilio",
+        channel_user_id="+1234567890",
+        user_id="app_user",
+        data={"role": "admin"},
+    )
+    await bridge.upsert_channel_user(cu)
+
+    loaded = await bridge.get_channel_user("twilio", "+1234567890")
+    assert loaded.user_id == "app_user"
+    assert loaded.data == {"role": "admin"}
+
+
+@pytest.mark.asyncio
+async def test_upsert_channel_user_updates(bridge):
+    cu = ChannelUser(
+        channel_id="linebot",
+        channel_user_id="user_2",
+        user_id="user_2",
+    )
+    await bridge.upsert_channel_user(cu)
+
+    cu.user_id = "linked_user"
+    await bridge.upsert_channel_user(cu)
+
+    loaded = await bridge.get_channel_user("linebot", "user_2")
+    assert loaded.user_id == "linked_user"
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_user(bridge):
+    await bridge.get_channel_user("linebot", "user_3", auto_create=True)
+    await bridge.delete_channel_user("linebot", "user_3")
+
+    result = await bridge.get_channel_user("linebot", "user_3")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_channel_users(bridge):
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="websocket", channel_user_id="ws_1", user_id="app_user"
+    ))
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="twilio", channel_user_id="+1234567890", user_id="app_user"
+    ))
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="linebot", channel_user_id="line_1", user_id="other_user"
+    ))
+
+    users = await bridge.find_channel_users("app_user")
+    assert len(users) == 2
+    channel_ids = {u.channel_id for u in users}
+    assert channel_ids == {"websocket", "twilio"}
+
+
+@pytest.mark.asyncio
+async def test_find_channel_users_empty(bridge):
+    users = await bridge.find_channel_users("nonexistent")
+    assert users == []
+
+
+@pytest.mark.asyncio
+async def test_different_channels_same_channel_user_id(bridge):
+    """Same channel_user_id on different channels should be independent."""
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="linebot", channel_user_id="user_x", user_id="line_user"
+    ))
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="twilio", channel_user_id="user_x", user_id="twilio_user"
+    ))
+
+    line = await bridge.get_channel_user("linebot", "user_x")
+    twilio = await bridge.get_channel_user("twilio", "user_x")
+    assert line.user_id == "line_user"
+    assert twilio.user_id == "twilio_user"
+
+
+# --- User Context tests ---
+
+@pytest.mark.asyncio
+async def test_get_context_not_found(bridge):
+    result = await bridge.get_context("nonexistent")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get_context(bridge):
+    await bridge.upsert_context(UserContext(
+        user_id="user_1",
+        context_id="ctx_123",
+    ))
+
+    ctx = await bridge.get_context("user_1")
+    assert ctx.user_id == "user_1"
+    assert ctx.context_id == "ctx_123"
+
+
+@pytest.mark.asyncio
+async def test_upsert_context_updates(bridge):
+    await bridge.upsert_context(UserContext(
+        user_id="user_2", context_id="ctx_old"
+    ))
+    await bridge.upsert_context(UserContext(
+        user_id="user_2", context_id="ctx_new"
+    ))
+
+    ctx = await bridge.get_context("user_2")
+    assert ctx.context_id == "ctx_new"
+
+
+@pytest.mark.asyncio
+async def test_get_context_timeout(bridge):
+    """Expired context should return None."""
+    await bridge.upsert_context(UserContext(
+        user_id="user_3",
+        context_id="ctx_expired",
+        updated_at=datetime.now(timezone.utc) - timedelta(seconds=5),
+    ))
+
+    ctx = await bridge.get_context("user_3")
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_context_independent_of_channel_user(bridge):
+    """Context is per user_id, not per channel."""
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="linebot", channel_user_id="line_1", user_id="shared_user"
+    ))
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="twilio", channel_user_id="+1111111111", user_id="shared_user"
+    ))
+    await bridge.upsert_context(UserContext(
+        user_id="shared_user", context_id="ctx_shared"
+    ))
+
+    ctx = await bridge.get_context("shared_user")
+    assert ctx.context_id == "ctx_shared"
+
+
+# --- link_channel_user tests ---
+
+@pytest.mark.asyncio
+async def test_link_channel_user_new(bridge):
+    """link_channel_user auto-creates channel user and returns context."""
+    await bridge.upsert_context(UserContext(
+        user_id="app_user", context_id="ctx_existing"
+    ))
+
+    ctx = await bridge.link_channel_user("twilio", "+9999999999", "app_user")
+    assert ctx.context_id == "ctx_existing"
+
+    cu = await bridge.get_channel_user("twilio", "+9999999999")
+    assert cu.user_id == "app_user"
+
+
+@pytest.mark.asyncio
+async def test_link_channel_user_updates_existing(bridge):
+    """link_channel_user updates user_id on existing channel user."""
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="twilio", channel_user_id="+8888888888", user_id="+8888888888"
+    ))
+    await bridge.upsert_context(UserContext(
+        user_id="linked_user", context_id="ctx_linked"
+    ))
+
+    ctx = await bridge.link_channel_user("twilio", "+8888888888", "linked_user")
+    assert ctx.context_id == "ctx_linked"
+
+    cu = await bridge.get_channel_user("twilio", "+8888888888")
+    assert cu.user_id == "linked_user"
+
+
+@pytest.mark.asyncio
+async def test_link_channel_user_no_context(bridge):
+    """link_channel_user returns None when linked user has no context."""
+    ctx = await bridge.link_channel_user("linebot", "line_user_1", "new_app_user")
+    assert ctx is None
+
+    cu = await bridge.get_channel_user("linebot", "line_user_1")
+    assert cu.user_id == "new_app_user"

--- a/tests/adapter/channel_context_bridge/test_pg_channel_context_bridge.py
+++ b/tests/adapter/channel_context_bridge/test_pg_channel_context_bridge.py
@@ -1,0 +1,163 @@
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+import os
+
+import pytest
+
+from aiavatar.adapter.channel_context_bridge.postgres import PostgreSQLChannelContextBridge
+from aiavatar.adapter.channel_context_bridge.base import ChannelUser, UserContext
+
+AIAVATAR_DB_HOST = os.getenv("AIAVATAR_DB_HOST", "localhost")
+AIAVATAR_DB_PORT = int(os.getenv("AIAVATAR_DB_PORT", 5432))
+AIAVATAR_DB_NAME = os.getenv("AIAVATAR_DB_NAME", "aiavatar")
+AIAVATAR_DB_USER = os.getenv("AIAVATAR_DB_USER", "postgres")
+AIAVATAR_DB_PASSWORD = os.getenv("AIAVATAR_DB_PASSWORD")
+
+pytestmark = pytest.mark.skipif(
+    not AIAVATAR_DB_PASSWORD,
+    reason="PostgreSQL credentials not configured",
+)
+
+
+@pytest.fixture
+def bridge() -> PostgreSQLChannelContextBridge:
+    return PostgreSQLChannelContextBridge(
+        host=AIAVATAR_DB_HOST,
+        port=AIAVATAR_DB_PORT,
+        dbname=AIAVATAR_DB_NAME,
+        user=AIAVATAR_DB_USER,
+        password=AIAVATAR_DB_PASSWORD,
+        timeout=1,
+    )
+
+
+@pytest.fixture
+def unique_id():
+    return f"test_{uuid4()}"
+
+
+# --- Channel User tests ---
+
+@pytest.mark.asyncio
+async def test_get_channel_user_not_found(bridge, unique_id):
+    result = await bridge.get_channel_user("linebot", unique_id)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_channel_user_auto_create(bridge, unique_id):
+    user = await bridge.get_channel_user("linebot", unique_id, auto_create=True)
+    assert user.channel_id == "linebot"
+    assert user.channel_user_id == unique_id
+    assert user.user_id == unique_id
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get_channel_user(bridge, unique_id):
+    cu = ChannelUser(
+        channel_id="twilio",
+        channel_user_id=unique_id,
+        user_id="app_user",
+        data={"role": "admin"},
+    )
+    await bridge.upsert_channel_user(cu)
+
+    loaded = await bridge.get_channel_user("twilio", unique_id)
+    assert loaded.user_id == "app_user"
+    assert loaded.data == {"role": "admin"}
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_user(bridge, unique_id):
+    await bridge.get_channel_user("linebot", unique_id, auto_create=True)
+    await bridge.delete_channel_user("linebot", unique_id)
+
+    result = await bridge.get_channel_user("linebot", unique_id)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_channel_users(bridge):
+    app_user_id = f"app_{uuid4()}"
+
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="websocket", channel_user_id=f"ws_{uuid4()}", user_id=app_user_id
+    ))
+    await bridge.upsert_channel_user(ChannelUser(
+        channel_id="twilio", channel_user_id=f"+1{uuid4().hex[:10]}", user_id=app_user_id
+    ))
+
+    users = await bridge.find_channel_users(app_user_id)
+    assert len(users) == 2
+    channel_ids = {u.channel_id for u in users}
+    assert channel_ids == {"websocket", "twilio"}
+
+
+# --- User Context tests ---
+
+@pytest.mark.asyncio
+async def test_get_context_not_found(bridge, unique_id):
+    result = await bridge.get_context(unique_id)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get_context(bridge, unique_id):
+    await bridge.upsert_context(UserContext(
+        user_id=unique_id, context_id="ctx_123"
+    ))
+
+    ctx = await bridge.get_context(unique_id)
+    assert ctx.user_id == unique_id
+    assert ctx.context_id == "ctx_123"
+
+
+@pytest.mark.asyncio
+async def test_get_context_timeout(bridge, unique_id):
+    await bridge.upsert_context(UserContext(
+        user_id=unique_id,
+        context_id="ctx_expired",
+        updated_at=datetime.now(timezone.utc) - timedelta(seconds=5),
+    ))
+
+    ctx = await bridge.get_context(unique_id)
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_context_updates(bridge, unique_id):
+    await bridge.upsert_context(UserContext(
+        user_id=unique_id, context_id="ctx_old"
+    ))
+    await bridge.upsert_context(UserContext(
+        user_id=unique_id, context_id="ctx_new"
+    ))
+
+    ctx = await bridge.get_context(unique_id)
+    assert ctx.context_id == "ctx_new"
+
+
+# --- link_channel_user tests ---
+
+@pytest.mark.asyncio
+async def test_link_channel_user(bridge, unique_id):
+    app_user_id = f"app_{uuid4()}"
+    await bridge.upsert_context(UserContext(
+        user_id=app_user_id, context_id="ctx_linked"
+    ))
+
+    ctx = await bridge.link_channel_user("twilio", unique_id, app_user_id)
+    assert ctx.context_id == "ctx_linked"
+
+    cu = await bridge.get_channel_user("twilio", unique_id)
+    assert cu.user_id == app_user_id
+
+
+@pytest.mark.asyncio
+async def test_link_channel_user_no_context(bridge, unique_id):
+    app_user_id = f"app_{uuid4()}"
+    ctx = await bridge.link_channel_user("linebot", unique_id, app_user_id)
+    assert ctx is None
+
+    cu = await bridge.get_channel_user("linebot", unique_id)
+    assert cu.user_id == app_user_id


### PR DESCRIPTION
Introduce `ChannelContextBridge` to map channel-specific user IDs (e.g. LINE, Twilio) to app-level user IDs and persist conversation context (context_id) per user across channels.

- Abstract base class with channel_user CRUD + user_context operations
- `bind()` method to auto-sync context_id via adapter hooks
- SQLite and PostgreSQL implementations