### PR TITLE
Add structured_content to tool call results for client-side data handling

### DIFF
--- a/aiavatar/adapter/http/server.py
+++ b/aiavatar/adapter/http/server.py
@@ -294,7 +294,8 @@ class AIAvatarHttpServer(Adapter):
                         text=response.text,
                         voice_text=response.voice_text,
                         audio_data=response.audio_data,
-                        metadata=response.metadata or {}
+                        metadata=response.metadata or {},
+                        structured_content=response.structured_content
                     )
 
                     # Callback for each response chunk

--- a/aiavatar/adapter/local/server.py
+++ b/aiavatar/adapter/local/server.py
@@ -198,7 +198,8 @@ class AIAvatarLocalServer(Adapter):
             text=response.text,
             voice_text=response.voice_text,
             audio_data=response.audio_data,
-            metadata=response.metadata or {}
+            metadata=response.metadata or {},
+            structured_content=response.structured_content
         )
 
         # Callback for each response chunk

--- a/aiavatar/adapter/models.py
+++ b/aiavatar/adapter/models.py
@@ -35,6 +35,7 @@ class AIAvatarResponse(BaseModel):
     avatar_control_request: Optional[AvatarControlRequest] = None
     audio_data: Optional[Union[bytes, str]] = None
     metadata: Optional[Dict] = None
+    structured_content: Optional[Dict] = None
 
 
 class AIAvatarException(Exception):

--- a/aiavatar/adapter/twilio/server.py
+++ b/aiavatar/adapter/twilio/server.py
@@ -396,7 +396,8 @@ class AIAvatarTwilioServer(Adapter):
 
         elif event_type == "mark":
             mark = message["mark"]["name"]
-            logger.info(f"mark: {mark} ({session_data.call_sid})")
+            if self.debug:
+                logger.info(f"mark: {mark} ({session_data.call_sid})")
 
             if mark == session_data.last_mark:
                 # Clear last mark if not overwritten by successive voice
@@ -432,7 +433,8 @@ class AIAvatarTwilioServer(Adapter):
             text=response.text,
             voice_text=response.voice_text,
             audio_data=response.audio_data,
-            metadata=response.metadata or {}
+            metadata=response.metadata or {},
+            structured_content=response.structured_content
         )
 
         # Callback for each response chunk (base class)

--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -316,7 +316,8 @@ class AIAvatarWebSocketServer(Adapter):
             text=response.text,
             voice_text=response.voice_text,
             audio_data=response.audio_data,
-            metadata=response.metadata or {}
+            metadata=response.metadata or {},
+            structured_content=response.structured_content
         )
 
         # Callback for each response chunk

--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -13,11 +13,12 @@ logger = logging.getLogger(__name__)
 
 
 class ToolCallResult:
-    def __init__(self, data: dict = None, is_final: bool = True, text: str = None, task_id: str = None):
+    def __init__(self, data: dict = None, is_final: bool = True, text: str = None, task_id: str = None, structured_content: dict = None):
         self.data = data or {}
         self.is_final = is_final
         self.text = text
         self.task_id = task_id
+        self.structured_content = structured_content
 
 
 class ToolCall:
@@ -37,6 +38,8 @@ class ToolCall:
             result_dict = {"data": self.result.data, "is_final": self.result.is_final}
             if self.result.task_id:
                 result_dict["task_id"] = self.result.task_id
+            if self.result.structured_content:
+                result_dict["structured_content"] = self.result.structured_content
             d["result"] = result_dict
         return d
 
@@ -60,13 +63,14 @@ class Guardrail(ABC):
 
 
 class LLMResponse:
-    def __init__(self, context_id: str, text: str = None, voice_text: str = None, tool_call: ToolCall = None, guradrail_name: str = None, error_info: dict = None):
+    def __init__(self, context_id: str, text: str = None, voice_text: str = None, tool_call: ToolCall = None, guradrail_name: str = None, error_info: dict = None, structured_content: dict = None):
         self.context_id = context_id
         self.text = text
         self.voice_text = voice_text
         self.tool_call = tool_call
         self.guradrail_name = guradrail_name
         self.error_info = error_info or {}
+        self.structured_content = structured_content
 
 
 class Tool:
@@ -414,7 +418,11 @@ The list of tools is as follows:
                 # Try synchronous first, fallback to background on timeout
                 done, _ = await asyncio.wait({task}, timeout=tool.background_timeout)
                 if done:
-                    yield ToolCallResult(data=task.result())
+                    result = task.result()
+                    if isinstance(result, ToolCallResult):
+                        yield result
+                    else:
+                        yield ToolCallResult(data=result)
                     return
 
             # Immediate background or timed-out: register callback and return

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -352,7 +352,7 @@ class ChatGPTService(LLMService):
                         if tr.text:
                             yield LLMResponse(context_id=context_id, text=tr.text)
                         else:
