### PR TITLE
Support Hermes agent and add on_stream_chunk handler to OpenClawTool

### DIFF
--- a/aiavatar/sts/llm/tools/openclaw_tool.py
+++ b/aiavatar/sts/llm/tools/openclaw_tool.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Callable
 import openai
 from .. import Tool
 
@@ -12,6 +13,8 @@ class OpenClawTool(Tool):
         openclaw_api_key: str,
         openclaw_base_url: str = None,
         openclaw_session_key: str = None,
+        openclaw_session_key_key: str = "x-openclaw-session-key",   # set "X-Hermes-Session-Id" for Hermes
+        stream: bool = False,
         immediate_message: str = "Accepted. You will be notified when the response is ready.",
         timeout: int = 30000,
         name=None,
@@ -26,7 +29,10 @@ class OpenClawTool(Tool):
             timeout=timeout
         )
         self.openclaw_session_key = openclaw_session_key
+        self.openclaw_session_key_key = openclaw_session_key_key
+        self.stream = stream
         self.debug = debug
+        self._on_stream_chunk: Callable = None
 
         super().__init__(
             name or "send_query_to_openclaw",
@@ -50,24 +56,50 @@ class OpenClawTool(Tool):
             immediate_message=immediate_message
         )
 
-    async def _call_openclaw_api(self, query: str) -> str:
+    def on_stream_chunk(self, func: Callable):
+        self._on_stream_chunk = func
+        return func
+
+    async def _call_openclaw_api(self, query: str, context_id: str) -> str:
         if self.debug:
             logger.info(f"Request to OpenClaw: {query}")
-        resp = await self.openai_client.chat.completions.create(
-            messages=[{"role": "user", "content": query}],
-            model="openclaw",
-            extra_headers={
-                "x-openclaw-session-key": self.openclaw_session_key or "agent:main:main"
-            }
-        )
-        answer = resp.choices[0].message.content
+
+        if self.stream:
+            stream = await self.openai_client.chat.completions.create(
+                messages=[{"role": "user", "content": query}],
+                model="hermes-agent",
+                stream=True,
+                extra_headers={
+                    self.openclaw_session_key_key: context_id or self.openclaw_session_key
+                }
+            )
+            chunks = []
+            async for chunk in stream:
+                if self._on_stream_chunk:
+                    await self._on_stream_chunk(chunk)
+                delta = chunk.choices[0].delta if chunk.choices else None
+                if delta and delta.content:
+                    chunks.append(delta.content)
+            answer = "".join(chunks)
+
+        else:
+            resp = await self.openai_client.chat.completions.create(
+                messages=[{"role": "user", "content": query}],
+                model="openclaw",
+                extra_headers={
+                    self.openclaw_session_key_key: context_id or self.openclaw_session_key
+                }
+            )
+            answer = resp.choices[0].message.content
+
         if self.debug:
             logger.info(f"Response from OpenClaw: {answer}")
         return answer
 
     async def invoke_openclaw(self, query: str, metadata: dict = None):
         try:
-            answer = await self._call_openclaw_api(query)
+            context_id = metadata["context_id"]
+            answer = await self._call_openclaw_api(query, context_id)
             return {"answer": answer}
         except Exception:
             logger.exception("Error at invoke_openclaw")


### PR DESCRIPTION
OpenClawTool now works with both OpenClaw 🦞 and Hermes ☤ by allowing the session header key to be overridden via `openclaw_session_key_key`.

Added on_stream_chunk decorator to handle intermediate stream chunks (tool usage, code execution, etc.) instead of logging them directly.