### PR TITLE
Support per-user OpenClaw/Hermes configurations

### DIFF
--- a/aiavatar/sts/llm/tools/openclaw_tool.py
+++ b/aiavatar/sts/llm/tools/openclaw_tool.py
@@ -7,14 +7,33 @@ from .. import Tool
 logger = logging.getLogger(__name__)
 
 
+class OpenClawConfig:
+    def __init__(
+        self,
+        *,
+        openclaw_api_key: str = None,
+        openclaw_base_url: str = None,
+        openclaw_session_key: str = None,
+        openclaw_session_key_key: str = None,
+        openclaw_model: str = None
+    ):
+        self.openclaw_api_key = openclaw_api_key
+        self.openclaw_base_url = openclaw_base_url
+        self.openclaw_session_key = openclaw_session_key
+        self.openclaw_session_key_key = openclaw_session_key_key
+        self.openclaw_model = openclaw_model
+
+
 class OpenClawTool(Tool):
     def __init__(
         self,
         *,
-        openclaw_api_key: str,
+        openclaw_api_key: str = None,
         openclaw_base_url: str = None,
         openclaw_session_key: str = None,
         openclaw_session_key_key: str = "x-openclaw-session-key",   # set "X-Hermes-Session-Id" for Hermes
+        openclaw_model: str = "openclaw",   # set "hermes-agent" for Hermes
+        openclaw_configs: Dict[str, OpenClawConfig] = None,
         stream: bool = False,
         immediate_message: str = "Accepted. You will be notified when the response is ready.",
         timeout: int = 30000,
@@ -24,13 +43,13 @@ class OpenClawTool(Tool):
         is_dynamic=False,
         debug: bool = False,
     ):
-        self.openai_client = openai.AsyncClient(
-            api_key=openclaw_api_key,
-            base_url=openclaw_base_url,
-            timeout=timeout
-        )
+        self.openclaw_api_key = openclaw_api_key
+        self.openclaw_base_url = openclaw_base_url
         self.openclaw_session_key = openclaw_session_key
         self.openclaw_session_key_key = openclaw_session_key_key
+        self.openclaw_model = openclaw_model
+        self.openclaw_configs = openclaw_configs or {}
+        self.timeout = timeout
         self.stream = stream
         self.debug = debug
         self._on_stream_chunk: Callable = None
@@ -122,48 +141,76 @@ class OpenClawTool(Tool):
             func=check,
         )
 
-    async def _call_openclaw_api(self, query: str, context_id: str, task_id: str = None) -> str:
+    def get_openclaw_config(self, user_id: str) -> OpenClawConfig:
+        config = OpenClawConfig()
+        user_config = self.openclaw_configs.get(user_id) or config
+        config.openclaw_api_key = user_config.openclaw_api_key or self.openclaw_api_key
+        config.openclaw_base_url = user_config.openclaw_base_url or self.openclaw_base_url
+        config.openclaw_session_key = user_config.openclaw_session_key or self.openclaw_session_key
+        config.openclaw_session_key_key = user_config.openclaw_session_key_key or self.openclaw_session_key_key
+        config.openclaw_model = user_config.openclaw_model or self.openclaw_model
+        return config
+
+    def update_openclaw_config(self, user_id: str, config: OpenClawConfig):
+        self.delete_openclaw_config(user_id)
+        self.openclaw_configs[user_id] = config
+
+    def delete_openclaw_config(self, user_id: str):
+        if user_id in self.openclaw_configs:
+            del self.openclaw_configs[user_id]
+
+    async def _call_openclaw_api(self, query: str, context_id: str, user_id: str, task_id: str) -> str:
         if self.debug:
-            logger.info(f"Request to OpenClaw: {query}")
+            logger.info(f"Request to OpenClaw (from {user_id}): {query}")
 
-        if self.stream:
-            stream = await self.openai_client.chat.completions.create(
-                messages=[{"role": "user", "content": query}],
-                model="hermes-agent",
-                stream=True,
-                extra_headers={
-                    self.openclaw_session_key_key: context_id or self.openclaw_session_key
-                }
-            )
-            chunks = []
-            async for chunk in stream:
-                if task_id and hasattr(chunk, "tool"):
-                    progress_line = ""
-                    if tool := chunk.tool:
-                        emoji = chunk.emoji or ""
-                        progress_line = f"- {emoji} {tool}"
-                        if label := chunk.label:
-                            progress_line += f": {label}"
-                        progress_line += "\n"
-                    if progress_line:
-                        self.add_progress(task_id, progress_line)
+        config = self.get_openclaw_config(user_id)
+        client = openai.AsyncClient(
+            api_key=config.openclaw_api_key,
+            base_url=config.openclaw_base_url,
+            timeout=self.timeout
+        )
 
