### PR TITLE
Fix race condition in background tool callback execution

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -13,12 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 class ToolCallResult:
-    def __init__(self, data: dict = None, is_final: bool = True, text: str = None, task_id: str = None, structured_content: dict = None):
+    def __init__(self, data: dict = None, is_final: bool = True, text: str = None, task_id: str = None, structured_content: dict = None, deferred_callback: callable = None):
         self.data = data or {}
         self.is_final = is_final
         self.text = text
         self.task_id = task_id
         self.structured_content = structured_content
+        self.deferred_callback = deferred_callback
 
 
 class ToolCall:
@@ -400,6 +401,21 @@ The list of tools is as follows:
         clean_text = clean_text.strip()
         return clean_text
 
+    def _start_deferred_callbacks(self, tool_calls: list):
+        """Start deferred background callbacks after tool output response completes.
+
+        This must be called after the LLM has processed tool outputs and the
+        response is fully received, to avoid race conditions where _on_completed
+        fires before the response chain (e.g. previous_response_id) is updated.
+        """
+        for tc in tool_calls:
+            if tc.result and tc.result.deferred_callback:
+                tool = self.tools.get(tc.name)
+                bg_task = asyncio.create_task(tc.result.deferred_callback())
+                if tool:
+                    tool._background_tasks.add(bg_task)
+                    bg_task.add_done_callback(tool._background_tasks.discard)
+
     async def execute_tool(self, name: str, arguments: dict, metadata: dict) -> AsyncGenerator[ToolCallResult, None]:
         tool = self.tools[name]
         if "metadata" in inspect.signature(tool.func).parameters:
@@ -436,7 +452,8 @@ The list of tools is as follows:
                         yield ToolCallResult(data=result)
                     return
 
-            # Immediate background or timed-out: register callback and return
+            # Immediate background or timed-out: defer callback to avoid race condition
+            # The caller must invoke deferred_callback after tool output response completes
             async def _wait_and_callback():
                 try:
                     result = await task
@@ -445,13 +462,10 @@ The list of tools is as follows:
                     logger.exception(f"Error in background tool execution: {name}")
                     await tool._on_completed(None, _metadata)
 
-            bg_task = asyncio.create_task(_wait_and_callback())
-            tool._background_tasks.add(bg_task)
-            bg_task.add_done_callback(tool._background_tasks.discard)
-
             yield ToolCallResult(
                 data={"message": tool.immediate_message},
-                task_id=task_id
+                task_id=task_id,
+                deferred_callback=_wait_and_callback
             )
             return
 

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -331,73 +331,78 @@ class ChatGPTService(LLMService):
                     yield LLMResponse(context_id=context_id, text=content)
 
         if tool_calls:
-            # Do something before tool calls (e.g. say to user that it will take a long time)
-            await self._on_before_tool_calls(tool_calls)
+            try:
+                # Do something before tool calls (e.g. say to user that it will take a long time)
+                await self._on_before_tool_calls(tool_calls)
 
-            # Execute tools
-            messages_length = len(messages)
-            has_direct_response = False
-            continue_chain = False
-            for tc in tool_calls:
-                if self.debug:
-                    logger.info(f"ToolCall: {tc.name}")
-                yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
+                # Execute tools
+                messages_length = len(messages)
+                has_direct_response = False
+                continue_chain = False
+                for tc in tool_calls:
+                    if self.debug:
+                        logger.info(f"ToolCall: {tc.name}")
+                    yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
 
-                tool_result = None
-                if tc.name == self.dynamic_tool_name:
-                    if not filtered_tools:
-                        tool_result = {"message": "No tools found"}
-                else:
-                    async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
-                        tc.result = tr
-                        if tr.text:
-                            yield LLMResponse(context_id=context_id, text=tr.text)
-                        else:
-                            yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
-                            if tr.is_final:
-                                tool_result = tr.data
-                                break
+                    tool_result = None
+                    if tc.name == self.dynamic_tool_name:
+                        if not filtered_tools:
+                            tool_result = {"message": "No tools found"}
+                    else:
+                        async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
+                            tc.result = tr
+                            if tr.text:
+                                yield LLMResponse(context_id=context_id, text=tr.text)
+                            else:
+                                yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
+                                if tr.is_final:
+                                    tool_result = tr.data
+                                    break
 
