### PR TITLE
Return exception text in OpenClawTool error

### DIFF
--- a/aiavatar/sts/llm/tools/openclaw_tool.py
+++ b/aiavatar/sts/llm/tools/openclaw_tool.py
@@ -229,8 +229,8 @@ class OpenClawTool(Tool):
         try:
             answer = await self._call_openclaw_api(query, context_id, user_id, task_id)
             return {"answer": answer}
-        except Exception:
+        except Exception as ex:
             logger.exception("Error at invoke_openclaw")
-            return {"answer": "Error"}
+            return {"answer": f"Error: {ex}"}
         finally:
             self.remove_running_task(task_id)


### PR DESCRIPTION
Capture the exception as `ex` and include its message in the returned error payload instead of the previous generic "Error". This makes assistant response more informative.