### PR TITLE
Fix missing context_id storage in VAD session on invoke

### DIFF
--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -275,6 +275,8 @@ class AIAvatarWebSocketServer(Adapter):
                 channel=request.channel,
                 metadata=request.metadata
             )):
+                if r.type == "start":
+                    self.sts.vad.set_session_data(request.session_id, "context_id", r.context_id)
                 await self.sts.handle_response(r)
 
         elif request.type == "data":


### PR DESCRIPTION
Store `context_id` from `invoke` response into VAD session data so that subsequent requests can maintain conversation continuity.