-                if self.debug:
-                    logger.info(f"ToolCall result: {tool_result}")
+                    if self.debug:
+                        logger.info(f"ToolCall result: {tool_result}")
 
-                if tool_result:
-                    # Use response_formatter for direct response if available
-                    tool_obj = self.tools.get(tc.name)
-                    if tool_obj and tool_obj._response_formatter:
-                        direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
-                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
-                        has_direct_response = True
-                        if tool_obj._response_formatter_continue_chain:
-                            continue_chain = True
+                    if tool_result:
+                        # Use response_formatter for direct response if available
+                        tool_obj = self.tools.get(tc.name)
+                        if tool_obj and tool_obj._response_formatter:
+                            direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
+                            yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
+                            has_direct_response = True
+                            if tool_obj._response_formatter_continue_chain:
+                                continue_chain = True
 
-                    messages.append({
-                        "role": "assistant",
-                        "tool_calls": [{
-                            "id": tc.id,
-                            "type": "function",
-                            "function": {
-                                "name": tc.name,
-                                "arguments": tc.arguments
-                            }
-                        }]
-                    })
+                        messages.append({
+                            "role": "assistant",
+                            "tool_calls": [{
+                                "id": tc.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tc.name,
+                                    "arguments": tc.arguments
+                                }
+                            }]
+                        })
 
-                    messages.append({
-                        "role": "tool",
-                        "content": json.dumps(tool_result),
-                        "tool_call_id": tc.id
-                    })
+                        messages.append({
+                            "role": "tool",
+                            "content": json.dumps(tool_result),
+                            "tool_call_id": tc.id
+                        })
 
-            if len(messages) > messages_length or try_dynamic_tools:
-                if not has_direct_response or continue_chain:
-                    # Send tool results back to LLM for follow-up response or chained tool calls
-                    suppress_text = has_direct_response
-                    async for llm_response in self.get_llm_stream_response(
-                        context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
-                    ):
-                        if llm_response.tool_call:
-                            suppress_text = False
-                            yield llm_response
-                        elif llm_response.error_info or not suppress_text:
-                            yield llm_response
+                if len(messages) > messages_length or try_dynamic_tools:
+                    if not has_direct_response or continue_chain:
+                        # Send tool results back to LLM for follow-up response or chained tool calls
+                        suppress_text = has_direct_response
+                        async for llm_response in self.get_llm_stream_response(
+                            context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
+                        ):
+                            if llm_response.tool_call:
+                                suppress_text = False
+                                yield llm_response
+                            elif llm_response.error_info or not suppress_text:
+                                yield llm_response
+
+            finally:
+                # Start deferred background callbacks regardless of errors
+                self._start_deferred_callbacks(tool_calls)

--- a/aiavatar/sts/llm/claude.py
+++ b/aiavatar/sts/llm/claude.py
@@ -246,88 +246,93 @@ class ClaudeService(LLMService):
                         tool_calls[-1].arguments += chunk.delta.partial_json
 
         if tool_calls:
-            # Do something before tool calls (e.g. say to user that it will take a long time)
-            await self._on_before_tool_calls(tool_calls)
+            try:
+                # Do something before tool calls (e.g. say to user that it will take a long time)
+                await self._on_before_tool_calls(tool_calls)
 
