### PR TITLE
Add channel-aware processing with auto channel tag insertion and per-channel TTS skip

### DIFF
--- a/aiavatar/adapter/linebot/server.py
+++ b/aiavatar/adapter/linebot/server.py
@@ -91,6 +91,8 @@ class AIAvatarLineBotServer(Adapter):
 
         # API server auth
         api_key: str = None,
+        # Channel
+        insert_channel_tag: bool = False,
         # Debug
         debug: bool = False
     ):
@@ -117,6 +119,7 @@ class AIAvatarLineBotServer(Adapter):
             db_connection_str=db_connection_str,
             session_state_manager=session_state_manager,
             performance_recorder=performance_recorder,
+            insert_channel_tag=insert_channel_tag,
             debug=debug
         )
 
@@ -246,7 +249,9 @@ class AIAvatarLineBotServer(Adapter):
             user_id=user_id,
             context_id=context_id,
             text=text,
-            files=files
+            files=files,
+            channel="linebot",
+            metadata={}
         )
 
         if self._preprocess_request:

--- a/aiavatar/adapter/twilio/server.py
+++ b/aiavatar/adapter/twilio/server.py
@@ -132,6 +132,7 @@ class AIAvatarTwilioServer(Adapter):
         auth_token: str = None,
         phone_number: str = None,
         webhook_base_url: str = None,
+        channel: str = "phone",
 
         # SMS
         enable_sms: bool = False,
@@ -146,6 +147,10 @@ class AIAvatarTwilioServer(Adapter):
         # Max turn control
         max_turn_count: int = 0,
         max_turn_prompt_prefix: str = None,
+
+        # Channel
+        insert_channel_tag: bool = False,
+        skip_tts_channels: List[str] = ["sms"],
 
         # Debug
         debug: bool = False,
@@ -191,6 +196,8 @@ class AIAvatarTwilioServer(Adapter):
             invoke_queue_idle_timeout=invoke_queue_idle_timeout,
             invoke_timeout=invoke_timeout,
             use_invoke_queue=use_invoke_queue,
+            insert_channel_tag=insert_channel_tag,
+            skip_tts_channels=skip_tts_channels,
             debug=debug
         )
 
@@ -206,6 +213,9 @@ class AIAvatarTwilioServer(Adapter):
 
         # Audio
         self.tts_sample_rate = tts_sample_rate
+
+        # Channel
+        self.channel = channel
 
         # Twilio
         self.phone_number = phone_number
@@ -365,6 +375,7 @@ class AIAvatarTwilioServer(Adapter):
             user_id = session_data.caller
 
             self.sts.vad.set_session_data(session_data.call_sid, "user_id", user_id, True)
+            self.sts.vad.set_session_data(session_data.call_sid, "channel", self.channel)
 
             logger.info(f"WebSocket connected for stream_sid: {stream_sid} / call_sid: {call_sid} / user_id: {user_id}")
 

--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -88,6 +88,8 @@ class AIAvatarWebSocketServer(Adapter):
         send_voiced: bool = False,
         # API server auth
         api_key: str = None,
+        # Channel
+        insert_channel_tag: bool = False,
         # Debug
         debug: bool = False,
     ):
@@ -132,6 +134,7 @@ class AIAvatarWebSocketServer(Adapter):
             invoke_queue_idle_timeout=invoke_queue_idle_timeout,
             invoke_timeout=invoke_timeout,
             use_invoke_queue=use_invoke_queue,
+            insert_channel_tag=insert_channel_tag,
             debug=debug
         )
 

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -70,10 +70,16 @@ class STSPipeline:
         invoke_queue_idle_timeout: float = 10.0,
         invoke_timeout: float = 60.0,
         use_invoke_queue: bool = False,
+        insert_channel_tag: bool = False,
+        skip_tts_channels: List[str] = None,
         debug: bool = False
     ):
         self.debug = debug
         self.use_invoke_queue = use_invoke_queue
+
+        # Channel
+        self.insert_channel_tag = insert_channel_tag
+        self.skip_tts_channels = skip_tts_channels or []
 
         # Database connection pool
         if db_pool_provider:
@@ -110,6 +116,7 @@ class STSPipeline:
                 session_id=session_id,
                 user_id=self.vad.get_session_data(session_id, "user_id"),
                 context_id=self.vad.get_session_data(session_id, "context_id"),
+                channel=self.vad.get_session_data(session_id, "channel"),
                 text=text,
                 audio_data=data,
                 audio_duration=recorded_duration,
@@ -357,6 +364,11 @@ class STSPipeline:
                     logger.info(f"Recognized text from request: {recognized_text}")
             else:
                 recognized_text = ""    # Request without both text and audio (e.g. image only)
+
+            # Insert channel tag
+            if self.insert_channel_tag and request.channel and recognized_text:
+                recognized_text = f"<channel name='{request.channel}' />{recognized_text}"
+
             request.text = recognized_text
 
             if self._validate_request:
@@ -491,6 +503,9 @@ class STSPipeline:
                                 await handler(request)
                     performance.llm_time = time() - start_time
 
+                    if not llm_stream_chunk.text:
+                        continue
+
                     # Parse language
                     if match := LANGUAGE_PATTERN.search(llm_stream_chunk.text):
                         language = match.group(1) or match.group(2)
@@ -502,11 +517,14 @@ class STSPipeline:
                         request.user_id,
                     )
 
-                    audio_chunk = await self.tts.synthesize(
-                        text=llm_stream_chunk.voice_text,
-                        style_info={"styled_text": llm_stream_chunk.text, "info": parsed_info or {}},
-                        language=language
-                    )
+                    if request.channel in self.skip_tts_channels:
+                        audio_chunk = None
+                    else:
+                        audio_chunk = await self.tts.synthesize(
+                            text=llm_stream_chunk.voice_text,
+                            style_info={"styled_text": llm_stream_chunk.text, "info": parsed_info or {}},
+                            language=language
+                        )
 
                     # TTS performance
                     if audio_chunk:


### PR DESCRIPTION
- Pipeline can auto-insert `<channel name='...' />` tag into LLM input based on request channel.
- TTS can be skipped for specific channels (e.g. SMS) to avoid unnecessary speech synthesis.
- Twilio adapter skips TTS for SMS by default.