### PR TITLE
Insert channel tag for image-only messages without text

### DIFF
--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -365,10 +365,11 @@ class STSPipeline:
                 recognized_text = ""    # Request without both text and audio (e.g. image only)
 
             # Insert channel tag
-            if self.insert_channel_tag and request.channel and recognized_text:
-                recognized_text = f"<channel name='{request.channel}' />{recognized_text}"
-
-            request.text = recognized_text
+            if self.insert_channel_tag and request.channel:
+                channel_tag = f"<channel name='{request.channel}' />"
+                request.text = f"{channel_tag}{recognized_text}" if recognized_text else channel_tag
+            else:
+                request.text = recognized_text
 
             if self._validate_request:
                 if reason := await self._validate_request(request):

--- a/tests/sts/test_pipeline.py
+++ b/tests/sts/test_pipeline.py
@@ -1131,3 +1131,103 @@ async def test_invoke_queued_multiple_sessions():
     assert session_id_2 in sts._request_queues or session_id_2 not in sts._request_queues
 
     await sts.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_insert_channel_tag_with_text():
+    """Test that channel tag is inserted before text when insert_channel_tag=True"""
+    session_id = f"test_insert_channel_tag_with_text_{str(uuid4())}"
+
+    sts = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=ChatGPTService(
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            model="gpt-4o-mini",
+        ),
+        tts=SpeechSynthesizerDummy(),
+        insert_channel_tag=True,
+        performance_recorder=SQLitePerformanceRecorder(),
+        debug=True
+    )
+
+    request = STSRequest(
+        session_id=session_id,
+        user_id="test_user",
+        text="Hello",
+        channel="linebot"
+    )
+
+    async for response in sts.invoke(request):
+        pass
+
+    assert request.text == "<channel name='linebot' />Hello"
+
+    await sts.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_insert_channel_tag_without_text():
+    """Test that channel tag is set as text when image-only request (no text)"""
+    session_id = f"test_insert_channel_tag_without_text_{str(uuid4())}"
+
+    sts = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=ChatGPTService(
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            model="gpt-4o-mini",
+        ),
+        tts=SpeechSynthesizerDummy(),
+        insert_channel_tag=True,
+        performance_recorder=SQLitePerformanceRecorder(),
+        debug=True
+    )
+
+    request = STSRequest(
+        session_id=session_id,
+        user_id="test_user",
+        text="",
+        files=[{"url": "data:image/png;base64,iVBORw0KGgo="}],
+        channel="linebot"
+    )
+
+    async for response in sts.invoke(request):
+        pass
+
+    assert request.text == "<channel name='linebot' />"
+
+    await sts.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_insert_channel_tag_disabled():
+    """Test that channel tag is not inserted when insert_channel_tag=False"""
+    session_id = f"test_insert_channel_tag_disabled_{str(uuid4())}"
+
+    sts = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=ChatGPTService(
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            model="gpt-4o-mini",
+        ),
+        tts=SpeechSynthesizerDummy(),
+        insert_channel_tag=False,
+        performance_recorder=SQLitePerformanceRecorder(),
+        debug=True
+    )
+
+    request = STSRequest(
+        session_id=session_id,
+        user_id="test_user",
+        text="Hello",
+        channel="linebot"
+    )
+
+    async for response in sts.invoke(request):
+        pass
+
+    assert request.text == "Hello"
+
+    await sts.shutdown()


### PR DESCRIPTION
Channel tag is now added to image-only messages (e.g. from LINE Bot) when `insert_channel_tag` is enabled, allowing the LLM to identify the source channel even when no text accompanies the image.