### PR TITLE
Save conversation history locally in OpenAI Responses services

### DIFF
--- a/aiavatar/sts/llm/openai_responses.py
+++ b/aiavatar/sts/llm/openai_responses.py
@@ -93,8 +93,15 @@ class OpenAIResponsesService(LLMService):
         return messages
 
     async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
-        # Context is managed at OpenAI server via previous_response_id
-        await self.context_manager.add_histories(context_id, [{}], "openai_responses")
+        # Save context locally for reference by other processes (LLM context is managed at server via previous_response_id)
+        if self._update_context_filter:
+            if isinstance(messages[0]["content"], list):
+                if "text" in messages[0]["content"][-1]:
+                    messages[0]["content"][-1]["text"] = self._update_context_filter(messages[0]["content"][-1]["text"])
+            elif isinstance(messages[0]["content"], str):
+                messages[0]["content"] = self._update_context_filter(messages[0]["content"])
+        messages.append({"role": "assistant", "content": response_text})
+        await self.context_manager.add_histories(context_id, messages, "openai_responses")
 
     def tool(self, spec: Dict):
         def decorator(func):

--- a/aiavatar/sts/llm/openai_responses_websocket.py
+++ b/aiavatar/sts/llm/openai_responses_websocket.py
@@ -178,8 +178,15 @@ class OpenAIResponsesWebSocketService(LLMService):
         return messages
 
     async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
-        # Context is managed at OpenAI server via previous_response_id
-        await self.context_manager.add_histories(context_id, [{}], "openai_responses_ws")
+        # Save context locally for reference by other processes (LLM context is managed at server via previous_response_id)
+        if self._update_context_filter:
+            if isinstance(messages[0]["content"], list):
+                if "text" in messages[0]["content"][-1]:
+                    messages[0]["content"][-1]["text"] = self._update_context_filter(messages[0]["content"][-1]["text"])
+            elif isinstance(messages[0]["content"], str):
+                messages[0]["content"] = self._update_context_filter(messages[0]["content"])
+        messages.append({"role": "assistant", "content": response_text})
+        await self.context_manager.add_histories(context_id, messages, "openai_responses_ws")
 
     def tool(self, spec: Dict):
         def decorator(func):

--- a/tests/sts/llm/test_openai_responses.py
+++ b/tests/sts/llm/test_openai_responses.py
@@ -62,9 +62,9 @@ async def test_openai_responses_service_simple():
     # Check server-side context management (response_id should be stored)
     assert context_id in service.response_ids, "response_id not stored for context."
 
-    # Check context marker was saved
+    # Check context was saved locally
     histories = await service.context_manager.get_histories(context_id)
-    assert len(histories) > 0, "No context marker was saved."
+    assert len(histories) > 0, "No local context was saved."
 
     await service.openai_client.close()
 

--- a/tests/sts/llm/test_openai_responses_websocket.py
+++ b/tests/sts/llm/test_openai_responses_websocket.py
@@ -66,9 +66,9 @@ async def test_openai_responses_ws_service_simple():
     # Check server-side context management (response_id should be stored)
     assert context_id in service.response_ids, "response_id not stored for context."
 
-    # Check context marker was saved
+    # Check context was saved locally
     histories = await service.context_manager.get_histories(context_id)
-    assert len(histories) > 0, "No context marker was saved."
+    assert len(histories) > 0, "No local context was saved."
 
     await service._ws_pool.close()
 


### PR DESCRIPTION
Store user/assistant messages in context manager for OpenAI Responses services (both HTTP and WebSocket). LLM context is still managed server-side via `previous_response_id`, but local history is now available for reference by other processes.