### PR TITLE
Add progress tracking for background tool execution

### DIFF
--- a/aiavatar/sts/llm/tools/openclaw_tool.py
+++ b/aiavatar/sts/llm/tools/openclaw_tool.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Callable
+from typing import Callable, Dict, List
+from uuid import uuid4
 import openai
 from .. import Tool
 
@@ -33,6 +34,7 @@ class OpenClawTool(Tool):
         self.stream = stream
         self.debug = debug
         self._on_stream_chunk: Callable = None
+        self._running_tasks: Dict[str, dict] = {}
 
         super().__init__(
             name or "send_query_to_openclaw",
@@ -60,7 +62,67 @@ class OpenClawTool(Tool):
         self._on_stream_chunk = func
         return func
 
-    async def _call_openclaw_api(self, query: str, context_id: str) -> str:
+    # Running tasks management
+
+    def add_running_task(self, request: str, metadata: dict, progress: str = None) -> str:
+        task_id = str(uuid4())
+        self._running_tasks[task_id] = {
+            "context_id": metadata.get("context_id"),
+            "user_id": metadata.get("user_id"),
+            "session_id": metadata.get("session_id"),
+            "channel": metadata.get("channel"),
+            "request": request,
+            "progress": progress or "",
+        }
+        return task_id
+
+    def get_running_tasks(self, context_id: str = None, user_id: str = None) -> List[dict]:
+        return [
+            {"request": t["request"], "progress": t["progress"]}
+            for t in self._running_tasks.values()
+            if (context_id and t["context_id"] == context_id)
+            or (user_id and t["user_id"] == user_id)
+        ]
+
+    def remove_running_task(self, task_id: str):
+        self._running_tasks.pop(task_id, None)
+
+    def add_progress(self, task_id: str, progress: str):
+        if task_id in self._running_tasks:
+            self._running_tasks[task_id]["progress"] += progress
+            if self.debug:
+                logger.info(f"OpenClaw progress: {progress}")
+
+    def create_check_tool(self, name: str = "check_running_openclaw_tasks", description: str = None) -> Tool:
+        openclaw_tool = self
+
+        async def check(metadata: dict = None):
+            tasks = openclaw_tool.get_running_tasks(
+                context_id=metadata.get("context_id"),
+                user_id=metadata.get("user_id"),
+            )
+            if tasks:
+                return {"running_tasks": tasks}
+            else:
+                return {"running_tasks": [], "message": "No running tasks."}
+
+        return Tool(
+            name=name,
+            spec={
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description or "Check the progress of running background tasks.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                    },
+                }
+            },
+            func=check,
+        )
+
+    async def _call_openclaw_api(self, query: str, context_id: str, task_id: str = None) -> str:
         if self.debug:
             logger.info(f"Request to OpenClaw: {query}")
 
@@ -75,6 +137,17 @@ class OpenClawTool(Tool):
             )
             chunks = []
             async for chunk in stream:
+                if task_id and hasattr(chunk, "tool"):
+                    progress_line = ""
+                    if tool := chunk.tool:
+                        emoji = chunk.emoji or ""
+                        progress_line = f"- {emoji} {tool}"
+                        if label := chunk.label:
+                            progress_line += f": {label}"
+                        progress_line += "\n"
+                    if progress_line:
+                        self.add_progress(task_id, progress_line)
+
                 if self._on_stream_chunk:
                     await self._on_stream_chunk(chunk)
                 delta = chunk.choices[0].delta if chunk.choices else None
@@ -97,10 +170,13 @@ class OpenClawTool(Tool):
         return answer
 
     async def invoke_openclaw(self, query: str, metadata: dict = None):
+        context_id = metadata.get("context_id", "")
+        task_id = self.add_running_task(request=query, metadata=metadata, progress="Start processing...\n")
         try:
-            context_id = metadata["context_id"]
-            answer = await self._call_openclaw_api(query, context_id)
+            answer = await self._call_openclaw_api(query, context_id, task_id)
             return {"answer": answer}
         except Exception:
             logger.exception("Error at invoke_openclaw")
             return {"answer": "Error"}
