### PR TITLE
Support tool call chaining with direct-response tools

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -87,6 +87,7 @@ class Tool:
         self.immediate_message = immediate_message
         self.background_timeout = background_timeout
         self._response_formatter: Callable = None
+        self._response_formatter_continue_chain: bool = False
 
     def on_completed(self, func: Callable):
         self._on_completed = func
@@ -96,9 +97,19 @@ class Tool:
         self._on_submitted = func
         return func
 
-    def response_formatter(self, func: Callable):
-        self._response_formatter = func
-        return func
+    def response_formatter(self, func_or_none=None, *, continue_chain: bool = False):
+        if callable(func_or_none):
+            # Called as @tool.response_formatter (no parentheses)
+            self._response_formatter = func_or_none
+            self._response_formatter_continue_chain = False
+            return func_or_none
+        else:
+            # Called as @tool.response_formatter(continue_chain=True)
+            def decorator(func: Callable):
+                self._response_formatter = func
+                self._response_formatter_continue_chain = continue_chain
+                return func
+            return decorator
 
     def parse_spec(self, spec: Dict[str, Any]) -> Tuple[str, str, Dict[str, Any]]:
         if spec.get("type") == "function" and "function" in spec:

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -337,6 +337,7 @@ class ChatGPTService(LLMService):
             # Execute tools
             messages_length = len(messages)
             has_direct_response = False
+            continue_chain = False
             for tc in tool_calls:
                 if self.debug:
                     logger.info(f"ToolCall: {tc.name}")
@@ -367,6 +368,8 @@ class ChatGPTService(LLMService):
                         direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
                         yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                         has_direct_response = True
+                        if tool_obj._response_formatter_continue_chain:
+                            continue_chain = True
 
                     messages.append({
                         "role": "assistant",
@@ -386,9 +389,15 @@ class ChatGPTService(LLMService):
                         "tool_call_id": tc.id
                     })
 
-            if not has_direct_response and (len(messages) > messages_length or try_dynamic_tools):
-                # Generate human-friendly message that explains tool result
-                async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
-                ):
-                    yield llm_response
+            if len(messages) > messages_length or try_dynamic_tools:
+                if not has_direct_response or continue_chain:
+                    # Send tool results back to LLM for follow-up response or chained tool calls
+                    suppress_text = has_direct_response
+                    async for llm_response in self.get_llm_stream_response(
+                        context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
+                    ):
+                        if llm_response.tool_call:
+                            suppress_text = False
+                            yield llm_response
+                        elif llm_response.error_info or not suppress_text:
+                            yield llm_response

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -254,6 +254,7 @@ class ClaudeService(LLMService):
             # Execute tools
             messages_length = len(messages)
             has_direct_response = False
+            continue_chain = False
             for tc in tool_calls:
                 if self.debug:
                     logger.info(f"ToolCall: {tc.name}")
@@ -289,6 +290,8 @@ class ClaudeService(LLMService):
                         direct_text = tool_obj._response_formatter(tool_result, arguments_json)
                         yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                         has_direct_response = True
+                        if tool_obj._response_formatter_continue_chain:
+                            continue_chain = True
 
                     assistant_content = []
                     if response_text:
@@ -316,9 +319,15 @@ class ClaudeService(LLMService):
                         }]
                     })
 
-            if not has_direct_response and (len(messages) > messages_length or try_dynamic_tools):
-                # Generate human-friendly message that explains tool result
-                async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
-                ):
-                    yield llm_response
+            if len(messages) > messages_length or try_dynamic_tools:
+                if not has_direct_response or continue_chain:
+                    # Send tool results back to LLM for follow-up response or chained tool calls
+                    suppress_text = has_direct_response
+                    async for llm_response in self.get_llm_stream_response(
+                        context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
+                    ):
+                        if llm_response.tool_call:
+                            suppress_text = False
+                            yield llm_response
+                        elif llm_response.error_info or not suppress_text:
+                            yield llm_response

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -332,6 +332,7 @@ class GeminiService(LLMService):
             # Execute tools
             messages_length = len(messages)
             has_direct_response = False