-            # NOTE: Claude 3.5 Sonnet doesn't return multiple tools at once for now (2025-01-07), but it's not explicitly documented.
-            #       Multiple tools will be called sequentially: user -(llm)-> tool_use -> tool_result -(llm)-> tool_use -> tool_result -(llm)-> assistant
-            # Execute tools
-            messages_length = len(messages)
-            has_direct_response = False
-            continue_chain = False
-            for tc in tool_calls:
-                if self.debug:
-                    logger.info(f"ToolCall: {tc.name}")
-                yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
+                # NOTE: Claude 3.5 Sonnet doesn't return multiple tools at once for now (2025-01-07), but it's not explicitly documented.
+                #       Multiple tools will be called sequentially: user -(llm)-> tool_use -> tool_result -(llm)-> tool_use -> tool_result -(llm)-> assistant
+                # Execute tools
+                messages_length = len(messages)
+                has_direct_response = False
+                continue_chain = False
+                for tc in tool_calls:
+                    if self.debug:
+                        logger.info(f"ToolCall: {tc.name}")
+                    yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
 
-                if tc.arguments:
-                    arguments_json = json.loads(tc.arguments)
-                else:
-                    arguments_json = {}
+                    if tc.arguments:
+                        arguments_json = json.loads(tc.arguments)
+                    else:
+                        arguments_json = {}
 