+        finally:
+            self.remove_running_task(task_id)

--- a/tests/sts/llm/tools/test_openclaw_running_tasks.py
+++ b/tests/sts/llm/tools/test_openclaw_running_tasks.py
@@ -1,0 +1,186 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from aiavatar.sts.llm.tools.openclaw_tool import OpenClawTool
+from aiavatar.sts.llm.base import LLMServiceDummy
+
+
+def make_openclaw_tool(**kwargs):
+    return OpenClawTool(
+        openclaw_api_key="test-key",
+        openclaw_base_url="http://localhost:9999",
+        **kwargs,
+    )
+
+
+# --- Running tasks store ---
+
+def test_add_and_get_running_task():
+    tool = make_openclaw_tool()
+    task_id = tool.add_running_task("Search weather", {"context_id": "ctx1", "user_id": "user1"}, "Searching...")
+
+    tasks = tool.get_running_tasks(context_id="ctx1")
+    assert len(tasks) == 1
+    assert tasks[0] == {"request": "Search weather", "progress": "Searching..."}
+    assert task_id in tool._running_tasks
+
+
+def test_add_progress():
+    tool = make_openclaw_tool()
+    task_id = tool.add_running_task("Search weather", {"context_id": "ctx1", "user_id": "user1"}, "Starting...")
+    tool.add_progress(task_id, "Almost done...")
+
+    tasks = tool.get_running_tasks(context_id="ctx1")
+    assert tasks[0]["progress"] == "Starting...Almost done..."
+
+
+def test_add_progress_nonexistent_task_is_noop():
+    tool = make_openclaw_tool()
+    tool.add_progress("nonexistent", "progress")
+    assert len(tool._running_tasks) == 0
+
+
+def test_remove_running_task():
+    tool = make_openclaw_tool()
+    task_id = tool.add_running_task("Search weather", {"context_id": "ctx1", "user_id": "user1"})
+    tool.remove_running_task(task_id)
+
+    assert len(tool._running_tasks) == 0
+    assert tool.get_running_tasks(context_id="ctx1") == []
+
+
+def test_remove_nonexistent_task_is_noop():
+    tool = make_openclaw_tool()
+    tool.remove_running_task("nonexistent")  # should not raise
+
+
+def test_get_running_tasks_by_context_id():
+    tool = make_openclaw_tool()
+    tool.add_running_task("Task A", {"context_id": "ctx1", "user_id": "user1"}, "Running")
+    tool.add_running_task("Task B", {"context_id": "ctx2", "user_id": "user1"}, "Running")
+    tool.add_running_task("Task C", {"context_id": "ctx1", "user_id": "user2"}, "Running")
+
+    tasks = tool.get_running_tasks(context_id="ctx1")
+    assert len(tasks) == 2
+    requests = {t["request"] for t in tasks}
+    assert requests == {"Task A", "Task C"}
+
+
+def test_get_running_tasks_by_user_id():
+    tool = make_openclaw_tool()
+    tool.add_running_task("Task A", {"context_id": "ctx1", "user_id": "user1"}, "Running")
+    tool.add_running_task("Task B", {"context_id": "ctx2", "user_id": "user2"}, "Running")
+    tool.add_running_task("Task C", {"context_id": "ctx3", "user_id": "user1"}, "Running")
+
+    tasks = tool.get_running_tasks(user_id="user1")
+    assert len(tasks) == 2
+    requests = {t["request"] for t in tasks}
+    assert requests == {"Task A", "Task C"}
+
+
+def test_get_running_tasks_empty():
+    tool = make_openclaw_tool()
+    assert tool.get_running_tasks(context_id="ctx1") == []
+
+
+def test_multiple_tasks_remove_one():
+    tool = make_openclaw_tool()
+    id1 = tool.add_running_task("Task A", {"context_id": "ctx1", "user_id": "user1"}, "Running")
+    id2 = tool.add_running_task("Task B", {"context_id": "ctx1", "user_id": "user1"}, "Running")
+
+    tool.remove_running_task(id1)
+
+    tasks = tool.get_running_tasks(context_id="ctx1")
+    assert len(tasks) == 1
+    assert tasks[0]["request"] == "Task B"
+
+
+# --- invoke_openclaw integration ---
+
+@pytest.mark.asyncio
+async def test_invoke_openclaw_registers_and_removes_task():
+    tool = make_openclaw_tool()
+
+    with patch.object(tool, "_call_openclaw_api", new_callable=AsyncMock) as mock_api:
+        mock_api.return_value = "sunny"
+
+        result = await tool.invoke_openclaw("weather?", {"context_id": "ctx1", "user_id": "user1"})
+
+    assert result == {"answer": "sunny"}
+    # Task should be removed after completion
+    assert tool.get_running_tasks(context_id="ctx1") == []
+
+
+@pytest.mark.asyncio
+async def test_invoke_openclaw_task_visible_during_execution():
+    tool = make_openclaw_tool()
+    captured_tasks = []
+
+    async def mock_api(query, context_id, task_id=None):
+        # Capture running tasks during execution
+        captured_tasks.extend(tool.get_running_tasks(context_id="ctx1"))
+        return "result"
+
+    with patch.object(tool, "_call_openclaw_api", side_effect=mock_api):
+        await tool.invoke_openclaw("do something", {"context_id": "ctx1", "user_id": "user1"})
+
+    # Task was visible during execution
+    assert len(captured_tasks) == 1
+    assert captured_tasks[0]["request"] == "do something"
+    assert captured_tasks[0]["progress"] == "Start processing...\n"
+
+    # Task removed after execution
+    assert tool.get_running_tasks(context_id="ctx1") == []
+
+
+@pytest.mark.asyncio
+async def test_invoke_openclaw_removes_task_on_error():
+    tool = make_openclaw_tool()
+
+    with patch.object(tool, "_call_openclaw_api", new_callable=AsyncMock) as mock_api:
+        mock_api.side_effect = RuntimeError("API error")
+
+        result = await tool.invoke_openclaw("fail", {"context_id": "ctx1", "user_id": "user1"})
+
+    assert result == {"answer": "Error"}
+    # Task should be removed even on error
+    assert tool.get_running_tasks(context_id="ctx1") == []
+
+
+# --- create_check_tool ---
+
+@pytest.mark.asyncio
+async def test_create_check_tool_returns_running_tasks():
+    tool = make_openclaw_tool()
+    check_tool = tool.create_check_tool()
+
+    tool.add_running_task("Search weather", {"context_id": "ctx1", "user_id": "user1"}, "Searching...")
+
+    result = await check_tool.func(metadata={"context_id": "ctx1", "user_id": "user1"})
+    assert result == {"running_tasks": [{"request": "Search weather", "progress": "Searching..."}]}
+
+
+@pytest.mark.asyncio
+async def test_create_check_tool_returns_empty():
+    tool = make_openclaw_tool()
+    check_tool = tool.create_check_tool()
+
+    result = await check_tool.func(metadata={"context_id": "ctx1", "user_id": "user1"})
+    assert result == {"running_tasks": [], "message": "No running tasks."}
+
+
+def test_create_check_tool_spec():
+    tool = make_openclaw_tool()
+    check_tool = tool.create_check_tool()
+
+    assert check_tool.name == "check_running_openclaw_tasks"
+    assert check_tool.spec["type"] == "function"
+    assert check_tool.spec["function"]["name"] == "check_running_openclaw_tasks"
+
+
+def test_create_check_tool_custom_name():
+    tool = make_openclaw_tool()
+    check_tool = tool.create_check_tool(name="my_check", description="Custom desc")
+
+    assert check_tool.name == "my_check"
+    assert check_tool.spec["function"]["description"] == "Custom desc"


### PR DESCRIPTION
Enable users to check the progress of running background tasks during conversation. When a tool like OpenClaw is processing asynchronously, the LLM can now report what's happening by calling a check tool that returns current request and progress info per context/user.