### PR TITLE
Propagate session_id and channel to tool metadata

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -371,7 +371,7 @@ The list of tools is as follows:
         return []
 
     @abstractmethod
-    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         pass
 
     def parse_tool_names(self, text: str) -> str:
@@ -504,7 +504,7 @@ The list of tools is as follows:
         
         return None
 
-    async def chat_stream(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def chat_stream(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, any] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         if self._print_chat:
             self._print_chat("user", context_id, user_id, text, files)
         else:
@@ -585,7 +585,7 @@ The list of tools is as follows:
 
             return None
 
-        async for chunk in self.get_llm_stream_response(context_id, user_id, messages, system_prompt_params, inline_llm_params=inline_llm_params):
+        async for chunk in self.get_llm_stream_response(context_id, user_id, messages, system_prompt_params, inline_llm_params=inline_llm_params, session_id=session_id, channel=channel):
             if chunk.error_info:
                 if self._on_error:
                     await self._on_error(chunk)
@@ -756,7 +756,7 @@ class LLMServiceDummy(LLMService):
         messages.append({"role": "assistant", "content": response_text})
         await self.context_manager.add_histories(context_id, messages, "dummy")
 
-    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         await asyncio.sleep(self.wait_sec)
         yield LLMResponse(
             context_id=context_id,

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -220,7 +220,7 @@ class ChatGPTService(LLMService):
 
         return tools
 
-    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         # Prepare all tools list (always include all tools)
         all_tools = [t.spec for _, t in self.tools.items()]
         if self.use_dynamic_tools:
@@ -347,7 +347,7 @@ class ChatGPTService(LLMService):
                     if not filtered_tools:
                         tool_result = {"message": "No tools found"}
                 else:
-                    async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id}):
+                    async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
                         tc.result = tr
                         if tr.text:
                             yield LLMResponse(context_id=context_id, text=tr.text)
@@ -389,6 +389,6 @@ class ChatGPTService(LLMService):
             if not has_direct_response and (len(messages) > messages_length or try_dynamic_tools):
                 # Generate human-friendly message that explains tool result
                 async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools
+                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
                 ):
                     yield llm_response

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -171,7 +171,7 @@ class ClaudeService(LLMService):
 
         return tools
 
-    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         # Select tools to use
         tool_instruction = ""
         if tools:
@@ -269,7 +269,7 @@ class ClaudeService(LLMService):
                     if not filtered_tools:
                         tool_result = {"message": "No tools found"}
                 else:
-                    async for tr in self.execute_tool(tc.name, arguments_json, {"context_id": context_id, "user_id": user_id}):
+                    async for tr in self.execute_tool(tc.name, arguments_json, {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
                         tc.result = tr
                         if tr.text:
                             yield LLMResponse(context_id=context_id, text=tr.text)
@@ -319,6 +319,6 @@ class ClaudeService(LLMService):
             if not has_direct_response and (len(messages) > messages_length or try_dynamic_tools):
                 # Generate human-friendly message that explains tool result
                 async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools
+                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
                 ):
                     yield llm_response

--- a/aiavatar/sts/llm/dify.py
+++ b/aiavatar/sts/llm/dify.py
@@ -93,7 +93,7 @@ class DifyService(LLMService):
         await self.context_manager.add_histories(context_id, [{}], "dify")
 
 
-    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         headers = {
             "Authorization": f"Bearer {self.api_key}"
         }

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -225,7 +225,7 @@ class GeminiService(LLMService):
 
         return tools
 
-    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         if self.thinking_level:
             thinking_config = types.ThinkingConfig(
                 thinking_level=self.thinking_level
@@ -346,7 +346,7 @@ class GeminiService(LLMService):
                         tool_names = [t["functionDeclarations"][0]["name"] for t in filtered_tools]
                         logger.info(f"Execute tool: {tc.name} / tools: {tool_names}")
 
-                    async for tr in self.execute_tool(tc.name, tc.arguments, {"context_id": context_id, "user_id": user_id}):
+                    async for tr in self.execute_tool(tc.name, tc.arguments, {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
                         tc.result = tr
                         if tr.text:
                             yield LLMResponse(context_id=context_id, text=tr.text)
@@ -379,6 +379,6 @@ class GeminiService(LLMService):
             if not has_direct_response and (len(messages) > messages_length or try_dynamic_tools):
                 # Generate human-friendly message that explains tool result
                 async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools
+                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
                 ):
                     yield llm_response

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -193,7 +193,7 @@ class LiteLLMService(LLMService):
 
         return tools
 
-    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         # Select tools to use
         tool_instruction = ""
         if tools:
@@ -292,7 +292,7 @@ class LiteLLMService(LLMService):
                     if not filtered_tools:
                         tool_result = {"message": "No tools found"}
                 else:
-                    async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id}):
+                    async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
                         tc.result = tr
                         if tr.text:
                             yield LLMResponse(context_id=context_id, text=tr.text)
@@ -335,6 +335,6 @@ class LiteLLMService(LLMService):
             if not has_direct_response and (len(messages) > messages_length or try_dynamic_tools):
                 # Generate human-friendly message that explains tool result
                 async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools
+                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
                 ):
                     yield llm_response