+            continue_chain = False
             for tc in tool_calls:
                 if self.debug:
                     logger.info(f"ToolCall: {tc.name}")
@@ -366,6 +367,8 @@ class GeminiService(LLMService):
                         direct_text = tool_obj._response_formatter(tool_result, tc.arguments)
                         yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                         has_direct_response = True
+                        if tool_obj._response_formatter_continue_chain:
+                            continue_chain = True
 
                     messages.append(types.Content(
                         role="model",
@@ -376,9 +379,15 @@ class GeminiService(LLMService):
                         parts=[types.Part.from_function_response(name=tc.name, response=tool_result)]
                     ))
 
-            if not has_direct_response and (len(messages) > messages_length or try_dynamic_tools):
-                # Generate human-friendly message that explains tool result
-                async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
-                ):
-                    yield llm_response
+            if len(messages) > messages_length or try_dynamic_tools:
+                if not has_direct_response or continue_chain:
+                    # Send tool results back to LLM for follow-up response or chained tool calls
+                    suppress_text = has_direct_response
+                    async for llm_response in self.get_llm_stream_response(
+                        context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
+                    ):
+                        if llm_response.tool_call:
+                            suppress_text = False
+                            yield llm_response
+                        elif llm_response.error_info or not suppress_text:
+                            yield llm_response

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -282,6 +282,7 @@ class LiteLLMService(LLMService):
             # Execute tools
             messages_length = len(messages)
             has_direct_response = False
+            continue_chain = False
             for tc in tool_calls:
                 if self.debug:
                     logger.info(f"ToolCall: {tc.name}")
@@ -312,6 +313,8 @@ class LiteLLMService(LLMService):
                         direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
                         yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
                         has_direct_response = True
+                        if tool_obj._response_formatter_continue_chain:
+                            continue_chain = True
 
                     messages.append({
                         "role": "assistant",
@@ -332,9 +335,15 @@ class LiteLLMService(LLMService):
                         "tool_call_id": tc.id
                     })
 
-            if not has_direct_response and (len(messages) > messages_length or try_dynamic_tools):
-                # Generate human-friendly message that explains tool result
-                async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
-                ):
-                    yield llm_response
+            if len(messages) > messages_length or try_dynamic_tools:
+                if not has_direct_response or continue_chain:
+                    # Send tool results back to LLM for follow-up response or chained tool calls
+                    suppress_text = has_direct_response
+                    async for llm_response in self.get_llm_stream_response(
+                        context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
+                    ):
+                        if llm_response.tool_call:
+                            suppress_text = False
+                            yield llm_response
+                        elif llm_response.error_info or not suppress_text:
+                            yield llm_response

--- a/aiavatar/sts/llm/openai_responses.py
+++ b/aiavatar/sts/llm/openai_responses.py
@@ -265,9 +265,16 @@ class OpenAIResponsesService(LLMService):
                         "output": json.dumps(tool_result),
                     })
 
-            if not has_direct_response and tool_outputs:
+            if tool_outputs:
                 # Send tool results back via recursive call with previous_response_id
+                suppress_text = has_direct_response
                 async for llm_response in self.get_llm_stream_response(
                     context_id, user_id, tool_outputs, system_prompt_params=system_prompt_params, session_id=session_id, channel=channel
                 ):
-                    yield llm_response
+                    if llm_response.tool_call:
+                        # Chained tool call detected: stop suppressing so the
+                        # subsequent tool's LLM response is yielded normally
+                        suppress_text = False
+                        yield llm_response
+                    elif llm_response.error_info or not suppress_text:
+                        yield llm_response

--- a/aiavatar/sts/llm/openai_responses_websocket.py
+++ b/aiavatar/sts/llm/openai_responses_websocket.py
@@ -258,6 +258,7 @@ class OpenAIResponsesWebSocketService(LLMService):
         try:
             async with self._ws_pool.connection() as ws:
                 current_input = messages