-                if self._on_stream_chunk:
-                    await self._on_stream_chunk(chunk)
-                delta = chunk.choices[0].delta if chunk.choices else None
-                if delta and delta.content:
-                    chunks.append(delta.content)
-            answer = "".join(chunks)
+        try:
+            if self.stream:
+                stream = await client.chat.completions.create(
+                    messages=[{"role": "user", "content": query}],
+                    model=config.openclaw_model,
+                    stream=True,
+                    extra_headers={
+                        config.openclaw_session_key_key: context_id or config.openclaw_session_key
+                    }
+                )
+                chunks = []
+                async for chunk in stream:
+                    if task_id and hasattr(chunk, "tool"):
+                        progress_line = ""
+                        if tool := chunk.tool:
+                            emoji = chunk.emoji or ""
+                            progress_line = f"- {emoji} {tool}"
+                            if label := chunk.label:
+                                progress_line += f": {label}"
+                            progress_line += "\n"
+                        if progress_line:
+                            self.add_progress(task_id, progress_line)
 
-        else:
-            resp = await self.openai_client.chat.completions.create(
-                messages=[{"role": "user", "content": query}],
-                model="openclaw",
-                extra_headers={
-                    self.openclaw_session_key_key: context_id or self.openclaw_session_key
-                }
-            )
-            answer = resp.choices[0].message.content
+                    if self._on_stream_chunk:
+                        await self._on_stream_chunk(task_id, chunk)
+                    delta = chunk.choices[0].delta if chunk.choices else None
+                    if delta and delta.content:
+                        chunks.append(delta.content)
+                answer = "".join(chunks)
+
+            else:
+                resp = await client.chat.completions.create(
+                    messages=[{"role": "user", "content": query}],
+                    model=config.openclaw_model,
+                    extra_headers={
+                        config.openclaw_session_key_key: context_id or config.openclaw_session_key
+                    }
+                )
+                answer = resp.choices[0].message.content
+        finally:
+            await client.close()
 
         if self.debug:
             logger.info(f"Response from OpenClaw: {answer}")
@@ -171,9 +218,16 @@ class OpenClawTool(Tool):
 
     async def invoke_openclaw(self, query: str, metadata: dict = None):
         context_id = metadata.get("context_id", "")
+        user_id = metadata.get("user_id", "")
+
+        config = self.get_openclaw_config(user_id)
+        if not config.openclaw_base_url:
+            logger.warning(f"OpenClaw base_url is not configured for user: {user_id}")
+            return {"answer": "OpenClaw is not configured for this user. Please set up your OpenClaw connection first."}
+
         task_id = self.add_running_task(request=query, metadata=metadata, progress="Start processing...\n")
         try:
-            answer = await self._call_openclaw_api(query, context_id, task_id)
+            answer = await self._call_openclaw_api(query, context_id, user_id, task_id)
             return {"answer": answer}
         except Exception:
             logger.exception("Error at invoke_openclaw")

--- a/tests/sts/llm/tools/test_openclaw_running_tasks.py
+++ b/tests/sts/llm/tools/test_openclaw_running_tasks.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
-from aiavatar.sts.llm.tools.openclaw_tool import OpenClawTool
+from aiavatar.sts.llm.tools.openclaw_tool import OpenClawTool, OpenClawConfig
 from aiavatar.sts.llm.base import LLMServiceDummy
 
 
@@ -116,7 +116,7 @@ async def test_invoke_openclaw_task_visible_during_execution():
     tool = make_openclaw_tool()
     captured_tasks = []
 
-    async def mock_api(query, context_id, task_id=None):
+    async def mock_api(query, context_id, user_id, task_id):
         # Capture running tasks during execution
         captured_tasks.extend(tool.get_running_tasks(context_id="ctx1"))
         return "result"
@@ -184,3 +184,267 @@ def test_create_check_tool_custom_name():
 
     assert check_tool.name == "my_check"
     assert check_tool.spec["function"]["description"] == "Custom desc"
