### PR TITLE
Support retrieving timestamps in get_histories

### DIFF
--- a/aiavatar/sts/llm/context_manager/base.py
+++ b/aiavatar/sts/llm/context_manager/base.py
@@ -13,7 +13,7 @@ class ContextManager(ABC):
         self._on_merge_context: Optional[Callable[[str, str, "ContextManager"], Awaitable[None]]] = None
 
     @abstractmethod
-    async def get_histories(self, context_id: Union[str, List[str]], limit: int = 100) -> List[Dict]:
+    async def get_histories(self, context_id: Union[str, List[str]], limit: int = 100, include_timestamp: bool = False) -> List[Dict]:
         pass
 
     @abstractmethod
@@ -76,7 +76,7 @@ class SQLiteContextManager(ContextManager):
         finally:
             conn.close()
 
-    async def get_histories(self, context_id: Union[str, List[str]], limit: int = 100) -> List[Dict]:
+    async def get_histories(self, context_id: Union[str, List[str]], limit: int = 100, include_timestamp: bool = False) -> List[Dict]:
         conn = sqlite3.connect(self.db_path)
         try:
             if not context_id:
@@ -101,8 +101,9 @@ class SQLiteContextManager(ContextManager):
 
             params.append(limit)
 
+            columns = "serialized_data, created_at" if include_timestamp else "serialized_data"
             sql = f"""
-            SELECT serialized_data
+            SELECT {columns}
             FROM chat_histories
             WHERE {' AND '.join(where_clauses)}
             ORDER BY id DESC
@@ -115,7 +116,14 @@ class SQLiteContextManager(ContextManager):
 
             # Reverse the list so that the newest item is at the end (larger index)
             rows.reverse()
-            results = [json.loads(row[0]) for row in rows]
+            if include_timestamp:
+                results = []
+                for row in rows:
+                    data = json.loads(row[0])
+                    data["created_at"] = row[1]
+                    results.append(data)
+            else:
+                results = [json.loads(row[0]) for row in rows]
             return results
 
         except Exception as ex:

--- a/aiavatar/sts/llm/context_manager/postgres.py
+++ b/aiavatar/sts/llm/context_manager/postgres.py
@@ -106,7 +106,7 @@ class PostgreSQLContextManager(ContextManager):
             except Exception:
                 logger.exception("Error at init_db")
 
-    async def get_histories(self, context_id: Union[str, List[str]], limit: int = 100) -> List[Dict]:
+    async def get_histories(self, context_id: Union[str, List[str]], limit: int = 100, include_timestamp: bool = False) -> List[Dict]:
         pool = await self.get_pool()
         async with pool.acquire() as conn:
             try:
@@ -136,8 +136,9 @@ class PostgreSQLContextManager(ContextManager):
 
                 params.append(limit)
 
+                columns = "serialized_data, created_at" if include_timestamp else "serialized_data"
                 sql = f"""
-                SELECT serialized_data
+                SELECT {columns}
                 FROM chat_histories
                 WHERE {' AND '.join(where_clauses)}
                 ORDER BY id DESC
@@ -152,6 +153,8 @@ class PostgreSQLContextManager(ContextManager):
                     data = row["serialized_data"]
                     if isinstance(data, str):
                         data = json.loads(data)
+                    if include_timestamp:
+                        data["created_at"] = row["created_at"].isoformat() if row["created_at"] else None
                     results.append(data)
                 return results
 

--- a/tests/sts/llm/context_manager/test_context_manager.py
+++ b/tests/sts/llm/context_manager/test_context_manager.py
@@ -117,6 +117,29 @@ async def test_get_histories_timeout(context_manager):
 
 
 @pytest.mark.asyncio
+async def test_get_histories_with_timestamp(context_manager):
+    context_id = "test_timestamp"
+    data_list = [
+        {"message": "Hello", "role": "user"},
+        {"message": "Hi there", "role": "assistant"}
+    ]
+    await context_manager.add_histories(context_id, data_list)
+
+    # Without timestamp
+    histories = await context_manager.get_histories(context_id)
+    assert len(histories) == 2
+    assert "created_at" not in histories[0]
+
+    # With timestamp
+    histories_ts = await context_manager.get_histories(context_id, include_timestamp=True)
+    assert len(histories_ts) == 2
+    assert "created_at" in histories_ts[0]
+    assert "created_at" in histories_ts[1]
+    assert histories_ts[0]["message"] == "Hello"
+    assert histories_ts[1]["message"] == "Hi there"
+
+
+@pytest.mark.asyncio
 async def test_merge_context(context_manager):
     await context_manager.add_histories("ctx_from", [{"message": "Hello from phone"}])
     await context_manager.add_histories("ctx_to", [{"message": "Hello from web"}])

--- a/tests/sts/llm/context_manager/test_pg_context_manager.py
+++ b/tests/sts/llm/context_manager/test_pg_context_manager.py
@@ -124,6 +124,29 @@ async def test_get_histories_timeout(context_manager):
 
 
 @pytest.mark.asyncio
+async def test_get_histories_with_timestamp(context_manager):
+    context_id = f"test_timestamp_{uuid4()}"
+    data_list = [
+        {"message": "Hello", "role": "user"},
+        {"message": "Hi there", "role": "assistant"}
+    ]
+    await context_manager.add_histories(context_id, data_list)
+
+    # Without timestamp
+    histories = await context_manager.get_histories(context_id)
+    assert len(histories) == 2
+    assert "created_at" not in histories[0]
+
+    # With timestamp
+    histories_ts = await context_manager.get_histories(context_id, include_timestamp=True)
+    assert len(histories_ts) == 2
+    assert "created_at" in histories_ts[0]
+    assert "created_at" in histories_ts[1]
+    assert histories_ts[0]["message"] == "Hello"
+    assert histories_ts[1]["message"] == "Hi there"
+
+
+@pytest.mark.asyncio
 async def test_merge_context(context_manager):
     ctx_from = f"ctx_from_{uuid4()}"
     ctx_to = f"ctx_to_{uuid4()}"


### PR DESCRIPTION
Allow callers to get `created_at` timestamps with history records for time-aware context handling.