+                suppress_output = False
 
                 while True:
                     # Build response.create message
@@ -288,7 +289,8 @@ class OpenAIResponsesWebSocketService(LLMService):
                         event_type = event.get("type")
 
                         if event_type == "response.output_text.delta":
-                            yield LLMResponse(context_id=context_id, text=event.get("delta", ""))
+                            if not suppress_output:
+                                yield LLMResponse(context_id=context_id, text=event.get("delta", ""))
 
                         elif event_type == "response.output_item.added":
                             item = event.get("item", {})
@@ -324,6 +326,11 @@ class OpenAIResponsesWebSocketService(LLMService):
                     # No tool calls — done
                     if not tool_calls:
                         break
+
+                    # If suppressing output but new tool calls arrived (chained tools),
+                    # reset suppression so the next round's response is yielded normally
+                    if suppress_output:
+                        suppress_output = False
 
                     # Execute tool calls
                     await self._on_before_tool_calls(tool_calls)
@@ -362,11 +369,16 @@ class OpenAIResponsesWebSocketService(LLMService):
                                 "output": json.dumps(tool_result),
                             })
 
-                    if has_direct_response or not tool_outputs:
+                    if not tool_outputs:
                         break
 
                     # Continue on the same connection with tool outputs
                     current_input = tool_outputs
+
+                    # When using direct response, still send tool outputs to keep
+                    # API conversation history consistent, but suppress the response text
+                    if has_direct_response:
+                        suppress_output = True
 
         except websockets.ConnectionClosed as ex:
             logger.warning(f"WebSocket connection closed: {ex}")

--- a/tests/sts/llm/test_chatgpt.py
+++ b/tests/sts/llm/test_chatgpt.py
@@ -393,6 +393,80 @@ async def test_chatgpt_service_tool_calls_response_formatter():
 
 
 @pytest.mark.asyncio
