### PR TITLE
Allow resetting user conversation context via delete_context

### DIFF
--- a/aiavatar/adapter/channel_context_bridge/base.py
+++ b/aiavatar/adapter/channel_context_bridge/base.py
@@ -51,6 +51,10 @@ class ChannelContextBridge(ABC):
     async def upsert_context(self, context: UserContext):
         pass
 
+    @abstractmethod
+    async def delete_context(self, user_id: str):
+        pass
+
     # Composite operations
     async def link_channel_user(self, channel_id: str, channel_user_id: str, user_id: str) -> Optional[UserContext]:
         """Link a channel user to an app user and return their context."""
@@ -288,6 +292,20 @@ class SQLiteChannelContextBridge(ChannelContextBridge):
                 )
         except:
             logger.exception("Error at upsert_context.")
+            raise
+        finally:
+            conn.close()
+
+    async def delete_context(self, user_id: str):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    "DELETE FROM user_contexts WHERE user_id = ?",
+                    (user_id,)
+                )
+        except:
+            logger.exception("Error at delete_context.")
             raise
         finally:
             conn.close()

--- a/aiavatar/adapter/channel_context_bridge/postgres.py
+++ b/aiavatar/adapter/channel_context_bridge/postgres.py
@@ -264,3 +264,15 @@ class PostgreSQLChannelContextBridge(ChannelContextBridge):
             except Exception as ex:
                 logger.error(f"Error at upsert_context: {ex}")
                 raise
+
+    async def delete_context(self, user_id: str):
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    "DELETE FROM user_contexts WHERE user_id = $1",
+                    user_id
+                )
+            except Exception as ex:
+                logger.error(f"Error at delete_context: {ex}")
+                raise

--- a/tests/adapter/channel_context_bridge/test_channel_context_bridge.py
+++ b/tests/adapter/channel_context_bridge/test_channel_context_bridge.py
@@ -164,6 +164,26 @@ async def test_get_context_timeout(bridge):
 
 
 @pytest.mark.asyncio
+async def test_delete_context(bridge):
+    await bridge.upsert_context(UserContext(
+        user_id="user_del", context_id="ctx_to_delete"
+    ))
+    ctx = await bridge.get_context("user_del")
+    assert ctx is not None
+
+    await bridge.delete_context("user_del")
+
+    ctx = await bridge.get_context("user_del")
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_delete_context_nonexistent(bridge):
+    """Deleting a non-existent context should not raise."""
+    await bridge.delete_context("nonexistent_user")
+
+
+@pytest.mark.asyncio
 async def test_context_independent_of_channel_user(bridge):
     """Context is per user_id, not per channel."""
     await bridge.upsert_channel_user(ChannelUser(

--- a/tests/adapter/channel_context_bridge/test_pg_channel_context_bridge.py
+++ b/tests/adapter/channel_context_bridge/test_pg_channel_context_bridge.py
@@ -137,6 +137,26 @@ async def test_upsert_context_updates(bridge, unique_id):
     assert ctx.context_id == "ctx_new"
 
 
+@pytest.mark.asyncio
+async def test_delete_context(bridge, unique_id):
+    await bridge.upsert_context(UserContext(
+        user_id=unique_id, context_id="ctx_to_delete"
+    ))
+    ctx = await bridge.get_context(unique_id)
+    assert ctx is not None
+
+    await bridge.delete_context(unique_id)
+
+    ctx = await bridge.get_context(unique_id)
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_delete_context_nonexistent(bridge, unique_id):
+    """Deleting a non-existent context should not raise."""
+    await bridge.delete_context(unique_id)
+
+
 # --- link_channel_user tests ---
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add `delete_context(user_id)` to `ChannelContextBridge` so that a user's context can be explicitly cleared without waiting for timeout expiry.