-                            yield LLMResponse(context_id=context_id, tool_call=tc)
+                            yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
                             if tr.is_final:
                                 tool_result = tr.data
                                 break
@@ -365,7 +365,7 @@ class ChatGPTService(LLMService):
                     tool_obj = self.tools.get(tc.name)
                     if tool_obj and tool_obj._response_formatter:
                         direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
-                        yield LLMResponse(context_id=context_id, text=direct_text)
+                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                         has_direct_response = True
 
                     messages.append({

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -274,7 +274,7 @@ class ClaudeService(LLMService):
                         if tr.text:
                             yield LLMResponse(context_id=context_id, text=tr.text)
                         else:
-                            yield LLMResponse(context_id=context_id, tool_call=tc)
+                            yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
                             if tr.is_final:
                                 tool_result = tr.data
                                 break
@@ -287,7 +287,7 @@ class ClaudeService(LLMService):
                     tool_obj = self.tools.get(tc.name)
                     if tool_obj and tool_obj._response_formatter:
                         direct_text = tool_obj._response_formatter(tool_result, arguments_json)
-                        yield LLMResponse(context_id=context_id, text=direct_text)
+                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                         has_direct_response = True
 
                     assistant_content = []

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -351,7 +351,7 @@ class GeminiService(LLMService):
                         if tr.text:
                             yield LLMResponse(context_id=context_id, text=tr.text)
                         else:
-                            yield LLMResponse(context_id=context_id, tool_call=tc)
+                            yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
                             if tr.is_final:
                                 tool_result = tr.data
                                 break
@@ -364,7 +364,7 @@ class GeminiService(LLMService):
                     tool_obj = self.tools.get(tc.name)
                     if tool_obj and tool_obj._response_formatter:
                         direct_text = tool_obj._response_formatter(tool_result, tc.arguments)
-                        yield LLMResponse(context_id=context_id, text=direct_text)
+                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                         has_direct_response = True
 
                     messages.append(types.Content(

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -297,7 +297,7 @@ class LiteLLMService(LLMService):
                         if tr.text:
                             yield LLMResponse(context_id=context_id, text=tr.text)
                         else:
-                            yield LLMResponse(context_id=context_id, tool_call=tc)
+                            yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
                             if tr.is_final:
                                 tool_result = tr.data
                                 break
@@ -310,7 +310,7 @@ class LiteLLMService(LLMService):
                     tool_obj = self.tools.get(tc.name)
                     if tool_obj and tool_obj._response_formatter:
                         direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
-                        yield LLMResponse(context_id=context_id, text=direct_text)
+                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                         has_direct_response = True
 
                     messages.append({

--- a/aiavatar/sts/llm/openai_responses.py
+++ b/aiavatar/sts/llm/openai_responses.py
@@ -236,7 +236,7 @@ class OpenAIResponsesService(LLMService):
                     if tr.text:
                         yield LLMResponse(context_id=context_id, text=tr.text)
                     else:
-                        yield LLMResponse(context_id=context_id, tool_call=tc)
+                        yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
                         if tr.is_final:
                             tool_result = tr.data
                             break
@@ -249,7 +249,7 @@ class OpenAIResponsesService(LLMService):
                     tool_obj = self.tools.get(tc.name)
                     if tool_obj and tool_obj._response_formatter:
                         direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
-                        yield LLMResponse(context_id=context_id, text=direct_text)
+                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                         has_direct_response = True
 
                     tool_outputs.append({

--- a/aiavatar/sts/llm/openai_responses_websocket.py
+++ b/aiavatar/sts/llm/openai_responses_websocket.py
@@ -334,7 +334,7 @@ class OpenAIResponsesWebSocketService(LLMService):
                             if tr.text:
                                 yield LLMResponse(context_id=context_id, text=tr.text)
                             else:
-                                yield LLMResponse(context_id=context_id, tool_call=tc)
+                                yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
                                 if tr.is_final:
                                     tool_result = tr.data
                                     break
@@ -346,7 +346,7 @@ class OpenAIResponsesWebSocketService(LLMService):
                             tool_obj = self.tools.get(tc.name)
                             if tool_obj and tool_obj._response_formatter:
                                 direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
-                                yield LLMResponse(context_id=context_id, text=direct_text)
+                                yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                                 has_direct_response = True
 
                             tool_outputs.append({

--- a/aiavatar/sts/models.py
+++ b/aiavatar/sts/models.py
@@ -37,3 +37,4 @@ class STSResponse:
     audio_data: bytes = None
     tool_call: ToolCall = None
     metadata: dict = None
+    structured_content: dict = None

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -544,7 +544,8 @@ class STSPipeline:
                         session_id=request.session_id,
                         user_id=request.user_id,
                         context_id=llm_stream_chunk.context_id,
-                        tool_call=llm_stream_chunk.tool_call
+                        tool_call=llm_stream_chunk.tool_call,
+                        structured_content=llm_stream_chunk.structured_content
                     )
                     continue
 
@@ -562,7 +563,8 @@ class STSPipeline:
                     voice_text=llm_stream_chunk.voice_text,
                     language=language,
                     audio_data=audio_chunk,
-                    metadata={"is_first_chunk": is_first_chunk, "is_guardrail_triggered": True if guradrail_name else False}
+                    metadata={"is_first_chunk": is_first_chunk, "is_guardrail_triggered": True if guradrail_name else False},
+                    structured_content=llm_stream_chunk.structured_content
                 )
                 is_first_chunk = False
 

--- a/tests/sts/llm/test_tool_background.py
+++ b/tests/sts/llm/test_tool_background.py
@@ -402,3 +402,101 @@ async def test_async_generator_yields_tool_call_result():
     assert results[0].is_final is False
     assert results[1].data == {"answer": "hello"}
     assert results[1].is_final is True
+
+
+# --- structured_content ---
+
+def test_tool_call_result_structured_content():
+    tr = ToolCallResult(
+        data={"raw": "data"},
+        structured_content={"key": "value", "nested": {"a": 1}}
+    )
+    assert tr.structured_content == {"key": "value", "nested": {"a": 1}}
+    assert tr.data == {"raw": "data"}
+
+
+def test_tool_call_result_structured_content_default_none():
+    tr = ToolCallResult(data={"msg": "hello"})
+    assert tr.structured_content is None
+
+
+def test_tool_call_to_dict_with_structured_content():
+    tr = ToolCallResult(
+        data={"msg": "hello"},
+        structured_content={"ui_data": [1, 2, 3]}
+    )
+    tc = ToolCall(id="1", name="test", arguments='{"q":"hi"}', result=tr)
+    d = tc.to_dict()
+    assert d["result"]["structured_content"] == {"ui_data": [1, 2, 3]}
+
+
+def test_tool_call_to_dict_without_structured_content():
+    tr = ToolCallResult(data={"msg": "hello"})
+    tc = ToolCall(id="1", name="test", arguments='{"q":"hi"}', result=tr)
+    d = tc.to_dict()
+    assert "structured_content" not in d["result"]
+
+
+@pytest.mark.asyncio
+async def test_structured_content_direct_return():
+    async def my_func(query: str):
+        return ToolCallResult(
+            data={"answer": query},
+            structured_content={"display": {"title": query, "type": "info"}}
+        )
+
+    tool = make_tool(my_func)
+    svc = make_service_with_tool(tool)
+
+    results = []
+    async for tr in svc.execute_tool("test_tool", {"query": "weather"}, {"context_id": "c1", "user_id": "u1"}):
+        results.append(tr)
+
+    assert len(results) == 1
+    assert results[0].data == {"answer": "weather"}
+    assert results[0].structured_content == {"display": {"title": "weather", "type": "info"}}
+
+
+@pytest.mark.asyncio
+async def test_structured_content_async_generator():
+    async def my_func(query: str):
+        yield ToolCallResult(data={"progress": 50}, is_final=False, structured_content={"status": "loading"})
+        yield ToolCallResult(data={"answer": query}, is_final=True, structured_content={"status": "complete", "results": [1, 2, 3]})
+
+    tool = make_tool(my_func)
+    svc = make_service_with_tool(tool)
+
+    results = []
+    async for tr in svc.execute_tool("test_tool", {"query": "test"}, {"context_id": "c1", "user_id": "u1"}):
+        results.append(tr)
+
+    assert results[0].structured_content == {"status": "loading"}
+    assert results[1].structured_content == {"status": "complete", "results": [1, 2, 3]}
+
+
+@pytest.mark.asyncio
+async def test_structured_content_background_timeout_completes():
+    completed = []
+
+    async def my_func(query: str):
+        await asyncio.sleep(0.1)
+        return ToolCallResult(
+            data={"answer": query},
+            structured_content={"card": {"title": query}}
+        )
+
+    tool = make_tool(my_func, background_timeout=5.0)
+
+    @tool.on_completed
+    async def handle_completed(result, metadata):
+        completed.append(result)
+
+    svc = make_service_with_tool(tool)
+
+    results = []
+    async for tr in svc.execute_tool("test_tool", {"query": "fast"}, {"context_id": "c1", "user_id": "u1"}):
+        results.append(tr)
+
+    assert len(results) == 1
+    assert results[0].data == {"answer": "fast"}
+    assert results[0].structured_content == {"card": {"title": "fast"}}


### PR DESCRIPTION
Tool call results can now carry `structured_content` alongside the regular data. While data is passed to the LLM as context, `structured_content` is NOT sent to the LLM. Instead it propagates through the full response pipeline (LLMResponse → STSResponse → AIAvatarResponse) and is delivered to the client as a top-level JSON field, enabling use cases such as rendering UI components, updating app state, or displaying rich content.