-                tool_result = None
-                if tc.name == self.dynamic_tool_name:
-                    if not filtered_tools:
-                        tool_result = {"message": "No tools found"}
-                else:
-                    async for tr in self.execute_tool(tc.name, arguments_json, {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
-                        tc.result = tr
-                        if tr.text:
-                            yield LLMResponse(context_id=context_id, text=tr.text)
-                        else:
-                            yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
-                            if tr.is_final:
-                                tool_result = tr.data
-                                break
+                    tool_result = None
+                    if tc.name == self.dynamic_tool_name:
+                        if not filtered_tools:
+                            tool_result = {"message": "No tools found"}
+                    else:
+                        async for tr in self.execute_tool(tc.name, arguments_json, {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
+                            tc.result = tr
+                            if tr.text:
+                                yield LLMResponse(context_id=context_id, text=tr.text)
+                            else:
+                                yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
+                                if tr.is_final:
+                                    tool_result = tr.data
+                                    break
 
-                if self.debug:
-                    logger.info(f"ToolCall result: {tool_result}")
+                    if self.debug:
+                        logger.info(f"ToolCall result: {tool_result}")
 
-                if tool_result:
-                    # Use response_formatter for direct response if available
-                    tool_obj = self.tools.get(tc.name)
-                    if tool_obj and tool_obj._response_formatter:
-                        direct_text = tool_obj._response_formatter(tool_result, arguments_json)
-                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
-                        has_direct_response = True
-                        if tool_obj._response_formatter_continue_chain:
-                            continue_chain = True
+                    if tool_result:
+                        # Use response_formatter for direct response if available
+                        tool_obj = self.tools.get(tc.name)
+                        if tool_obj and tool_obj._response_formatter:
+                            direct_text = tool_obj._response_formatter(tool_result, arguments_json)
+                            yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
+                            has_direct_response = True
+                            if tool_obj._response_formatter_continue_chain:
+                                continue_chain = True
 
-                    assistant_content = []
-                    if response_text:
+                        assistant_content = []
+                        if response_text:
+                            assistant_content.append({
+                                "type": "text",
+                                "text": response_text
+                            })
                         assistant_content.append({
-                            "type": "text",
-                            "text": response_text
+                            "type": "tool_use",
+                            "id": tc.id,
+                            "name": tc.name,
+                            "input": arguments_json
                         })
-                    assistant_content.append({
-                        "type": "tool_use",
-                        "id": tc.id,
-                        "name": tc.name,
-                        "input": arguments_json
-                    })
-                    messages.append({
-                        "role": "assistant",
-                        "content": assistant_content
-                    })
+                        messages.append({
+                            "role": "assistant",
+                            "content": assistant_content
+                        })
 
-                    messages.append({
-                        "role": "user",
-                        "content": [{
-                            "type": "tool_result",
-                            "tool_use_id": tc.id,
-                            "content": json.dumps(tool_result)
-                        }]
-                    })
+                        messages.append({
+                            "role": "user",
+                            "content": [{
+                                "type": "tool_result",
+                                "tool_use_id": tc.id,
+                                "content": json.dumps(tool_result)
+                            }]
+                        })
 
-            if len(messages) > messages_length or try_dynamic_tools:
-                if not has_direct_response or continue_chain:
-                    # Send tool results back to LLM for follow-up response or chained tool calls
-                    suppress_text = has_direct_response
-                    async for llm_response in self.get_llm_stream_response(
-                        context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
-                    ):
-                        if llm_response.tool_call:
-                            suppress_text = False
-                            yield llm_response
-                        elif llm_response.error_info or not suppress_text:
-                            yield llm_response
+                if len(messages) > messages_length or try_dynamic_tools:
+                    if not has_direct_response or continue_chain:
+                        # Send tool results back to LLM for follow-up response or chained tool calls
+                        suppress_text = has_direct_response
+                        async for llm_response in self.get_llm_stream_response(
+                            context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
+                        ):
+                            if llm_response.tool_call:
+                                suppress_text = False
+                                yield llm_response
+                            elif llm_response.error_info or not suppress_text:
+                                yield llm_response
+
+            finally:
+                # Start deferred background callbacks regardless of errors
+                self._start_deferred_callbacks(tool_calls)

--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -324,70 +324,75 @@ class GeminiService(LLMService):
                         try_dynamic_tools = True
 
         if tool_calls:
-            # Do something before tool calls (e.g. say to user that it will take a long time)
-            await self._on_before_tool_calls(tool_calls)
+            try:
+                # Do something before tool calls (e.g. say to user that it will take a long time)
+                await self._on_before_tool_calls(tool_calls)
 
-            # NOTE: Gemini 2.0 Flash doesn't return multiple tools at once for now (2025-01-07), but it's not explicitly documented.
-            #       Multiple tools will be called sequentially: user -(llm)-> function_call -> function_response -(llm)-> function_call -> function_response -(llm)-> assistant
-            # Execute tools
-            messages_length = len(messages)
-            has_direct_response = False
-            continue_chain = False
-            for tc in tool_calls:
-                if self.debug:
-                    logger.info(f"ToolCall: {tc.name}")
-                yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
-
-                tool_result = None
-                if tc.name == self.dynamic_tool_name:
-                    if not filtered_tools:
-                        tool_result = {"message": "No tools found"}
-                else:
+                # NOTE: Gemini 2.0 Flash doesn't return multiple tools at once for now (2025-01-07), but it's not explicitly documented.
+                #       Multiple tools will be called sequentially: user -(llm)-> function_call -> function_response -(llm)-> function_call -> function_response -(llm)-> assistant
+                # Execute tools
+                messages_length = len(messages)
+                has_direct_response = False
+                continue_chain = False
+                for tc in tool_calls:
                     if self.debug:
-                        tool_names = [t["functionDeclarations"][0]["name"] for t in filtered_tools]
-                        logger.info(f"Execute tool: {tc.name} / tools: {tool_names}")
+                        logger.info(f"ToolCall: {tc.name}")
+                    yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
 
-                    async for tr in self.execute_tool(tc.name, tc.arguments, {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
-                        tc.result = tr
-                        if tr.text:
-                            yield LLMResponse(context_id=context_id, text=tr.text)
-                        else:
-                            yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
-                            if tr.is_final:
-                                tool_result = tr.data
-                                break
+                    tool_result = None
+                    if tc.name == self.dynamic_tool_name:
+                        if not filtered_tools:
+                            tool_result = {"message": "No tools found"}
+                    else:
+                        if self.debug:
+                            tool_names = [t["functionDeclarations"][0]["name"] for t in filtered_tools]
+                            logger.info(f"Execute tool: {tc.name} / tools: {tool_names}")
 
-                if self.debug:
-                    logger.info(f"ToolCall result: {tool_result}")
+                        async for tr in self.execute_tool(tc.name, tc.arguments, {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
+                            tc.result = tr
+                            if tr.text:
+                                yield LLMResponse(context_id=context_id, text=tr.text)
+                            else:
+                                yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
+                                if tr.is_final:
+                                    tool_result = tr.data
+                                    break
 
-                if tool_result:
-                    # Use response_formatter for direct response if available
-                    tool_obj = self.tools.get(tc.name)
-                    if tool_obj and tool_obj._response_formatter:
-                        direct_text = tool_obj._response_formatter(tool_result, tc.arguments)
-                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
-                        has_direct_response = True
-                        if tool_obj._response_formatter_continue_chain:
-                            continue_chain = True
+                    if self.debug:
+                        logger.info(f"ToolCall result: {tool_result}")
 
-                    messages.append(types.Content(
-                        role="model",
-                        parts=model_response_parts
-                    ))
-                    messages.append(types.Content(
-                        role="user",
-                        parts=[types.Part.from_function_response(name=tc.name, response=tool_result)]
-                    ))
+                    if tool_result:
+                        # Use response_formatter for direct response if available
+                        tool_obj = self.tools.get(tc.name)
+                        if tool_obj and tool_obj._response_formatter:
+                            direct_text = tool_obj._response_formatter(tool_result, tc.arguments)
+                            yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
+                            has_direct_response = True
+                            if tool_obj._response_formatter_continue_chain:
+                                continue_chain = True
 
-            if len(messages) > messages_length or try_dynamic_tools:
-                if not has_direct_response or continue_chain:
-                    # Send tool results back to LLM for follow-up response or chained tool calls
-                    suppress_text = has_direct_response
-                    async for llm_response in self.get_llm_stream_response(
-                        context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
-                    ):
-                        if llm_response.tool_call:
-                            suppress_text = False
-                            yield llm_response
-                        elif llm_response.error_info or not suppress_text:
-                            yield llm_response
+                        messages.append(types.Content(
+                            role="model",
+                            parts=model_response_parts
+                        ))
+                        messages.append(types.Content(
+                            role="user",
+                            parts=[types.Part.from_function_response(name=tc.name, response=tool_result)]
+                        ))
+
+                if len(messages) > messages_length or try_dynamic_tools:
+                    if not has_direct_response or continue_chain:
+                        # Send tool results back to LLM for follow-up response or chained tool calls
+                        suppress_text = has_direct_response
+                        async for llm_response in self.get_llm_stream_response(
+                            context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
+                        ):
+                            if llm_response.tool_call:
+                                suppress_text = False
+                                yield llm_response
+                            elif llm_response.error_info or not suppress_text:
+                                yield llm_response
+
+            finally:
+                # Start deferred background callbacks regardless of errors
+                self._start_deferred_callbacks(tool_calls)

--- a/aiavatar/sts/llm/litellm.py
+++ b/aiavatar/sts/llm/litellm.py
@@ -276,74 +276,79 @@ class LiteLLMService(LLMService):
                     yield LLMResponse(context_id=context_id, text=content)
 
         if tool_calls:
-            # Do something before tool calls (e.g. say to user that it will take a long time)
-            await self._on_before_tool_calls(tool_calls)
+            try:
+                # Do something before tool calls (e.g. say to user that it will take a long time)
+                await self._on_before_tool_calls(tool_calls)
 
-            # Execute tools
-            messages_length = len(messages)
-            has_direct_response = False
-            continue_chain = False
-            for tc in tool_calls:
-                if self.debug:
-                    logger.info(f"ToolCall: {tc.name}")
-                yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
+                # Execute tools
+                messages_length = len(messages)
+                has_direct_response = False
+                continue_chain = False
+                for tc in tool_calls:
+                    if self.debug:
+                        logger.info(f"ToolCall: {tc.name}")
+                    yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
 
-                tool_result = None
-                if tc.name == self.dynamic_tool_name:
-                    if not filtered_tools:
-                        tool_result = {"message": "No tools found"}
-                else:
-                    async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
-                        tc.result = tr
-                        if tr.text:
-                            yield LLMResponse(context_id=context_id, text=tr.text)
-                        else:
-                            yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
-                            if tr.is_final:
-                                tool_result = tr.data
-                                break
+                    tool_result = None
+                    if tc.name == self.dynamic_tool_name:
+                        if not filtered_tools:
+                            tool_result = {"message": "No tools found"}
+                    else:
+                        async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
+                            tc.result = tr
+                            if tr.text:
+                                yield LLMResponse(context_id=context_id, text=tr.text)
+                            else:
+                                yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
+                                if tr.is_final:
+                                    tool_result = tr.data
+                                    break
 
-                if self.debug:
-                    logger.info(f"ToolCall result: {tool_result}")
+                    if self.debug:
+                        logger.info(f"ToolCall result: {tool_result}")
 
-                if tool_result:
-                    # Use response_formatter for direct response if available
-                    tool_obj = self.tools.get(tc.name)
-                    if tool_obj and tool_obj._response_formatter:
-                        direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
-                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
-                        has_direct_response = True
-                        if tool_obj._response_formatter_continue_chain:
-                            continue_chain = True
+                    if tool_result:
+                        # Use response_formatter for direct response if available
+                        tool_obj = self.tools.get(tc.name)
+                        if tool_obj and tool_obj._response_formatter:
+                            direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
+                            yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
+                            has_direct_response = True
+                            if tool_obj._response_formatter_continue_chain:
+                                continue_chain = True
 
-                    messages.append({
-                        "role": "assistant",
-                        "tool_calls": [{
-                            "id": tc.id,
-                            "type": "function",
-                            "function": {
-                                "name": tc.name,
-                                "arguments": tc.arguments
-                            }
-                        }],
-                        "content": response_text if response_text else None
-                    })
+                        messages.append({
+                            "role": "assistant",
+                            "tool_calls": [{
+                                "id": tc.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tc.name,
+                                    "arguments": tc.arguments
+                                }
+                            }],
+                            "content": response_text if response_text else None
+                        })
 
-                    messages.append({
-                        "role": "tool",
-                        "content": json.dumps(tool_result),
-                        "tool_call_id": tc.id
-                    })
+                        messages.append({
+                            "role": "tool",
+                            "content": json.dumps(tool_result),
+                            "tool_call_id": tc.id
+                        })
 
-            if len(messages) > messages_length or try_dynamic_tools:
-                if not has_direct_response or continue_chain:
-                    # Send tool results back to LLM for follow-up response or chained tool calls
-                    suppress_text = has_direct_response
-                    async for llm_response in self.get_llm_stream_response(
-                        context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
-                    ):
-                        if llm_response.tool_call:
-                            suppress_text = False
-                            yield llm_response
-                        elif llm_response.error_info or not suppress_text:
-                            yield llm_response
+                if len(messages) > messages_length or try_dynamic_tools:
+                    if not has_direct_response or continue_chain:
+                        # Send tool results back to LLM for follow-up response or chained tool calls
+                        suppress_text = has_direct_response
+                        async for llm_response in self.get_llm_stream_response(
+                            context_id, user_id, messages, system_prompt_params=system_prompt_params, tools=filtered_tools, session_id=session_id, channel=channel
+                        ):
+                            if llm_response.tool_call:
+                                suppress_text = False
+                                yield llm_response
+                            elif llm_response.error_info or not suppress_text:
+                                yield llm_response
+
+            finally:
+                # Start deferred background callbacks regardless of errors
+                self._start_deferred_callbacks(tool_calls)

--- a/aiavatar/sts/llm/openai_responses.py
+++ b/aiavatar/sts/llm/openai_responses.py
@@ -228,53 +228,58 @@ class OpenAIResponsesService(LLMService):
 
         # Execute tool calls
         if tool_calls:
-            await self._on_before_tool_calls(tool_calls)
+            try:
+                await self._on_before_tool_calls(tool_calls)
 
-            tool_outputs = []
-            has_direct_response = False
-            for tc in tool_calls:
-                if self.debug:
-                    logger.info(f"ToolCall: {tc.name}")
-                yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
+                tool_outputs = []
+                has_direct_response = False
+                for tc in tool_calls:
+                    if self.debug:
+                        logger.info(f"ToolCall: {tc.name}")
+                    yield LLMResponse(context_id=context_id, tool_call=ToolCall(id=tc.id, name=tc.name, arguments=tc.arguments, result=None))
 
-                tool_result = None
-                async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
-                    tc.result = tr
-                    if tr.text:
-                        yield LLMResponse(context_id=context_id, text=tr.text)
-                    else:
-                        yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
-                        if tr.is_final:
-                            tool_result = tr.data
-                            break
+                    tool_result = None
+                    async for tr in self.execute_tool(tc.name, json.loads(tc.arguments), {"context_id": context_id, "user_id": user_id, "session_id": session_id, "channel": channel}):
+                        tc.result = tr
+                        if tr.text:
+                            yield LLMResponse(context_id=context_id, text=tr.text)
+                        else:
+                            yield LLMResponse(context_id=context_id, tool_call=tc, structured_content=tr.structured_content)
+                            if tr.is_final:
+                                tool_result = tr.data
+                                break
 
-                if self.debug:
-                    logger.info(f"ToolCall result: {tool_result}")
+                    if self.debug:
+                        logger.info(f"ToolCall result: {tool_result}")
 
-                if tool_result:
-                    # Use response_formatter for direct response if available
-                    tool_obj = self.tools.get(tc.name)
-                    if tool_obj and tool_obj._response_formatter:
-                        direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
-                        yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
-                        has_direct_response = True
+                    if tool_result:
+                        # Use response_formatter for direct response if available
+                        tool_obj = self.tools.get(tc.name)
+                        if tool_obj and tool_obj._response_formatter:
+                            direct_text = tool_obj._response_formatter(tool_result, json.loads(tc.arguments))
+                            yield LLMResponse(context_id=context_id, text=direct_text, structured_content=tc.result.structured_content if tc.result else None)
+                            has_direct_response = True
 
-                    tool_outputs.append({
-                        "type": "function_call_output",
-                        "call_id": tc.id,
-                        "output": json.dumps(tool_result),
-                    })
+                        tool_outputs.append({
+                            "type": "function_call_output",
+                            "call_id": tc.id,
+                            "output": json.dumps(tool_result),
+                        })
 
-            if tool_outputs:
-                # Send tool results back via recursive call with previous_response_id
-                suppress_text = has_direct_response
-                async for llm_response in self.get_llm_stream_response(
-                    context_id, user_id, tool_outputs, system_prompt_params=system_prompt_params, session_id=session_id, channel=channel
-                ):
-                    if llm_response.tool_call:
-                        # Chained tool call detected: stop suppressing so the
-                        # subsequent tool's LLM response is yielded normally
-                        suppress_text = False
-                        yield llm_response
-                    elif llm_response.error_info or not suppress_text:
-                        yield llm_response
+                if tool_outputs:
+                    # Send tool results back via recursive call with previous_response_id
+                    suppress_text = has_direct_response
+                    async for llm_response in self.get_llm_stream_response(
+                        context_id, user_id, tool_outputs, system_prompt_params=system_prompt_params, session_id=session_id, channel=channel
+                    ):
+                        if llm_response.tool_call:
+                            # Chained tool call detected: stop suppressing so the
+                            # subsequent tool's LLM response is yielded normally
+                            suppress_text = False
+                            yield llm_response
+                        elif llm_response.error_info or not suppress_text:
+                            yield llm_response
+
+            finally:
+                # Start deferred background callbacks regardless of errors
+                self._start_deferred_callbacks(tool_calls)

--- a/aiavatar/sts/llm/openai_responses_websocket.py
+++ b/aiavatar/sts/llm/openai_responses_websocket.py
@@ -255,6 +255,7 @@ class OpenAIResponsesWebSocketService(LLMService):
         # System prompt
         system_prompt = await self._get_system_prompt(context_id, user_id, system_prompt_params)
 
+        deferred_tool_calls = []
         try:
             async with self._ws_pool.connection() as ws:
                 current_input = messages
@@ -369,6 +370,8 @@ class OpenAIResponsesWebSocketService(LLMService):
                                 "output": json.dumps(tool_result),
                             })
 
+                    deferred_tool_calls.extend(tool_calls)
+
                     if not tool_outputs:
                         break
 
@@ -387,3 +390,7 @@ class OpenAIResponsesWebSocketService(LLMService):
         except Exception as ex:
             logger.warning(f"Error from OpenAI Responses API (WebSocket): {ex}")
             yield LLMResponse(context_id=context_id, error_info={"exception": ex, "response_json": None})
+
+        finally:
+            # Start deferred background callbacks regardless of API errors
+            self._start_deferred_callbacks(deferred_tool_calls)

--- a/tests/sts/llm/test_tool_background.py
+++ b/tests/sts/llm/test_tool_background.py
@@ -95,9 +95,14 @@ async def test_immediate_background():
     assert results[0].data == {"message": tool.immediate_message}
     assert results[0].task_id is not None
     assert results[0].is_final is True
+    assert results[0].deferred_callback is not None
 
-    # on_completed not called yet
+    # on_completed not called yet (deferred)
     assert len(completed) == 0
+
+    # Simulate caller starting deferred callbacks after response completes
+    tc = ToolCall(id="1", name="test_tool", arguments='{"query": "hello"}', result=results[0])
+    svc._start_deferred_callbacks([tc])
 
     # Wait for background task
     await asyncio.sleep(0.15)
@@ -200,9 +205,14 @@ async def test_timeout_falls_back_to_background():
     assert len(results) == 1
     assert results[0].data == {"message": tool.immediate_message}
     assert results[0].task_id is not None
+    assert results[0].deferred_callback is not None
 
-    # on_completed not called yet
+    # on_completed not called yet (deferred)
     assert len(completed) == 0
+
+    # Simulate caller starting deferred callbacks after response completes
+    tc = ToolCall(id="1", name="test_tool", arguments='{"query": "slow"}', result=results[0])
+    svc._start_deferred_callbacks([tc])
 
     # Wait for background to finish
     await asyncio.sleep(5)
@@ -233,6 +243,11 @@ async def test_background_error_calls_on_completed_with_none():
         results.append(tr)
 
     assert results[0].task_id is not None
+    assert results[0].deferred_callback is not None
+
+    # Simulate caller starting deferred callbacks after response completes
+    tc = ToolCall(id="1", name="test_tool", arguments='{"query": "fail"}', result=results[0])
+    svc._start_deferred_callbacks([tc])
 
     await asyncio.sleep(0.1)
 
@@ -284,8 +299,17 @@ async def test_background_tasks_cleaned_up():
 
     svc = make_service_with_tool(tool)
 
-    async for _ in svc.execute_tool("test_tool", {"query": "hi"}, {"context_id": "c1", "user_id": "u1"}):
-        pass
+    results = []
+    async for tr in svc.execute_tool("test_tool", {"query": "hi"}, {"context_id": "c1", "user_id": "u1"}):
+        results.append(tr)
+
+    # Task should NOT be started yet (deferred)
+    assert len(tool._background_tasks) == 0
+    assert results[0].deferred_callback is not None
+
+    # Simulate caller starting deferred callbacks after response completes
+    tc = ToolCall(id="1", name="test_tool", arguments='{"query": "hi"}', result=results[0])
+    svc._start_deferred_callbacks([tc])
 
     # Task should be in the set while running
     assert len(tool._background_tasks) == 1


### PR DESCRIPTION
When a background tool completed very quickly (e.g. returning "not configured"), its `_on_completed` callback fired via `asyncio.create_task` before the tool output response chain finished, potentially triggering a new LLM request with stale conversation state.

Defer background callbacks until after the full response chain completes, and ensure they always execute regardless of API errors via try/finally.