--- a/aiavatar/sts/llm/openai_responses.py
+++ b/aiavatar/sts/llm/openai_responses.py
@@ -134,7 +134,7 @@ class OpenAIResponsesService(LLMService):
             tool_to_add.is_dynamic = is_dynamic
         self.tools[tool_to_add.name] = tool_to_add
 
-    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         # Build tools list
         all_tools = [t.spec for _, t in self.tools.items()]
 
@@ -231,7 +231,7 @@ class OpenAIResponsesService(LLMService):
                 yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
 
                 tool_result = None
-                async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id}):
+                async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
                     tc.result = tr
                     if tr.text:
                         yield LLMResponse(context_id=context_id, text=tr.text)
@@ -261,6 +261,6 @@ class OpenAIResponsesService(LLMService):
             if not has_direct_response and tool_outputs:
                 # Send tool results back via recursive call with previous_response_id
                 async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, tool_outputs, system_prompt_params=system_prompt_params
+                    context_id, user_id, tool_outputs, system_prompt_params=system_prompt_params, session_id=session_id, channel=channel
                 ):
                     yield llm_response

--- a/aiavatar/sts/llm/openai_responses_websocket.py
+++ b/aiavatar/sts/llm/openai_responses_websocket.py
@@ -244,7 +244,7 @@ class OpenAIResponsesWebSocketService(LLMService):
 
         return message
 
-    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:
+    async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[Dict], system_prompt_params: Dict[str, any] = None, tools: List[Dict[str, any]] = None, inline_llm_params: Dict[str, any] = None, session_id: str = None, channel: str = None) -> AsyncGenerator[LLMResponse, None]:
         # System prompt
         system_prompt = await self._get_system_prompt(context_id, user_id, system_prompt_params)
 
@@ -329,7 +329,7 @@ class OpenAIResponsesWebSocketService(LLMService):
                         yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
 
                         tool_result = None
-                        async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id}):
+                        async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
                             tc.result = tr
                             if tr.text:
                                 yield LLMResponse(context_id=context_id, text=tr.text)

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -469,7 +469,15 @@ class STSPipeline:
                     metadata={"is_quick_response": True, "is_first_chunk": True}
                 )
 
-            llm_stream = self.llm.chat_stream(request.context_id, request.user_id, request.text, request.files, request.system_prompt_params)
+            llm_stream = self.llm.chat_stream(
+                context_id=request.context_id,
+                user_id=request.user_id,
+                text=request.text,
+                files=request.files,
+                system_prompt_params=request.system_prompt_params,
+                session_id=request.session_id,
+                channel=request.channel
+            )
 
             # TTS
             async def synthesize_stream() -> AsyncGenerator[Tuple[bytes, LLMResponse], None]:


### PR DESCRIPTION
Pass `session_id` and `channel` through the LLM service layer into `execute_tool` metadata, allowing `on_completed` callbacks to route background task results back to the originating adapter and session.