### PR TITLE
Fix Twilio adapter storing raw phone number as user_id in VAD session

### DIFF
--- a/aiavatar/adapter/twilio/server.py
+++ b/aiavatar/adapter/twilio/server.py
@@ -387,9 +387,6 @@ class AIAvatarTwilioServer(Adapter):
 
             user_id = session_data.caller
 
-            self.sts.vad.set_session_data(session_data.call_sid, "user_id", user_id, True)
-            self.sts.vad.set_session_data(session_data.call_sid, "channel", self.channel)
-
             logger.info(f"WebSocket connected for stream_sid: {stream_sid} / call_sid: {call_sid} / user_id: {user_id}")
 
             # Callback for session start (base class)
@@ -400,6 +397,9 @@ class AIAvatarTwilioServer(Adapter):
             )
             for on_session_start in self._on_session_start_handlers:
                 await on_session_start(request, session_data)
+
+            self.sts.vad.set_session_data(session_data.call_sid, "user_id", request.user_id, True)
+            self.sts.vad.set_session_data(session_data.call_sid, "channel", self.channel)
 
             if self._on_connect:
                 asyncio.create_task(self._on_connect(request, session_data))


### PR DESCRIPTION
Move `set_session_data` after `on_session_start` handlers so that the resolved `user_id` (UUID) from `channel_context_bridge` is stored in the VAD session instead of the raw phone number.

Previously, tools receiving `metadata` would get the phone number as `user_id`, causing channel user lookups to fail (e.g. outbound call fallback in `on_openclaw_response`).

This aligns with the WebSocket adapter which already applies `on_session_start` before setting VAD session data.