+
+
+# --- Per-user OpenClaw config ---
+
+def test_get_openclaw_config_defaults_when_no_user_config():
+    tool = make_openclaw_tool(
+        openclaw_session_key="default-session",
+        openclaw_session_key_key="x-openclaw-session-key",
+        openclaw_model="openclaw",
+    )
+    config = tool.get_openclaw_config("unknown_user")
+
+    assert config.openclaw_api_key == "test-key"
+    assert config.openclaw_base_url == "http://localhost:9999"
+    assert config.openclaw_session_key == "default-session"
+    assert config.openclaw_session_key_key == "x-openclaw-session-key"
+    assert config.openclaw_model == "openclaw"
+
+
+def test_get_openclaw_config_partial_override():
+    tool = make_openclaw_tool(
+        openclaw_session_key="default-session",
+        openclaw_session_key_key="x-openclaw-session-key",
+        openclaw_model="openclaw",
+        openclaw_configs={
+            "user1": OpenClawConfig(
+                openclaw_api_key="user1-key",
+                openclaw_base_url="http://user1-server:8000",
+            ),
+        },
+    )
+    config = tool.get_openclaw_config("user1")
+
+    # Overridden by user config
+    assert config.openclaw_api_key == "user1-key"
+    assert config.openclaw_base_url == "http://user1-server:8000"
+    # Falls back to tool defaults
+    assert config.openclaw_session_key == "default-session"
+    assert config.openclaw_session_key_key == "x-openclaw-session-key"
+    assert config.openclaw_model == "openclaw"
+
+
+def test_get_openclaw_config_full_override():
+    tool = make_openclaw_tool(
+        openclaw_session_key="default-session",
+        openclaw_session_key_key="x-openclaw-session-key",
+        openclaw_model="openclaw",
+        openclaw_configs={
+            "user1": OpenClawConfig(
+                openclaw_api_key="user1-key",
+                openclaw_base_url="http://user1-hermes:8000",
+                openclaw_session_key="user1-session",
+                openclaw_session_key_key="X-Hermes-Session-Id",
+                openclaw_model="hermes-agent",
+            ),
+        },
+    )
+    config = tool.get_openclaw_config("user1")
+
+    assert config.openclaw_api_key == "user1-key"
+    assert config.openclaw_base_url == "http://user1-hermes:8000"
+    assert config.openclaw_session_key == "user1-session"
+    assert config.openclaw_session_key_key == "X-Hermes-Session-Id"
+    assert config.openclaw_model == "hermes-agent"
+
+
+def test_get_openclaw_config_different_users_get_different_configs():
+    tool = make_openclaw_tool(
+        openclaw_session_key="default-session",
+        openclaw_session_key_key="x-openclaw-session-key",
+        openclaw_model="openclaw",
+        openclaw_configs={
+            "user1": OpenClawConfig(openclaw_api_key="key-1", openclaw_base_url="http://server-1"),
+            "user2": OpenClawConfig(openclaw_api_key="key-2", openclaw_model="hermes-agent"),
+        },
+    )
+
+    c1 = tool.get_openclaw_config("user1")
+    c2 = tool.get_openclaw_config("user2")
+
+    assert c1.openclaw_api_key == "key-1"
+    assert c1.openclaw_base_url == "http://server-1"
+    assert c1.openclaw_model == "openclaw"  # fallback
+
+    assert c2.openclaw_api_key == "key-2"
+    assert c2.openclaw_base_url == "http://localhost:9999"  # fallback
+    assert c2.openclaw_model == "hermes-agent"
+
+
+def test_update_openclaw_config():
+    tool = make_openclaw_tool()
+    tool.update_openclaw_config("user1", OpenClawConfig(openclaw_api_key="new-key"))
+
+    config = tool.get_openclaw_config("user1")
+    assert config.openclaw_api_key == "new-key"
+
+
+def test_update_openclaw_config_replaces_existing():
+    tool = make_openclaw_tool(
+        openclaw_configs={
+            "user1": OpenClawConfig(openclaw_api_key="old-key"),
+        },
+    )
+    tool.update_openclaw_config("user1", OpenClawConfig(openclaw_api_key="new-key"))
+
+    config = tool.get_openclaw_config("user1")
+    assert config.openclaw_api_key == "new-key"
+
+
+def test_delete_openclaw_config():
+    tool = make_openclaw_tool(
+        openclaw_configs={
+            "user1": OpenClawConfig(openclaw_api_key="user1-key"),
+        },
+    )
+    tool.delete_openclaw_config("user1")
+
+    # Should fall back to tool defaults
+    config = tool.get_openclaw_config("user1")
+    assert config.openclaw_api_key == "test-key"
+
+
+def test_delete_openclaw_config_nonexistent_is_noop():
+    tool = make_openclaw_tool()
+    tool.delete_openclaw_config("nonexistent")  # should not raise
+
+
+# --- _call_openclaw_api uses per-user config ---
+
+@pytest.mark.asyncio
+async def test_call_openclaw_api_uses_user_config():
+    """Verify that _call_openclaw_api creates a client with per-user config values."""
+    tool = make_openclaw_tool(
+        openclaw_session_key="default-session",
+        openclaw_session_key_key="x-openclaw-session-key",
+        openclaw_model="openclaw",
+        openclaw_configs={
+            "user1": OpenClawConfig(
+                openclaw_api_key="user1-key",
+                openclaw_base_url="http://user1-server:8000",
+                openclaw_session_key_key="X-Hermes-Session-Id",
+                openclaw_model="hermes-agent",
+            ),
+        },
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock()]
+    mock_resp.choices[0].message.content = "user1 response"
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+    mock_client.close = AsyncMock()
+
+    with patch("aiavatar.sts.llm.tools.openclaw_tool.openai.AsyncClient", return_value=mock_client) as mock_ctor:
+        answer = await tool._call_openclaw_api("hello", "ctx1", "user1", "task1")
+
+    # Client created with user1's config
+    mock_ctor.assert_called_once_with(
+        api_key="user1-key",
+        base_url="http://user1-server:8000",
+        timeout=30000,
+    )
+    # API called with user1's model and header
+    call_kwargs = mock_client.chat.completions.create.call_args
+    assert call_kwargs.kwargs["model"] == "hermes-agent"
+    assert call_kwargs.kwargs["extra_headers"]["X-Hermes-Session-Id"] == "ctx1"
+    assert answer == "user1 response"
+    mock_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_call_openclaw_api_falls_back_to_defaults():
+    """Verify that _call_openclaw_api uses tool defaults for unknown users."""
+    tool = make_openclaw_tool(
+        openclaw_session_key="default-session",
+        openclaw_session_key_key="x-openclaw-session-key",
+        openclaw_model="openclaw",
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock()]
+    mock_resp.choices[0].message.content = "default response"
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+    mock_client.close = AsyncMock()
+
+    with patch("aiavatar.sts.llm.tools.openclaw_tool.openai.AsyncClient", return_value=mock_client) as mock_ctor:
+        answer = await tool._call_openclaw_api("hello", "ctx1", "unknown_user", "task1")
+
+    # Client created with tool defaults
+    mock_ctor.assert_called_once_with(
+        api_key="test-key",
+        base_url="http://localhost:9999",
+        timeout=30000,
+    )
+    call_kwargs = mock_client.chat.completions.create.call_args
+    assert call_kwargs.kwargs["model"] == "openclaw"
+    assert call_kwargs.kwargs["extra_headers"]["x-openclaw-session-key"] == "ctx1"
+    assert answer == "default response"
+
+
+@pytest.mark.asyncio
+async def test_call_openclaw_api_closes_client_on_error():
+    """Verify that client.close() is called even when the API call fails."""
+    tool = make_openclaw_tool()
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(side_effect=RuntimeError("API error"))
+    mock_client.close = AsyncMock()
+
+    with patch("aiavatar.sts.llm.tools.openclaw_tool.openai.AsyncClient", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="API error"):
+            await tool._call_openclaw_api("hello", "ctx1", "user1", "task1")
+
+    mock_client.close.assert_awaited_once()
+
+
+# --- base_url guard in invoke_openclaw ---
+
+@pytest.mark.asyncio
+async def test_invoke_openclaw_rejects_unconfigured_user():
+    """When no base_url is resolved for the user, return an error message without calling the API."""
+    tool = OpenClawTool(
+        openclaw_configs={
+            "configured_user": OpenClawConfig(
+                openclaw_api_key="key",
+                openclaw_base_url="http://server:8000",
+                openclaw_session_key_key="x-openclaw-session-key",
+                openclaw_model="openclaw",
+            ),
+        },
+        stream=False,
+    )
+
+    result = await tool.invoke_openclaw("hello", {"context_id": "ctx1", "user_id": "unknown_user"})
+
+    assert "not configured" in result["answer"].lower()
+    # No running task should remain
+    assert tool.get_running_tasks(user_id="unknown_user") == []
+
+
+@pytest.mark.asyncio
+async def test_invoke_openclaw_allows_configured_user():
+    """Configured user should pass the base_url check and call the API."""
+    tool = OpenClawTool(
+        openclaw_configs={
+            "user1": OpenClawConfig(
+                openclaw_api_key="key",
+                openclaw_base_url="http://server:8000",
+                openclaw_session_key_key="x-openclaw-session-key",
+                openclaw_model="openclaw",
+            ),
+        },
+        stream=False,
+    )
+
+    with patch.object(tool, "_call_openclaw_api", new_callable=AsyncMock) as mock_api:
+        mock_api.return_value = "success"
+        result = await tool.invoke_openclaw("hello", {"context_id": "ctx1", "user_id": "user1"})
+
+    assert result == {"answer": "success"}
+    mock_api.assert_awaited_once()


### PR DESCRIPTION
Allow each user to connect to their own OpenClaw or Hermes instance with independent API keys, base URLs, session keys, and models.