### PR TITLE
Add vision stream support for real-time camera-based interaction

### DIFF
--- a/examples/websocket/html/ui.js
+++ b/examples/websocket/html/ui.js
@@ -6,7 +6,7 @@
  *   // Then wire up page-specific logic (onResponseReceived, lipsync, etc.)
  */
 class AvatarUI {
-    constructor({ aiavatar, userId, camera, onStop, toolLabels }) {
+    constructor({ aiavatar, userId, camera, onStop, toolLabels, voiceDetectMode, voiceHoldDuration }) {
         this.aiavatar = aiavatar;
         this.sessionId = crypto.randomUUID();
         this.userId = userId || localStorage.getItem("userId") || crypto.randomUUID();
@@ -20,6 +20,12 @@ class AvatarUI {
         this.cameraEnabled = false;
         this.isServerProcessing = false;
         this.isBargeInBlocked = false;
+
+        // Voice detection: "rms" (client-side) or "voiced" (server event)
+        this.voiceDetectMode = voiceDetectMode || "rms";
+        this.voiceHoldDuration = voiceHoldDuration || 1000; // ms
+        this.isUserSpeaking = false;
+        this._voiceHoldTimer = null;
 
         // Input level averaging
         this.rmsSum = 0;
@@ -60,25 +66,50 @@ class AvatarUI {
         });
     }
 
-    // --- Microphone frame color & input level ---
+    // --- Voice detection (isUserSpeaking) ---
+
+    _setUserSpeaking() {
+        this.isUserSpeaking = true;
+        if (this._voiceHoldTimer) clearTimeout(this._voiceHoldTimer);
+        this._voiceHoldTimer = setTimeout(() => {
+            this.isUserSpeaking = false;
+        }, this.voiceHoldDuration);
+    }
+
+    // --- Microphone glow ---
+
+    setMicGlow(active) {
+        if (active) {
+            this.avatarFrame.classList.add("mic-active");
+        } else {
+            this.avatarFrame.classList.remove("mic-active");
+        }
+    }
+
+    // --- Microphone input level & voice detection ---
 
     _setupMicrophoneCallback() {
         this.aiavatar.onMicrophoneDataSend = (rms) => {
+            // Glow: always RMS-driven (frame-by-frame)
             if (rms > 0.01) {
-                this.avatarFrame.classList.add("mic-active");
+                this.setMicGlow(true);
             } else {
-                this.avatarFrame.classList.remove("mic-active");
+                this.setMicGlow(false);
             }
 
+            // Voice detection: mode-dependent
+            if (this.voiceDetectMode === "rms" && rms > 0.01) {
+                this._setUserSpeaking();
+            }
+
+            // dB display (always, regardless of mode)
             this.rmsSum += rms;
             this.rmsCount++;
-
             const currentTime = Date.now();
             if (currentTime - this.lastUpdateTime >= 500) {
                 const avgRms = this.rmsSum / this.rmsCount;
                 const dbLevel = avgRms > 0 ? 20 * Math.log10(avgRms) : -80;
                 this.inputLevelElement.textContent = `${dbLevel.toFixed(1)} dB`;
-
                 this.rmsSum = 0;
                 this.rmsCount = 0;
                 this.lastUpdateTime = currentTime;
@@ -234,6 +265,11 @@ class AvatarUI {
             }
         }
 
+        // Voiced mode: voice detection via server event
+        if (response.type === "voiced" && this.voiceDetectMode === "voiced") {
+            this._setUserSpeaking();
+        }
+
         // Track server processing state
         if (response.type === "accepted") {
             this.isServerProcessing = true;
@@ -246,7 +282,9 @@ class AvatarUI {
 
         // Vision / camera capture
         if (response.type === "vision" && response.metadata !== null) {
-            if (response.metadata.source === "camera" && this.cameraEnabled) {
+            if (this.onVisionRequested) {
+                this.onVisionRequested(response.metadata.source);
+            } else if (response.metadata.source === "camera" && this.cameraEnabled) {
                 this.camera.capture();
             }
         }

--- a/examples/websocket/html/vision-stream.js
+++ b/examples/websocket/html/vision-stream.js
@@ -1,0 +1,203 @@
+class VisionStreamClient {
+  /**
+   * @param {Object} options
+   * @param {string}  options.serverUrl
+   * @param {string}  options.contextId
+   * @param {string}  [options.userId]             - User ID (optional)
+   * @param {number}  [options.interval=5]        - Minimum interval in seconds
+   * @param {number}  [options.maxLongEdge=512]
+   * @param {number}  [options.jpegQuality=0.8]   - JPEG quality (0.0 to 1.0)
+   * @param {number}  [options.videoIdealSize=1920] - Ideal long-edge resolution for getUserMedia
+   * @param {string}  [options.facingMode="user"] - "user" (front) or "environment" (back)
+   * @param {HTMLVideoElement}  [options.videoElement]   - Preview element (optional)
+   * @param {HTMLCanvasElement} [options.canvasElement]  - Preview element (optional)
+   * @param {function} [options.pauseWhen]  - () => boolean  Pauses capture while true
+   * @param {function} [options.onResult]  - (text, attentionLevel, imageUrl) => number|void  Return positive ms to cooldown
+   * @param {function} [options.onError]   - (seq, error) => void
+   */
+  constructor({
+    serverUrl,
+    contextId = null,
+    userId = null,
+    interval = 5,
+    maxLongEdge = 512,
+    jpegQuality = 0.8,
+    videoIdealSize = 1920,
+    facingMode = "user",
+    videoElement = null,
+    canvasElement = null,
+    pauseWhen = null,
+    onResult = null,
+    onError = null,
+  }) {
+    this.serverUrl = serverUrl;
+    this.contextId = contextId;
+    this.userId = userId;
+    this.interval = interval;
+    this.maxLongEdge = maxLongEdge;
+    this.jpegQuality = jpegQuality;
+    this.videoIdealSize = videoIdealSize;
+    this.facingMode = facingMode;
+    this.videoElement = videoElement;
+    this.canvasElement = canvasElement;
+    this.pauseWhen = pauseWhen;
+    this.onResult = onResult;
+    this.onError = onError;
+
+    this._seq = 0;
+    this._running = false;
+    this._stream = null;
+    this._video = null;
+    this._abortController = null;
+
+    // Internal canvas (created automatically if canvasElement is not provided)
+    this._canvas = this.canvasElement || document.createElement("canvas");
+    this._ctx = this._canvas.getContext("2d");
+  }
+
+  _getVideoConstraints() {
+    const c = { facingMode: this.facingMode };
+    if (this.videoIdealSize) {
+      c.width = { ideal: this.videoIdealSize };
+    }
+    return c;
+  }
+
+  async _startStream() {
+    if (this._stream) {
+      this._stream.getTracks().forEach(t => t.stop());
+    }
+
+    this._stream = await navigator.mediaDevices.getUserMedia({
+      video: this._getVideoConstraints(),
+    });
+
+    const video = this._video || this.videoElement || document.createElement("video");
+    video.srcObject = this._stream;
+    video.playsInline = true;
+    video.style.transform = this.facingMode === "user" ? "scaleX(-1)" : "";
+    await video.play();
+    this._video = video;
+  }
+
+  async start() {
+    if (this._running) return;
+    this._running = true;
+
+    await this._startStream();
+    this._loop();
+  }
+
+  stop() {
+    this._running = false;
+    if (this._abortController) {
+      this._abortController.abort();
+      this._abortController = null;
+    }
+    if (this._video) {
+      this._video.srcObject = null;
+      this._video = null;
+    }
+    if (this._stream) {
+      this._stream.getTracks().forEach(t => t.stop());
+      this._stream = null;
+    }
+  }
+
+  async switchCamera(facingMode) {
+    this.facingMode = facingMode || (this.facingMode === "user" ? "environment" : "user");
+    if (this._running) {
+      await this._startStream();
+    }
+  }
+
+  _capture() {
+    const video = this._video;
+    if (!video || video.readyState < video.HAVE_CURRENT_DATA) return null;
+
+    const vw = video.videoWidth;
+    const vh = video.videoHeight;
+    const longEdge = Math.max(vw, vh);
+
+    let dw = vw, dh = vh;
+    if (this.maxLongEdge && longEdge > this.maxLongEdge) {
+      const scale = this.maxLongEdge / longEdge;
+      dw = Math.round(vw * scale);
+      dh = Math.round(vh * scale);
+    }
+
+    this._canvas.width = dw;
+    this._canvas.height = dh;
+    this._ctx.drawImage(video, 0, 0, dw, dh);
+
+    this._seq++;
+    return new Promise(resolve => {
+      this._canvas.toBlob(blob => resolve(blob), "image/jpeg", this.jpegQuality);
+    });
+  }
+
+  async capture() {
+    const blob = await this._capture();
+    if (!blob) return null;
+    return await this._blobToDataURL(blob);
+  }
+
+  async _send(blob) {
+    const form = new FormData();
+    form.append("context_id", this.contextId);
+    if (this.userId) form.append("user_id", this.userId);
+    form.append("image", blob, "frame.jpg");
+
+    this._abortController = new AbortController();
+    const resp = await fetch(this.serverUrl, {
+      method: "POST",
+      body: form,
+      signal: this._abortController.signal,
+    });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const data = await resp.json();
+    return data;
+  }
+
+  _blobToDataURL(blob) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  async _loop() {
+    while (this._running) {
+      const start = performance.now();
+
+      if (!this.contextId || (this.pauseWhen && this.pauseWhen())) {
+        await new Promise(r => setTimeout(r, 500));
+        continue;
+      }
+
+      const blob = await this._capture();
+      if (blob) {
+        try {
+          const data = await this._send(blob);
+          if (this.onResult) {
+            const imageUrl = data.image_url || await this._blobToDataURL(blob);
+            const cooldown = await this.onResult(data.text || "", data.attention_level || 0, imageUrl);
+            if (cooldown > 0) {
+              await new Promise(r => setTimeout(r, cooldown));
+            }
+          }
+        } catch (e) {
+          if (this.onError) this.onError(this._seq, e);
+        }
+      }
+
+      const elapsed = (performance.now() - start) / 1000;
+      const sleepTime = this.interval - elapsed;
+      if (sleepTime > 0) {
+        await new Promise(r => setTimeout(r, sleepTime * 1000));
+      }
+    }
+  }
+}

--- a/examples/websocket/html/vrm.html
+++ b/examples/websocket/html/vrm.html
@@ -266,6 +266,31 @@
             width: 100%;
         }
 
+        /* ── Narrow screen (mobile portrait) ── */
+        @media (max-width: 480px) {
+            .message-speaker {
+                font-size: var(--vn-speaker-font-size-sp, 10px);
+                padding: 4px 10px;
+                left: 6px;
+            }
+            .vn-menu {
+                right: 4px;
+                gap: 1px;
+            }
+            .vn-menu-btn {
+                font-size: 9px;
+                width: 58px;
+                padding: 4px 0;
+            }
+            .vn-vol-wrap {
+                width: 58px;
+            }
+            .message-text {
+                padding: 14px 14px;
+                font-size: var(--vn-text-font-size-sp, 14px);
+            }
+        }
+
         .volume-popup {
             position: absolute;
             bottom: calc(100% + 6px);
@@ -444,6 +469,19 @@
             height: 100%;
             z-index: 1;
         }
+
+        /* ── Vision stream preview (top-left) ── */
+        #visionPreview {
+            position: fixed;
+            top: 12px;
+            left: 12px;
+            max-width: 25vw;
+            border-radius: 8px;
+            border: 1px solid rgba(180, 200, 255, 0.18);
+            z-index: 200;
+            display: none;
+            box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+        }
     </style>
     <!-- Optional theme: place a theme.css in the same directory to override styles -->
     <link rel="stylesheet" href="vrm-themes/theme-girly.css">
@@ -458,6 +496,9 @@
         <canvas id="vrmCanvas"></canvas>
         <div class="vrm-placeholder" id="vrmPlaceholder">Drop or load a VRM file</div>
     </div>
+
+    <!-- Vision stream preview -->
+    <video id="visionPreview" playsinline muted></video>
 
     <!-- Mic activity glow -->
     <div class="mic-glow" id="micGlow"></div>
@@ -475,6 +516,7 @@
             <div class="vn-menu">
                 <button class="vn-menu-btn" id="chatBtn">START</button>
                 <button class="vn-menu-btn" id="bargeInBtn">BARGE-IN</button>
+                <button class="vn-menu-btn" id="visionBtn">VISION</button>
                 <div class="vn-vol-wrap" id="volumeControl">
                     <button class="vn-menu-btn" id="volumeBtn">VOL</button>
                     <div class="volume-popup" id="volumePopup">
@@ -496,14 +538,12 @@
         <span>Input: </span>
         <span id="inputLevel">0.0 dB</span>
     </div>
-    <video id="cameraVideo" style="display: none;" playsinline></video>
-    <canvas id="cameraCanvas" style="display: none;"></canvas>
     <input type="checkbox" id="interruptToggle" style="display:none;">
     <input type="checkbox" id="cameraToggle" style="display:none;">
 
     <script src="aiavatar.js"></script>
-    <script src="camera.js"></script>
-    <script src="lipsync.js"></script>
+    <script src="vision-stream.js"></script>
+<script src="lipsync.js"></script>
     <script src="ui.js"></script>
     <script src="vrm-idle.js"></script>
 
@@ -1589,26 +1629,10 @@
         aiavatar.onResetFace = () => idle.clearVisemes();
         aiavatar.onPlaybackEnd = () => idle.clearVisemes();
 
-        // Camera (vision)
-        const cam = new Camera({
-            videoElement: document.getElementById('cameraVideo'),
-            canvasElement: document.getElementById('cameraCanvas'),
-            onCapture: (imageDataUrl) => {
-                aiavatar.ws.send(JSON.stringify({
-                    type: "invoke",
-                    session_id: ui.sessionId,
-                    user_id: ui.userId,
-                    files: [{ url: imageDataUrl }],
-                    allow_merge: false,
-                    wait_in_queue: true
-                }));
-            }
-        });
-
         // Shared UI
         const ui = new AvatarUI({
             aiavatar,
-            camera: cam,
+            // voiceDetectMode: "voiced",
             toolLabels: {
                 "send_query_to_openclaw": "Asking OpenClaw🦞",
             }
@@ -1727,18 +1751,94 @@
         }, 1000);
 
         // ============================================================
+        // Vision Stream
+        // ============================================================
+        const VISION_SERVER_URL = "../vision";
+        const VISION_STREAM_ENABLED = true;  // Set false to disable periodic sending (camera stays active for on-demand capture)
+        const visionPreview = document.getElementById('visionPreview');
+        const visionBtn = document.getElementById('visionBtn');
+        let visionClient = null;
+        let visionActive = false;
+
+        visionPreview.addEventListener('click', () => {
+            if (visionClient) visionClient.switchCamera();
+        });
+
+        visionBtn.addEventListener('click', async () => {
+            visionActive = !visionActive;
+            visionBtn.classList.toggle('active', visionActive);
+
+            if (visionActive) {
+                visionPreview.style.display = 'block';
+                visionClient = new VisionStreamClient({
+                    serverUrl: VISION_SERVER_URL,
+                    contextId: aiavatar.chatContextId || null,
+                    userId: ui.userId,
+                    interval: 3,
+                    maxLongEdge: 1536,
+                    jpegQuality: 0.7,
+                    videoElement: visionPreview,
+                    pauseWhen: () => !VISION_STREAM_ENABLED || ui.isUserSpeaking,
+                    onResult: (text, attentionLevel, imageUrl) => {
+                        console.log(`[Vision] (${attentionLevel}) ${text}`);
+                        if (attentionLevel >= 3) {
+                            aiavatar.ws.send(JSON.stringify({
+                                type: "invoke",
+                                session_id: ui.sessionId,
+                                user_id: ui.userId,
+                                // text: "$Noteworthy visual information has been received. Rather than simply describing what you see, respond in a way that is appropriate to the current conversational context.",
+                                text: "$注目すべき視覚情報が入力されました。見えたものの解説ではなく、これまでの文脈の中でこの画像が見えたときに相応しい反応をしてください",
+                                files: [{ url: imageUrl }],
+                                allow_merge: false,
+                                wait_in_queue: true
+                            }));
+                            return 10000; // cooldown milliseconds
+                        }
+                    },
+                    onError: (seq, err) => {
+                        console.error(`[Vision] Error:`, err);
+                    },
+                });
+                await visionClient.start();
+            } else {
+                if (visionClient) {
+                    visionClient.stop();
+                    visionClient = null;
+                }
+                visionPreview.style.display = 'none';
+            }
+        });
+
+        // Response handling for vision
+        ui.onVisionRequested = async (source) => {
+            if (visionActive) {
+                const imageDataUrl = await visionClient.capture();
+                if (!imageDataUrl) return;
+                const imageMessage = {
+                    type: "invoke",
+                    session_id: ui.sessionId,
+                    user_id: ui.userId,
+                    // text: "$Here is visual information needed for your response. Rather than simply describing what you see, respond in a way that is appropriate to the current conversational context.",
+                    text: "$応答に必要な視覚情報を提供します。単に見えたものの説明だけではなく、これまでの文脈の中でこの画像が見えたときに相応しい反応をしてください",
+                    files: [{url: imageDataUrl}],
+                    allow_merge: false,
+                    wait_in_queue: true
+                };
+                aiavatar.ws.send(JSON.stringify(imageMessage));
+            }
+        };
+
+        // ============================================================
         // Galge-style control wiring
         // ============================================================
         const micGlow = document.getElementById('micGlow');
         const chatBtn = document.getElementById('chatBtn');
         const bargeInBtn = document.getElementById('bargeInBtn');
 
-        // Override mic activity visual: use bottom glow instead of frame color
-        const origMicCallback = aiavatar.onMicrophoneDataSend;
-        aiavatar.onMicrophoneDataSend = (rms) => {
-            origMicCallback?.(rms);
+        // Override mic glow: use bottom glow bar instead of frame color
+        ui.setMicGlow = (active) => {
             if (!showMicGlow) return;
-            if (rms > 0.01) {
+            if (active) {
                 micGlow.classList.add('active');
             } else {
                 micGlow.classList.remove('active');
@@ -1797,6 +1897,10 @@
                 aiavatar.updateFace("neutral", 0);
             } else if (response.type === "tool_call") {
                 console.log(response.metadata);
+            }
+            // Update vision client context
+            if (visionClient && response.context_id) {
+                visionClient.contextId = response.context_id;
             }
             // Update connection info
             if (response.type === "connected") {

--- a/examples/websocket/vision_stream/__init__.py
+++ b/examples/websocket/vision_stream/__init__.py
@@ -1,0 +1,9 @@
+from .history_provider import HistoryProvider, InlineMemoryHistoryProvider, LinkedFileHistoryProvider
+from .result_recorder import VisionResultRecorder
+from .server import (
+    VisionStreamServer,
+    DEFAULT_SYSTEM_PROMPT,
+    DEFAULT_SYSTEM_PROMPT_JP,
+    DEFAULT_REQUEST_TEMPLATE,
+    DEFAULT_REQUEST_TEMPLATE_JP,
+)

--- a/examples/websocket/vision_stream/history_provider.py
+++ b/examples/websocket/vision_stream/history_provider.py
@@ -1,0 +1,181 @@
+import abc
+import base64
+from collections import defaultdict
+import logging
+from pathlib import Path
+import time
+from typing import Optional
+import aiofiles
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+
+logger = logging.getLogger(__name__)
+
+
+class HistoryProvider(abc.ABC):
+    """Abstract base class for image history backends.
+
+    Subclass this to implement custom storage (e.g., S3, Redis).
+    """
+
+    def __init__(self, image_dir: Optional[str] = None, image_size: Optional[int] = None):
+        self.image_dir = Path(image_dir) if image_dir else None
+        self.image_size = image_size
+
+    async def _save_image(self, context_id: str, image_bytes: bytes, image_id: str):
+        """Save original image to disk."""
+        dir_path = self.image_dir / context_id
+        dir_path.mkdir(parents=True, exist_ok=True)
+        async with aiofiles.open(dir_path / f"{image_id}.jpg", "wb") as f:
+            await f.write(image_bytes)
+
+    def _resize_image(self, image_bytes: bytes) -> bytes:
+        from PIL import Image
+        import io
+        img = Image.open(io.BytesIO(image_bytes))
+        long_edge = max(img.size)
+        if long_edge <= self.image_size:
+            return image_bytes
+        scale = self.image_size / long_edge
+        new_size = (int(img.width * scale), int(img.height * scale))
+        img = img.resize(new_size, Image.LANCZOS)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        return buf.getvalue()
+
+    @abc.abstractmethod
+    async def store_image(self, context_id: str, image_bytes: bytes, image_id: str) -> str:
+        """Store an image and return a URL (data URL, HTTP URL, etc.) for the LLM."""
+        ...
+
+    @abc.abstractmethod
+    def get(self, context_id: str) -> list[tuple[float, str, str]]:
+        """Return history entries as [(timestamp, image_url, raw_text), ...]."""
+        ...
+
+    @abc.abstractmethod
+    def add(self, context_id: str, timestamp: float, image_url: str, raw_text: str):
+        """Append a new entry to the history."""
+        ...
+
+    @abc.abstractmethod
+    def cleanup(self):
+        """Evict stale entries (called before each request)."""
+        ...
+
+
+class InlineMemoryHistoryProvider(HistoryProvider):
+    """In-memory image history with base64 data URLs. Simple, no HTTP serving needed."""
+
+    def __init__(
+        self,
+        max_size: int = 20,
+        truncate_to: int = 5,
+        ttl: float = 600.0,
+        image_dir: Optional[str] = "vision_stream_images",
+        image_size: Optional[int] = 1024,
+    ):
+        super().__init__(image_dir=image_dir, image_size=image_size)
+        self.max_size = max_size
+        self.truncate_to = truncate_to
+        self.ttl = ttl
+        self._store: dict[str, list] = defaultdict(list)
+
+    async def store_image(self, context_id: str, image_bytes: bytes, image_id: str) -> str:
+        if self.image_dir:
+            await self._save_image(context_id, image_bytes, image_id)
+
+        if self.image_size:
+            image_bytes = self._resize_image(image_bytes)
+
+        b64 = base64.b64encode(image_bytes).decode("ascii")
+        return f"data:image/jpeg;base64,{b64}"
+
+    def get(self, context_id: str) -> list[tuple[float, str, str]]:
+        return self._store[context_id]
+
+    def add(self, context_id: str, timestamp: float, image_url: str, raw_text: str):
+        history = self._store[context_id]
+        history.append((timestamp, image_url, raw_text))
+        if len(history) >= self.max_size:
+            logger.info(
+                f"[{context_id}] History truncated: {len(history)} -> {self.truncate_to}"
+            )
+            self._store[context_id] = history[-self.truncate_to:]
+
+    def cleanup(self):
+        now = time.time()
+        expired = [
+            cid for cid, history in self._store.items()
+            if history and (now - history[-1][0]) > self.ttl
+        ]
+        for cid in expired:
+            logger.info(f"Evicting stale image history: {cid}")
+            del self._store[cid]
+
+
+class LinkedFileHistoryProvider(HistoryProvider):
+    """File-based image history served via HTTP. OpenAI can cache by URL."""
+
+    def __init__(
+        self,
+        base_url: str,
+        image_dir: str = "vision_stream_images",
+        image_path: str = "/vision/images",
+        max_size: int = 20,
+        truncate_to: int = 5,
+        ttl: float = 600.0,
+        image_size: Optional[int] = 1024,
+    ):
+        super().__init__(image_dir=image_dir, image_size=image_size)
+        self.base_url = base_url.rstrip("/")
+        self.image_path = image_path
+        self.max_size = max_size
+        self.truncate_to = truncate_to
+        self.ttl = ttl
+        self._store: dict[str, list] = defaultdict(list)
+
+    async def store_image(self, context_id: str, image_bytes: bytes, image_id: str) -> str:
+        await self._save_image(context_id, image_bytes, image_id)
+        # Save resized version and return its URL if image_size is set
+        if self.image_size:
+            resized = self._resize_image(image_bytes)
+            async with aiofiles.open(self.image_dir / context_id / f"{image_id}_sm.jpg", "wb") as f:
+                await f.write(resized)
+            return f"{self.base_url}{self.image_path}/{context_id}/{image_id}_sm"
+        return f"{self.base_url}{self.image_path}/{context_id}/{image_id}"
+
+    def get(self, context_id: str) -> list[tuple[float, str, str]]:
+        return self._store[context_id]
+
+    def add(self, context_id: str, timestamp: float, image_url: str, raw_text: str):
+        history = self._store[context_id]
+        history.append((timestamp, image_url, raw_text))
+        if len(history) >= self.max_size:
+            logger.info(
+                f"[{context_id}] History truncated: {len(history)} -> {self.truncate_to}"
+            )
+            self._store[context_id] = history[-self.truncate_to:]
+
+    def cleanup(self):
+        now = time.time()
+        expired = [
+            cid for cid, history in self._store.items()
+            if history and (now - history[-1][0]) > self.ttl
+        ]
+        for cid in expired:
+            logger.info(f"Evicting stale image history: {cid}")
+            del self._store[cid]
+
+    def get_router(self) -> APIRouter:
+        router = APIRouter()
+        image_dir = self.image_dir
+
+        @router.get(f"{self.image_path}/{{context_id}}/{{image_id}}")
+        async def get_image(context_id: str, image_id: str):
+            file_path = image_dir / context_id / f"{image_id}.jpg"
+            if not file_path.is_file():
+                raise HTTPException(status_code=404)
+            return FileResponse(file_path, media_type="image/jpeg")
+
+        return router

--- a/examples/websocket/vision_stream/result_recorder.py
+++ b/examples/websocket/vision_stream/result_recorder.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+import logging
+import queue
+import sqlite3
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class VisionResultRecorder:
+    def __init__(self, db_path: str = "vision_stream.db"):
+        self.db_path = db_path
+        self.record_queue: queue.Queue = queue.Queue()
+        self.stop_event = threading.Event()
+        self.init_db()
+        self.worker_thread = threading.Thread(target=self._worker, daemon=True)
+        self.worker_thread.start()
+
+    def init_db(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS vision_records (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        created_at TIMESTAMP,
+                        context_id TEXT,
+                        user_id TEXT,
+                        attention_level INTEGER,
+                        comment TEXT,
+                        image_id TEXT
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_vision_records_context_id_created_at
+                    ON vision_records (context_id, created_at)
+                    """
+                )
+        finally:
+            conn.close()
+
+    def _worker(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            while not self.stop_event.is_set() or not self.record_queue.empty():
+                try:
+                    row = self.record_queue.get(timeout=0.5)
+                except queue.Empty:
+                    continue
+                conn.execute(
+                    "INSERT INTO vision_records (created_at, context_id, user_id, attention_level, comment, image_id) VALUES (?, ?, ?, ?, ?, ?)",
+                    row,
+                )
+                conn.commit()
+                self.record_queue.task_done()
+        finally:
+            conn.close()
+
+    def record(self, context_id: str, attention_level: int, comment: str, image_id: Optional[str] = None, user_id: Optional[str] = None):
+        self.record_queue.put((datetime.now(timezone.utc), context_id, user_id, attention_level, comment, image_id))
+
+    def get_records(self, context_id: str, limit: int = 100, min_attention_level: Optional[int] = None, user_id: Optional[str] = None, since: Optional[datetime] = None, until: Optional[datetime] = None) -> list[dict]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            where = ["context_id = ?"]
+            params: list = [context_id]
+            if user_id is not None:
+                where.append("user_id = ?")
+                params.append(user_id)
+            if min_attention_level is not None:
+                where.append("attention_level >= ?")
+                params.append(min_attention_level)
+            if since is not None:
+                where.append("created_at >= ?")
+                params.append(since)
+            if until is not None:
+                where.append("created_at <= ?")
+                params.append(until)
+            params.append(limit)
+            cursor = conn.execute(
+                f"""
+                SELECT created_at, context_id, user_id, attention_level, comment, image_id
+                FROM vision_records
+                WHERE {' AND '.join(where)}
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                params,
+            )
+            rows = cursor.fetchall()
+            rows.reverse()
+            return [
+                {"created_at": r[0], "context_id": r[1], "user_id": r[2], "attention_level": r[3], "comment": r[4], "image_id": r[5]}
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
+    def close(self):
+        self.stop_event.set()
+        self.record_queue.join()
+        self.worker_thread.join()

--- a/examples/websocket/vision_stream/server.py
+++ b/examples/websocket/vision_stream/server.py
@@ -1,0 +1,248 @@
+from datetime import datetime
+import logging
+import re
+import time
+from typing import Optional
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+from fastapi import APIRouter, UploadFile, File, Form
+from openai import AsyncOpenAI
+from aiavatar.sts.llm.context_manager import ContextManager
+from .history_provider import HistoryProvider, InlineMemoryHistoryProvider
+from .result_recorder import VisionResultRecorder
+
+logger = logging.getLogger(__name__)
+
+
+ATTENTION_PATTERN = re.compile(r'<attention\s+level="(\d+)"\s*/>\s*')
+
+DEFAULT_SYSTEM_PROMPT = """\
+Your task is to provide visual information to an AI avatar.
+The images are captured by the AI character's camera at intervals of a few seconds.
+Check the image and comment on anything noteworthy for the character.
+
+- If there is prior history, focus on changes from the previous frame
+- Ignore minor changes; focus on people or objects appearing/disappearing, color changes, pose changes, etc.
+- Keep output under 50 characters
+- When a change warrants the AI character's attention, prepend <attention level="{value}" /> to your comment
+- The level values are defined as follows:
+    1: The subject's appearance has changed
+    2: A subject has appeared/disappeared, made a significant pose change, or the scene is emotionally striking (beautiful, frightening, etc.)
+    3: The subject is clearly making a direct appeal or gesture toward the camera
+- Each image has a timestamp. Adjust your response based on elapsed time since the last frame:
+    - A few seconds to ~1 minute: Normal change detection
+    - Several minutes or longer gap: Treat as a reunion (e.g., "Welcome back")
+    - Empty history: Treat as a first encounter
+- If a "Recent conversation" section is present, take the conversation content into account
+- If the recent conversation includes a request to look at something (e.g., "look at this"), treat the next image as level=3
+"""
+
+DEFAULT_SYSTEM_PROMPT_JP = """\
+あなたのタスクは、AIアバターに視覚情報を与えること。
+与えられた画像はAIキャラクターのカメラが3秒に1回のペースで撮影している。
+キャラクターとして特に注目すべき情報があるか画像をチェックしてコメントせよ。
+
+## チェックのルール
+
+- 前回までのやり取り履歴がある場合、変化に注目する
+- 軽微な変化は無視し、人物や物が映ったまたは消えた、色が変わった、ポーズが変わったなどに注目する
+- 出力は50文字以内とする
+- この変化を特にAIキャラクターに通知したいときは、コメントの先頭に<attention level="{value}" />を付与すること
+- levelの値の基準は以下の3段階とする:
+    1: 被写体の様子が変化したとき
+    2: 被写体の存在やポーズ、前フレームから大きな変化があったとき。または見えている景色がとても美しかったり恐ろしかったり、感情を揺さぶられるようなものであるとき
+    3: 被写体がこちらに向かって明らかなアピールや主張をしているとき
+- level=3とした場合、その理由をコメントに含むこと。さらに理由とする文脈がある場合は、その部分を抜粋して示すこと
+- 各画像にはタイムスタンプが付与されている。前回からの経過時間に応じて反応を変えること:
+    - 数秒〜1分程度: 通常の変化検出
+    - 数分〜数十分のブランク: 久しぶりの再会として扱う（例: おかえり）
+    - 履歴が空の場合: 初めての出会いとして扱う
+- 「直近の会話」セクションがある場合、被写体とキャラクターの会話内容も踏まえてコメントすること
+"""
+
+DEFAULT_REQUEST_TEMPLATE = """\
+Captured at: {timestamp}
+Determine the attention level based on both the image itself and the conversational context below.
+
+----
+{conversation_summary}
+"""
+
+DEFAULT_REQUEST_TEMPLATE_JP = """\
+撮影日時: {timestamp}
+
+levelの値は画像そのものに加えて以下に示す会話の文脈も考慮して決定すること。
+
+----
+{conversation_summary}
+"""
+
+
+class VisionStreamServer:
+    def __init__(
+        self,
+        *,
+        openai_api_key: str,
+        openai_model: str = "gpt-5.4-mini",
+        openai_base_url: Optional[str] = None,
+        reasoning_effort: str = "none",
+        temperature: float = 1.0,
+        system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+        context_manager: ContextManager = None,
+        conversation_history_count: int = 20,
+        image_history: HistoryProvider = None,
+        include_image_url: bool = False,
+        request_template: str = DEFAULT_REQUEST_TEMPLATE,
+        timezone: str = "Asia/Tokyo",
+        result_recorder: VisionResultRecorder = None,
+    ):
+        self.openai_client = AsyncOpenAI(api_key=openai_api_key, base_url=openai_base_url)
+        self.model = openai_model
+        self.reasoning_effort = reasoning_effort
+        self.temperature = temperature
+        self.system_prompt = system_prompt
+        self.context_manager = context_manager
+        self.conversation_history_count = conversation_history_count
+        self.image_history = image_history or InlineMemoryHistoryProvider()
+        self.include_image_url = include_image_url
+        self.request_template = request_template
+        self.tz = ZoneInfo(timezone)
+        self.result_recorder = result_recorder or VisionResultRecorder()
+
+    @staticmethod
+    def _extract_text_content(content) -> str:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    parts.append(item.get("text", ""))
+            return " ".join(parts)
+        return str(content)
+
+    def _summarize_conversation(self, messages: list) -> Optional[str]:
+        lines = []
+        for msg in messages:
+            role = msg.get("role", "")
+            content = self._extract_text_content(msg.get("content", ""))
+            created_at = msg.get("created_at", "")
+            prefix = ""
+            if created_at:
+                try:
+                    dt = datetime.fromisoformat(created_at)
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+                    dt = dt.astimezone(self.tz)
+                    prefix = f"[{dt.strftime('%Y-%m-%d %H:%M:%S')}] "
+                except Exception:
+                    prefix = f"[{created_at}] "
+            if role == "user":
+                lines.append(f"{prefix}User: {content}")
+            elif role == "assistant":
+                lines.append(f"{prefix}Character: {content}")
+        if not lines:
+            return None
+        return "## Recent conversation\n" + "\n".join(lines)
+
+    async def _build_messages(self, context_id: str, image_bytes: bytes, image_id: str) -> tuple:
+        messages = [{"role": "system", "content": self.system_prompt}]
+
+        # Image history — placed first for prompt cache stability
+        for ts, image_url, raw_text in self.image_history.get(context_id):
+            time_str = datetime.fromtimestamp(ts, tz=self.tz).strftime("%Y-%m-%d %H:%M:%S")
+            messages.append({
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": f"[{time_str}]"},
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                ],
+            })
+            messages.append({"role": "assistant", "content": raw_text})
+
+        # New image — conversation summary embedded via request_template
+        conversation_summary = ""
+        if self.context_manager:
+            try:
+                conv_history = await self.context_manager.get_histories(
+                    context_id, self.conversation_history_count, include_timestamp=True
+                )
+                conversation_summary = self._summarize_conversation(conv_history) or ""
+            except Exception as e:
+                logger.warning(f"Failed to get conversation history: {e}")
+
+        image_url = await self.image_history.store_image(context_id, image_bytes, image_id)
+        now_str = datetime.now(tz=self.tz).strftime("%Y-%m-%d %H:%M:%S")
+        request_text = self.request_template.format(
+            timestamp=now_str,
+            conversation_summary=conversation_summary,
+        )
+
+        messages.append({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": request_text},
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ],
+        })
+        return messages, image_url
+
+    @staticmethod
+    def parse_attention(text: str) -> tuple[str, int]:
+        m = ATTENTION_PATTERN.search(text)
+        if not m:
+            return text, 0
+        level = int(m.group(1))
+        cleaned = ATTENTION_PATTERN.sub("", text).strip()
+        return cleaned, level
+
+    async def process_image(self, context_id: str, image_bytes: bytes, user_id: Optional[str] = None) -> dict:
+        self.image_history.cleanup()
+
+        image_id = f"{datetime.now().strftime('%Y%m%d%H%M%S')}_{uuid4().hex}"
+        api_start = time.monotonic()
+        messages, image_url = await self._build_messages(context_id, image_bytes, image_id)
+
+        resp = await self.openai_client.chat.completions.create(
+            model=self.model,
+            reasoning_effort=self.reasoning_effort,
+            messages=messages,
+            temperature=self.temperature,
+        )
+        raw_text = resp.choices[0].message.content
+        api_elapsed = time.monotonic() - api_start
+        logger.info(f"[{context_id}] ({api_elapsed:.2f}s) {raw_text}")
+
+        attention_level = 0
+        text = raw_text or ""
+        if text:
+            text, attention_level = self.parse_attention(text)
+
+        if raw_text:
+            self.image_history.add(context_id, time.time(), image_url, raw_text)
+
+        if self.result_recorder:
+            self.result_recorder.record(context_id, attention_level, text, image_id, user_id)
+
+        result = {"text": text, "attention_level": attention_level}
+        if self.include_image_url:
+            result["image_url"] = image_url
+        return result
+
+    def get_vision_records(self, context_id: str, limit: int = 100, min_attention_level: Optional[int] = None, user_id: Optional[str] = None, since: Optional[datetime] = None, until: Optional[datetime] = None) -> list[dict]:
+        return self.result_recorder.get_records(context_id, limit, min_attention_level, user_id, since, until)
+
+    def get_router(self, path: str = "/vision") -> APIRouter:
+        router = APIRouter()
+        server = self
+
+        @router.post(path)
+        async def post_vision(
+            context_id: str = Form(...),
+            image: UploadFile = File(...),
+            user_id: Optional[str] = Form(None),
+        ):
+            image_bytes = await image.read()
+            return await server.process_image(context_id, image_bytes, user_id)
+
+        return router


### PR DESCRIPTION
Enable periodic camera image streaming and on-demand vision capture in the websocket example. Periodic streaming is controlled by `VISION_STREAM_ENABLED` (default: false). When enabled, the vision stream server (examples/websocket/vision_stream/) must be running. Also remove the camera.js dependency from vrm.html, now replaced by `VisionStreamClient`.