+async def test_chatgpt_service_chained_tool_calls_mixed():
+    """
+    Test chained tool calls where a direct-response tool (response_formatter with
+    continue_chain=True) is called first, and its result triggers the LLM to call
+    a second tool (normal LLM response).
+    """
+    service = ChatGPTService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt=(
+            "You have two tools: get_balance and get_campaign_info.\n"
+            "When the user asks about campaigns:\n"
+            "1. FIRST call get_balance\n"
+            "2. If balance >= 1000000, call get_campaign_info\n"
+            "3. Tell the user about the campaign based on get_campaign_info result\n"
+            "Always follow this exact order. Never skip steps."
+        ),
+        model=MODEL,
+        temperature=0.0
+    )
+    context_id = f"test_chained_mixed_{uuid4()}"
+
+    balance_spec = {
+        "type": "function",
+        "function": {
+            "name": "get_balance",
+            "description": "Get the user's account balance. Always call this first.",
+            "parameters": {"type": "object", "properties": {}}
+        }
+    }
+
+    @service.tool(balance_spec)
+    async def get_balance() -> Dict[str, Any]:
+        return {"balance": 1500000, "currency": "JPY"}
+
+    @service.tools["get_balance"].response_formatter(continue_chain=True)
+    def format_balance(result, arguments):
+        return f"残高: {result['balance']:,}{result['currency']}\n"
+
+    campaign_spec = {
+        "type": "function",
+        "function": {
+            "name": "get_campaign_info",
+            "description": "Get campaign information for eligible users with balance >= 1,000,000 JPY. Call this after get_balance.",
+            "parameters": {"type": "object", "properties": {}}
+        }
+    }
+
+    @service.tool(campaign_spec)
+    async def get_campaign_info() -> Dict[str, Any]:
+        return {"campaign_name": "Premium Gold Campaign", "bonus_rate": "5%"}
+
+    collected_text = []
+    tools_called = []
+
+    async for resp in service.chat_stream(context_id, "test_user", "キャンペーンはありますか？"):
+        if resp.error_info:
+            pytest.fail(f"Error during chained tool call: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+        if resp.tool_call and resp.tool_call.name:
+            tools_called.append(resp.tool_call.name)
+
+    full_text = "".join(collected_text)
+
+    assert "get_balance" in tools_called, f"get_balance was not called. Called: {tools_called}"
+    assert "残高" in full_text, f"Direct response from get_balance not found: {full_text}"
+    assert "get_campaign_info" in tools_called, f"get_campaign_info was not called (chain broken). Called: {tools_called}"
+    assert "Premium Gold Campaign" in full_text or "5%" in full_text, \
+        f"LLM response about campaign not found (suppressed?): {full_text}"
+
+    await service.openai_client.close()
+
+
+@pytest.mark.asyncio
 async def test_chatgpt_service_tool_calls_iter():
     """
     Test ChatGPTService with a registered tool that returns iteration.

--- a/tests/sts/llm/test_claude.py
+++ b/tests/sts/llm/test_claude.py
@@ -302,6 +302,72 @@ async def test_claude_service_tool_calls():
 
 
 @pytest.mark.asyncio
+async def test_claude_service_chained_tool_calls_mixed():
+    """
+    Test chained tool calls where a direct-response tool (response_formatter with
+    continue_chain=True) is called first, and its result triggers the LLM to call
+    a second tool (normal LLM response).
+    """
+    service = ClaudeService(
+        anthropic_api_key=CLAUDE_API_KEY,
+        system_prompt=(
+            "You have two tools: get_balance and get_campaign_info.\n"
+            "When the user asks about campaigns:\n"
+            "1. FIRST call get_balance\n"
+            "2. If balance >= 1000000, call get_campaign_info\n"
+            "3. Tell the user about the campaign based on get_campaign_info result\n"
+            "Always follow this exact order. Never skip steps."
+        ),
+        model=MODEL,
+        temperature=0.0
+    )
+    context_id = f"test_chained_mixed_{uuid4()}"
+
+    balance_spec = {
+        "name": "get_balance",
+        "description": "Get the user's account balance. Always call this first.",
+        "input_schema": {"type": "object", "properties": {}}
+    }
+
+    @service.tool(balance_spec)
+    async def get_balance() -> Dict[str, Any]:
+        return {"balance": 1500000, "currency": "JPY"}
+
+    @service.tools["get_balance"].response_formatter(continue_chain=True)
+    def format_balance(result, arguments):
+        return f"残高: {result['balance']:,}{result['currency']}\n"
+
+    campaign_spec = {
+        "name": "get_campaign_info",
+        "description": "Get campaign information for eligible users with balance >= 1,000,000 JPY. Call this after get_balance.",
+        "input_schema": {"type": "object", "properties": {}}
+    }
+
+    @service.tool(campaign_spec)
+    async def get_campaign_info() -> Dict[str, Any]:
+        return {"campaign_name": "Premium Gold Campaign", "bonus_rate": "5%"}
+
+    collected_text = []
+    tools_called = []
+
+    async for resp in service.chat_stream(context_id, "test_user", "キャンペーンはありますか？"):
+        if resp.error_info:
+            pytest.fail(f"Error during chained tool call: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+        if resp.tool_call and resp.tool_call.name:
+            tools_called.append(resp.tool_call.name)
+
+    full_text = "".join(collected_text)
+
+    assert "get_balance" in tools_called, f"get_balance was not called. Called: {tools_called}"
+    assert "残高" in full_text, f"Direct response from get_balance not found: {full_text}"
+    assert "get_campaign_info" in tools_called, f"get_campaign_info was not called (chain broken). Called: {tools_called}"
+    assert "Premium Gold Campaign" in full_text or "5%" in full_text, \
+        f"LLM response about campaign not found (suppressed?): {full_text}"
+
+
+@pytest.mark.asyncio
 async def test_claude_service_tool_calls_iter():
     """
     Test ClaudeService with a registered tool that returns iteration.

--- a/tests/sts/llm/test_gemini.py
+++ b/tests/sts/llm/test_gemini.py
@@ -305,6 +305,76 @@ async def test_gemini_service_tool_calls():
 
 
 @pytest.mark.asyncio
+async def test_gemini_service_chained_tool_calls_mixed():
+    """
+    Test chained tool calls where a direct-response tool (response_formatter with
+    continue_chain=True) is called first, and its result triggers the LLM to call
+    a second tool (normal LLM response).
+    """
+    service = GeminiService(
+        gemini_api_key=GEMINI_API_KEY,
+        system_prompt=(
+            "You have two tools: get_balance and get_campaign_info.\n"
+            "When the user asks about campaigns:\n"
+            "1. FIRST call get_balance\n"
+            "2. If balance >= 1000000, call get_campaign_info\n"
+            "3. Tell the user about the campaign based on get_campaign_info result\n"
+            "Always follow this exact order. Never skip steps."
+        ),
+        model=MODEL,
+        temperature=0.0,
+    )
+    context_id = f"test_chained_mixed_{uuid4()}"
+
+    balance_spec = {
+        "functionDeclarations": [{
+            "name": "get_balance",
+            "description": "Get the user's account balance. Always call this first.",
+            "parameters": {"type": "object", "properties": {}}
+        }]
+    }
+
+    @service.tool(balance_spec)
+    async def get_balance() -> Dict[str, Any]:
+        return {"balance": 1500000, "currency": "JPY"}
+
+    @service.tools["get_balance"].response_formatter(continue_chain=True)
+    def format_balance(result, arguments):
+        return f"残高: {result['balance']:,}{result['currency']}\n"
+
+    campaign_spec = {
+        "functionDeclarations": [{
+            "name": "get_campaign_info",
+            "description": "Get campaign information for eligible users with balance >= 1,000,000 JPY. Call this after get_balance.",
+            "parameters": {"type": "object", "properties": {}}
+        }]
+    }
+
+    @service.tool(campaign_spec)
+    async def get_campaign_info() -> Dict[str, Any]:
+        return {"campaign_name": "Premium Gold Campaign", "bonus_rate": "5%"}
+
+    collected_text = []
+    tools_called = []
+
+    async for resp in service.chat_stream(context_id, "test_user", "キャンペーンはありますか？"):
+        if resp.error_info:
+            pytest.fail(f"Error during chained tool call: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+        if resp.tool_call and resp.tool_call.name:
+            tools_called.append(resp.tool_call.name)
+
+    full_text = "".join(collected_text)
+
+    assert "get_balance" in tools_called, f"get_balance was not called. Called: {tools_called}"
+    assert "残高" in full_text, f"Direct response from get_balance not found: {full_text}"
+    assert "get_campaign_info" in tools_called, f"get_campaign_info was not called (chain broken). Called: {tools_called}"
+    assert "Premium Gold Campaign" in full_text or "5%" in full_text, \
+        f"LLM response about campaign not found (suppressed?): {full_text}"
+
+
+@pytest.mark.asyncio
 async def test_gemini_service_tool_calls():
     """
     Test GeminiService with a registered tool that returns iteration.

--- a/tests/sts/llm/test_litellm.py
+++ b/tests/sts/llm/test_litellm.py
@@ -302,6 +302,78 @@ async def test_litellm_service_tool_calls():
 
 
 @pytest.mark.asyncio
+async def test_litellm_service_chained_tool_calls_mixed():
+    """
+    Test chained tool calls where a direct-response tool (response_formatter with
+    continue_chain=True) is called first, and its result triggers the LLM to call
+    a second tool (normal LLM response).
+    """
+    service = LiteLLMService(
+        api_key=CLAUDE_API_KEY,
+        system_prompt=(
+            "You have two tools: get_balance and get_campaign_info.\n"
+            "When the user asks about campaigns:\n"
+            "1. FIRST call get_balance\n"
+            "2. If balance >= 1000000, call get_campaign_info\n"
+            "3. Tell the user about the campaign based on get_campaign_info result\n"
+            "Always follow this exact order. Never skip steps."
+        ),
+        model=MODEL,
+        temperature=0.0,
+    )
+    context_id = f"test_chained_mixed_{uuid4()}"
+
+    balance_spec = {
+        "type": "function",
+        "function": {
+            "name": "get_balance",
+            "description": "Get the user's account balance. Always call this first.",
+            "parameters": {"type": "object", "properties": {}}
+        }
+    }
+
+    @service.tool(balance_spec)
+    async def get_balance() -> Dict[str, Any]:
+        return {"balance": 1500000, "currency": "JPY"}
+
+    @service.tools["get_balance"].response_formatter(continue_chain=True)
+    def format_balance(result, arguments):
+        return f"残高: {result['balance']:,}{result['currency']}\n"
+
+    campaign_spec = {
+        "type": "function",
+        "function": {
+            "name": "get_campaign_info",
+            "description": "Get campaign information for eligible users with balance >= 1,000,000 JPY. Call this after get_balance.",
+            "parameters": {"type": "object", "properties": {}}
+        }
+    }
+
+    @service.tool(campaign_spec)
+    async def get_campaign_info() -> Dict[str, Any]:
+        return {"campaign_name": "Premium Gold Campaign", "bonus_rate": "5%"}
+
+    collected_text = []
+    tools_called = []
+
+    async for resp in service.chat_stream(context_id, "test_user", "キャンペーンはありますか？"):
+        if resp.error_info:
+            pytest.fail(f"Error during chained tool call: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+        if resp.tool_call and resp.tool_call.name:
+            tools_called.append(resp.tool_call.name)
+
+    full_text = "".join(collected_text)
+
+    assert "get_balance" in tools_called, f"get_balance was not called. Called: {tools_called}"
+    assert "残高" in full_text, f"Direct response from get_balance not found: {full_text}"
+    assert "get_campaign_info" in tools_called, f"get_campaign_info was not called (chain broken). Called: {tools_called}"
+    assert "Premium Gold Campaign" in full_text or "5%" in full_text, \
+        f"LLM response about campaign not found (suppressed?): {full_text}"
+
+
+@pytest.mark.asyncio
 async def test_litellm_service_tool_calls():
     """
     Test LiteLLMService with a registered tool that returns iteration.

--- a/tests/sts/llm/test_openai_responses.py
+++ b/tests/sts/llm/test_openai_responses.py
@@ -212,6 +212,119 @@ async def test_openai_responses_service_tool_calls_response_formatter():
     full_text = "".join(collected_text)
     assert "Formatter: 1+1の計算結果は2です。" in full_text, f"Direct response not found in text: {full_text}"
 
+    # Verify response_ids is valid after direct response (tool output must be sent to API)
+    assert context_id in service.response_ids, "response_id should be set after response_formatter call."
+
+    # Verify conversation can continue without "No tool output found" error
+    collected_text2 = []
+    async for resp in service.chat_stream(context_id, "test_user", "ありがとう"):
+        if resp.error_info:
+            pytest.fail(f"Error after response_formatter call (response_ids corrupted): {resp.error_info}")
+        if resp.text:
+            collected_text2.append(resp.text)
+
+    assert len("".join(collected_text2)) > 0, "No response after response_formatter call."
+
+    await service.openai_client.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_service_chained_tool_calls_mixed():
+    """
+    Test chained tool calls where a direct-response tool (response_formatter) is called first,
+    and its result triggers the LLM to call a second tool (normal LLM response).
+    Verifies that suppress_output resets correctly so the chained tool's LLM response is yielded.
+    This test actually calls OpenAI Responses API, so it may cost tokens.
+    """
+    service = OpenAIResponsesService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt=(
+            "You have two tools: get_balance and get_campaign_info.\n"
+            "When the user asks about campaigns:\n"
+            "1. FIRST call get_balance\n"
+            "2. If balance >= 1000000, call get_campaign_info\n"
+            "3. Tell the user about the campaign based on get_campaign_info result\n"
+            "Always follow this exact order. Never skip steps."
+        ),
+        model=MODEL,
+        temperature=0.0
+    )
+    context_id = f"test_chained_mixed_{uuid4()}"
+
+    # Tool 1: get_balance (with response_formatter = direct response)
+    balance_spec = {
+        "type": "function",
+        "function": {
+            "name": "get_balance",
+            "description": "Get the user's account balance. Always call this first.",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+            }
+        }
+    }
+
+    @service.tool(balance_spec)
+    async def get_balance() -> Dict[str, Any]:
+        return {"balance": 1500000, "currency": "JPY"}
+
+    @service.tools["get_balance"].response_formatter(continue_chain=True)
+    def format_balance(result, arguments):
+        return f"残高: {result['balance']:,}{result['currency']}\n"
+
+    # Tool 2: get_campaign_info (normal LLM response, no response_formatter)
+    campaign_spec = {
+        "type": "function",
+        "function": {
+            "name": "get_campaign_info",
+            "description": "Get campaign information for eligible users with balance >= 1,000,000 JPY. Call this after get_balance.",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+            }
+        }
+    }
+
+    @service.tool(campaign_spec)
+    async def get_campaign_info() -> Dict[str, Any]:
+        return {"campaign_name": "Premium Gold Campaign", "bonus_rate": "5%"}
+
+    collected_text = []
+    tools_called = []
+
+    async for resp in service.chat_stream(context_id, "test_user", "キャンペーンはありますか？"):
+        if resp.error_info:
+            pytest.fail(f"Error during chained tool call: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+        if resp.tool_call and resp.tool_call.name:
+            tools_called.append(resp.tool_call.name)
+
+    full_text = "".join(collected_text)
+
+    # Verify get_balance was called (direct response tool)
+    assert "get_balance" in tools_called, f"get_balance was not called. Called: {tools_called}"
+
+    # Verify the direct response text from response_formatter appeared
+    assert "残高" in full_text, f"Direct response from get_balance not found in text: {full_text}"
+
+    # Verify get_campaign_info was called (chained tool, normal LLM response)
+    assert "get_campaign_info" in tools_called, f"get_campaign_info was not called (chain broken). Called: {tools_called}"
+
+    # Verify the LLM generated a response using the campaign info (not suppressed)
+    assert "Premium Gold Campaign" in full_text or "5%" in full_text, \
+        f"LLM response about campaign not found (suppressed?): {full_text}"
+
+    # Verify conversation can continue
+    collected_text2 = []
+    async for resp in service.chat_stream(context_id, "test_user", "ありがとう"):
+        if resp.error_info:
+            pytest.fail(f"Error after chained tool calls: {resp.error_info}")
+        if resp.text:
+            collected_text2.append(resp.text)
+
+    assert len("".join(collected_text2)) > 0, "No response after chained tool calls."
+
     await service.openai_client.close()
 
 

--- a/tests/sts/llm/test_openai_responses_websocket.py
+++ b/tests/sts/llm/test_openai_responses_websocket.py
@@ -223,6 +223,119 @@ async def test_openai_responses_ws_service_tool_calls_response_formatter():
     full_text = "".join(collected_text)
     assert "Formatter: 1+1の計算結果は2です。" in full_text, f"Direct response not found in text: {full_text}"
 
+    # Verify response_ids is valid after direct response (tool output must be sent to API)
+    assert context_id in service.response_ids, "response_id should be set after response_formatter call."
+
+    # Verify conversation can continue without "No tool output found" error
+    collected_text2 = []
+    async for resp in service.chat_stream(context_id, "test_user", "ありがとう"):
+        if resp.error_info:
+            pytest.fail(f"Error after response_formatter call (response_ids corrupted): {resp.error_info}")
+        if resp.text:
+            collected_text2.append(resp.text)
+
+    assert len("".join(collected_text2)) > 0, "No response after response_formatter call."
+
+    await service._ws_pool.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_ws_service_chained_tool_calls_mixed():
+    """
+    Test chained tool calls where a direct-response tool (response_formatter) is called first,
+    and its result triggers the LLM to call a second tool (normal LLM response).
+    Verifies that suppress_output resets correctly so the chained tool's LLM response is yielded.
+    This test actually calls OpenAI Responses API via WebSocket, so it may cost tokens.
+    """
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt=(
+            "You have two tools: get_balance and get_campaign_info.\n"
+            "When the user asks about campaigns:\n"
+            "1. FIRST call get_balance\n"
+            "2. If balance >= 1000000, call get_campaign_info\n"
+            "3. Tell the user about the campaign based on get_campaign_info result\n"
+            "Always follow this exact order. Never skip steps."
+        ),
+        model=MODEL,
+        reasoning_effort="none",
+    )
+    context_id = f"test_ws_chained_mixed_{uuid4()}"
+
+    # Tool 1: get_balance (with response_formatter = direct response)
+    balance_spec = {
+        "type": "function",
+        "function": {
+            "name": "get_balance",
+            "description": "Get the user's account balance. Always call this first.",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+            }
+        }
+    }
+
+    @service.tool(balance_spec)
+    async def get_balance() -> Dict[str, Any]:
+        return {"balance": 1500000, "currency": "JPY"}
+
+    @service.tools["get_balance"].response_formatter(continue_chain=True)
+    def format_balance(result, arguments):
+        return f"残高: {result['balance']:,}{result['currency']}\n"
+
+    # Tool 2: get_campaign_info (normal LLM response, no response_formatter)
+    campaign_spec = {
+        "type": "function",
+        "function": {
+            "name": "get_campaign_info",
+            "description": "Get campaign information for eligible users with balance >= 1,000,000 JPY. Call this after get_balance.",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+            }
+        }
+    }
+
+    @service.tool(campaign_spec)
+    async def get_campaign_info() -> Dict[str, Any]:
+        return {"campaign_name": "Premium Gold Campaign", "bonus_rate": "5%"}
+
+    collected_text = []
+    tools_called = []
+
+    async for resp in service.chat_stream(context_id, "test_user", "キャンペーンはありますか？"):
+        if resp.error_info:
+            pytest.fail(f"Error during chained tool call: {resp.error_info}")
+        if resp.text:
+            collected_text.append(resp.text)
+        if resp.tool_call and resp.tool_call.name:
+            tools_called.append(resp.tool_call.name)
+
+    full_text = "".join(collected_text)
+
+    # Verify get_balance was called (direct response tool)
+    assert "get_balance" in tools_called, f"get_balance was not called. Called: {tools_called}"
+
+    # Verify the direct response text from response_formatter appeared
+    assert "残高" in full_text, f"Direct response from get_balance not found in text: {full_text}"
+
+    # Verify get_campaign_info was called (chained tool, normal LLM response)
+    assert "get_campaign_info" in tools_called, f"get_campaign_info was not called (chain broken). Called: {tools_called}"
+
+    # Verify the LLM generated a response using the campaign info (not suppressed)
+    assert "Premium Gold Campaign" in full_text or "5%" in full_text, \
+        f"LLM response about campaign not found (suppressed?): {full_text}"
+
+    # Verify conversation can continue
+    collected_text2 = []
+    async for resp in service.chat_stream(context_id, "test_user", "ありがとう"):
+        if resp.error_info:
+            pytest.fail(f"Error after chained tool calls: {resp.error_info}")
+        if resp.text:
+            collected_text2.append(resp.text)
+
+    assert len("".join(collected_text2)) > 0, "No response after chained tool calls."
+
     await service._ws_pool.close()
 
 


### PR DESCRIPTION
Fix conversation breakage when `response_formatter` (direct-response) tools are involved in multi-tool chains.

For Responses API services, tool outputs are now always sent back to the API to keep server-side history consistent, preventing `response_ids` corruption that broke conversation continuity.

For Chat Completions services, add `continue_chain` parameter to `response_formatter` decorator, allowing direct-response tools to participate in tool call chains instead of unconditionally terminating the chain.