### PR TITLE
Persist response IDs across process restarts with ResponseIdStore

### DIFF
--- a/aiavatar/sts/llm/openai_responses.py
+++ b/aiavatar/sts/llm/openai_responses.py
@@ -5,6 +5,7 @@ from typing import AsyncGenerator, Dict, List, Union
 import openai as openai_module
 from . import LLMService, LLMResponse, ToolCall, Tool
 from .context_manager import ContextManager
+from .response_id_store import ResponseIdStore, SQLiteResponseIdStore
 
 logger = getLogger(__name__)
 
@@ -27,6 +28,7 @@ class OpenAIResponsesService(LLMService):
         split_on_control_tags: bool = True,
         voice_text_tag: Union[str, List[str]] = None,
         context_manager: ContextManager = None,
+        response_id_store: ResponseIdStore = None,
         shared_context_ids: List[str] = None,
         db_connection_str: str = "aiavatar.db",
         debug: bool = False
@@ -48,7 +50,14 @@ class OpenAIResponsesService(LLMService):
         )
         self.reasoning_effort = reasoning_effort
         self.extra_body = extra_body
-        self.response_ids: Dict[str, str] = {}
+        if response_id_store:
+            self.response_id_store = response_id_store
+        else:
+            if db_connection_str.startswith("postgresql://"):
+                from .response_id_store.postgres import PostgreSQLResponseIdStore
+                self.response_id_store = PostgreSQLResponseIdStore(connection_str=db_connection_str)
+            else:
+                self.response_id_store = SQLiteResponseIdStore(db_path=db_connection_str)
         self._edit_response_params = None
 
         self.openai_client = openai_module.AsyncClient(
@@ -73,7 +82,7 @@ class OpenAIResponsesService(LLMService):
         messages = []
 
         # Add initial messages for the first call only (no server-side history yet)
-        if not self.response_ids.get(context_id):
+        if not await self.response_id_store.get(context_id):
             initial_msgs = await self._get_initial_messages(context_id, user_id, system_prompt_params)
             if initial_msgs:
                 messages.extend(initial_msgs)
@@ -157,7 +166,7 @@ class OpenAIResponsesService(LLMService):
             response_params["instructions"] = system_prompt
 
         # Previous response for conversation continuity
-        if previous_response_id := self.response_ids.get(context_id):
+        if previous_response_id := await self.response_id_store.get(context_id):
             response_params["previous_response_id"] = previous_response_id
 
         # Temperature and reasoning effort
@@ -224,7 +233,7 @@ class OpenAIResponsesService(LLMService):
                     tool_calls[idx].arguments += event.delta
 
             elif event.type == "response.completed":
-                self.response_ids[context_id] = event.response.id
+                await self.response_id_store.set(context_id, event.response.id)
 
         # Execute tool calls
         if tool_calls:

--- a/aiavatar/sts/llm/openai_responses_websocket.py
+++ b/aiavatar/sts/llm/openai_responses_websocket.py
@@ -8,6 +8,7 @@ from typing import AsyncGenerator, Dict, List, Union
 import websockets
 from . import LLMService, LLMResponse, ToolCall, Tool
 from .context_manager import ContextManager
+from .response_id_store import ResponseIdStore, SQLiteResponseIdStore
 
 logger = getLogger(__name__)
 
@@ -109,6 +110,7 @@ class OpenAIResponsesWebSocketService(LLMService):
         max_connections: int = 100,  # Max concurrent WebSocket connections (= max parallel requests)
         max_connection_age: float = 3300,
         context_manager: ContextManager = None,
+        response_id_store: ResponseIdStore = None,
         shared_context_ids: List[str] = None,
         db_connection_str: str = "aiavatar.db",
         debug: bool = False
@@ -129,7 +131,14 @@ class OpenAIResponsesWebSocketService(LLMService):
         )
         self.reasoning_effort = reasoning_effort
         self.extra_body = extra_body
-        self.response_ids: Dict[str, str] = {}
+        if response_id_store:
+            self.response_id_store = response_id_store
+        else:
+            if db_connection_str.startswith("postgresql://"):
+                from .response_id_store.postgres import PostgreSQLResponseIdStore
+                self.response_id_store = PostgreSQLResponseIdStore(connection_str=db_connection_str)
+            else:
+                self.response_id_store = SQLiteResponseIdStore(db_path=db_connection_str)
         self._edit_response_params = None
 
         base = ws_url or "wss://api.openai.com"
@@ -158,7 +167,7 @@ class OpenAIResponsesWebSocketService(LLMService):
         messages = []
 
         # Add initial messages for the first call only (no server-side history yet)
-        if not self.response_ids.get(context_id):
+        if not await self.response_id_store.get(context_id):
             initial_msgs = await self._get_initial_messages(context_id, user_id, system_prompt_params)
             if initial_msgs:
                 messages.extend(initial_msgs)
@@ -226,7 +235,7 @@ class OpenAIResponsesWebSocketService(LLMService):
             tool_to_add.is_dynamic = is_dynamic
         self.tools[tool_to_add.name] = tool_to_add
 
-    def _build_response_create(self, context_id: str, input_data: list, system_prompt: str = None) -> dict:
+    async def _build_response_create(self, context_id: str, input_data: list, system_prompt: str = None) -> dict:
         """Build a response.create message for WebSocket."""
         message = {
             "type": "response.create",
@@ -237,7 +246,7 @@ class OpenAIResponsesWebSocketService(LLMService):
         if system_prompt:
             message["instructions"] = system_prompt
 
-        if previous_response_id := self.response_ids.get(context_id):
+        if previous_response_id := await self.response_id_store.get(context_id):
             message["previous_response_id"] = previous_response_id
 
         # Temperature and reasoning effort
@@ -263,7 +272,7 @@ class OpenAIResponsesWebSocketService(LLMService):
 
                 while True:
                     # Build response.create message
-                    ws_message = self._build_response_create(context_id, current_input, system_prompt)
+                    ws_message = await self._build_response_create(context_id, current_input, system_prompt)
 
                     if self.extra_body:
                         ws_message["extra_body"] = self.extra_body
@@ -308,7 +317,7 @@ class OpenAIResponsesWebSocketService(LLMService):
                         elif event_type == "response.completed":
                             resp = event.get("response", {})
                             if resp_id := resp.get("id"):
-                                self.response_ids[context_id] = resp_id
+                                await self.response_id_store.set(context_id, resp_id)
                             break
 
                         elif event_type == "response.failed":

--- a/aiavatar/sts/llm/response_id_store/__init__.py
+++ b/aiavatar/sts/llm/response_id_store/__init__.py
@@ -1,0 +1,1 @@
+from .base import ResponseIdStore, SQLiteResponseIdStore

--- a/aiavatar/sts/llm/response_id_store/base.py
+++ b/aiavatar/sts/llm/response_id_store/base.py
@@ -1,0 +1,109 @@
+import sqlite3
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ResponseIdStore:
+    """Duck-typing interface for response ID storage.
+
+    Maps context_id to an external service's conversation identifier
+    (e.g. OpenAI Responses API response_id, Dify conversation_id).
+    """
+
+    async def get(self, context_id: str) -> Optional[str]:
+        raise NotImplementedError
+
+    async def set(self, context_id: str, response_id: str) -> None:
+        raise NotImplementedError
+
+    async def delete(self, context_id: str) -> None:
+        raise NotImplementedError
+
+    async def delete_older_than(self, seconds: int) -> None:
+        raise NotImplementedError
+
+
+class SQLiteResponseIdStore(ResponseIdStore):
+    def __init__(self, db_path: str = "aiavatar.db"):
+        self.db_path = db_path
+        self.init_db()
+
+    def init_db(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS response_ids (
+                        context_id TEXT PRIMARY KEY,
+                        response_id TEXT NOT NULL,
+                        updated_at TIMESTAMP NOT NULL
+                    )
+                    """
+                )
+        except Exception as ex:
+            logger.exception(f"Error at init_db: {ex}")
+        finally:
+            conn.close()
+
+    async def get(self, context_id: str) -> Optional[str]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT response_id FROM response_ids WHERE context_id = ?",
+                (context_id,),
+            )
+            row = cursor.fetchone()
+            return row[0] if row else None
+        except Exception as ex:
+            logger.exception(f"Error at get: {ex}")
+            return None
+        finally:
+            conn.close()
+
+    async def set(self, context_id: str, response_id: str) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO response_ids (context_id, response_id, updated_at)
+                    VALUES (?, ?, ?)
+                    """,
+                    (context_id, response_id, datetime.now(timezone.utc)),
+                )
+        except Exception as ex:
+            logger.exception(f"Error at set: {ex}")
+        finally:
+            conn.close()
+
+    async def delete(self, context_id: str) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    "DELETE FROM response_ids WHERE context_id = ?",
+                    (context_id,),
+                )
+        except Exception as ex:
+            logger.exception(f"Error at delete: {ex}")
+        finally:
+            conn.close()
+
+    async def delete_older_than(self, seconds: int) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cutoff = datetime.now(timezone.utc) - timedelta(seconds=seconds)
+            with conn:
+                conn.execute(
+                    "DELETE FROM response_ids WHERE updated_at < ?",
+                    (cutoff,),
+                )
+        except Exception as ex:
+            logger.exception(f"Error at delete_older_than: {ex}")
+        finally:
+            conn.close()

--- a/aiavatar/sts/llm/response_id_store/postgres.py
+++ b/aiavatar/sts/llm/response_id_store/postgres.py
@@ -1,0 +1,145 @@
+import asyncio
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Callable, Awaitable, Optional
+import asyncpg
+from .base import ResponseIdStore
+
+logger = logging.getLogger(__name__)
+
+
+class PostgreSQLResponseIdStore(ResponseIdStore):
+    def __init__(
+        self,
+        *,
+        get_pool: Callable[[], Awaitable[asyncpg.Pool]] = None,
+        host: str = "localhost",
+        port: int = 5432,
+        dbname: str = "aiavatar",
+        user: str = "postgres",
+        password: str = None,
+        connection_str: str = None,
+        db_pool_min_size: int = 1,
+        db_pool_max_size: int = 5,
+    ):
+        self._get_pool_func = get_pool
+        self.host = host
+        self.port = port
+        self.dbname = dbname
+        self.user = user
+        self.password = password
+        self.connection_str = connection_str
+        self.db_pool_min_size = db_pool_min_size
+        self.db_pool_max_size = db_pool_max_size
+        self._pool: asyncpg.Pool = None
+        self._pool_lock = asyncio.Lock()
+        self._db_initialized = False
+
+    async def get_pool(self) -> asyncpg.Pool:
+        if self._get_pool_func is not None:
+            pool = await self._get_pool_func()
+            if not self._db_initialized:
+                async with self._pool_lock:
+                    if not self._db_initialized:
+                        await self.init_db(pool)
+            return pool
+
+        if self._pool is not None and self._db_initialized:
+            return self._pool
+
+        async with self._pool_lock:
+            if self._pool is not None and self._db_initialized:
+                return self._pool
+
+            if self._pool is None:
+                if self.connection_str:
+                    self._pool = await asyncpg.create_pool(
+                        dsn=self.connection_str,
+                        min_size=self.db_pool_min_size,
+                        max_size=self.db_pool_max_size,
+                    )
+                else:
+                    self._pool = await asyncpg.create_pool(
+                        host=self.host,
+                        port=self.port,
+                        database=self.dbname,
+                        user=self.user,
+                        password=self.password,
+                        min_size=self.db_pool_min_size,
+                        max_size=self.db_pool_max_size,
+                    )
+
+            await self.init_db(self._pool)
+
+        return self._pool
+
+    async def init_db(self, pool: asyncpg.Pool):
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS response_ids (
+                        context_id TEXT PRIMARY KEY,
+                        response_id TEXT NOT NULL,
+                        updated_at TIMESTAMP NOT NULL
+                    )
+                    """
+                )
+                self._db_initialized = True
+            except Exception:
+                logger.exception("Error at init_db")
+
+    async def get(self, context_id: str) -> Optional[str]:
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                row = await conn.fetchrow(
+                    "SELECT response_id FROM response_ids WHERE context_id = $1",
+                    context_id,
+                )
+                return row["response_id"] if row else None
+            except Exception as ex:
+                logger.exception(f"Error at get: {ex}")
+                return None
+
+    async def set(self, context_id: str, response_id: str) -> None:
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    """
+                    INSERT INTO response_ids (context_id, response_id, updated_at)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT (context_id) DO UPDATE
+                    SET response_id = EXCLUDED.response_id,
+                        updated_at = EXCLUDED.updated_at
+                    """,
+                    context_id,
+                    response_id,
+                    datetime.now(timezone.utc).replace(tzinfo=None),
+                )
+            except Exception as ex:
+                logger.exception(f"Error at set: {ex}")
+
+    async def delete(self, context_id: str) -> None:
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                await conn.execute(
+                    "DELETE FROM response_ids WHERE context_id = $1",
+                    context_id,
+                )
+            except Exception as ex:
+                logger.exception(f"Error at delete: {ex}")
+
+    async def delete_older_than(self, seconds: int) -> None:
+        pool = await self.get_pool()
+        async with pool.acquire() as conn:
+            try:
+                cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=seconds)
+                await conn.execute(
+                    "DELETE FROM response_ids WHERE updated_at < $1",
+                    cutoff,
+                )
+            except Exception as ex:
+                logger.exception(f"Error at delete_older_than: {ex}")

--- a/tests/sts/llm/response_id_store/test_pg_response_id_store.py
+++ b/tests/sts/llm/response_id_store/test_pg_response_id_store.py
@@ -1,0 +1,86 @@
+import os
+from datetime import datetime, timezone, timedelta
+from uuid import uuid4
+import pytest
+import pytest_asyncio
+from aiavatar.sts.llm.response_id_store.postgres import PostgreSQLResponseIdStore
+
+AIAVATAR_DB_PORT = os.getenv("AIAVATAR_DB_PORT")
+AIAVATAR_DB_USER = os.getenv("AIAVATAR_DB_USER")
+AIAVATAR_DB_PASSWORD = os.getenv("AIAVATAR_DB_PASSWORD")
+
+
+@pytest_asyncio.fixture
+async def store():
+    s = PostgreSQLResponseIdStore(
+        port=AIAVATAR_DB_PORT,
+        user=AIAVATAR_DB_USER,
+        password=AIAVATAR_DB_PASSWORD,
+    )
+    yield s
+    if s._pool is not None:
+        await s._pool.close()
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent(store):
+    result = await store.get(f"non_existent_{uuid4()}")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_set_and_get(store):
+    ctx = f"ctx_{uuid4()}"
+    await store.set(ctx, "resp_abc")
+    result = await store.get(ctx)
+    assert result == "resp_abc"
+
+
+@pytest.mark.asyncio
+async def test_set_overwrite(store):
+    ctx = f"ctx_{uuid4()}"
+    await store.set(ctx, "resp_old")
+    await store.set(ctx, "resp_new")
+    result = await store.get(ctx)
+    assert result == "resp_new"
+
+
+@pytest.mark.asyncio
+async def test_delete(store):
+    ctx = f"ctx_{uuid4()}"
+    await store.set(ctx, "resp_abc")
+    await store.delete(ctx)
+    result = await store.get(ctx)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent(store):
+    await store.delete(f"non_existent_{uuid4()}")
+
+
+@pytest.mark.asyncio
+async def test_delete_older_than(store):
+    ctx_new = f"ctx_new_{uuid4()}"
+    ctx_old = f"ctx_old_{uuid4()}"
+
+    await store.set(ctx_new, "resp_new")
+
+    # Insert an old record directly
+    old_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=7200)
+    pool = await store.get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO response_ids (context_id, response_id, updated_at)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (context_id) DO UPDATE
+            SET response_id = EXCLUDED.response_id, updated_at = EXCLUDED.updated_at
+            """,
+            ctx_old, "resp_old", old_time,
+        )
+
+    await store.delete_older_than(3600)
+
+    assert await store.get(ctx_old) is None
+    assert await store.get(ctx_new) == "resp_new"

--- a/tests/sts/llm/response_id_store/test_response_id_store.py
+++ b/tests/sts/llm/response_id_store/test_response_id_store.py
@@ -1,0 +1,76 @@
+import os
+import sqlite3
+from datetime import datetime, timezone, timedelta
+import pytest
+from aiavatar.sts.llm.response_id_store import SQLiteResponseIdStore
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return os.path.join(tmp_path, "test_response_ids.db")
+
+
+@pytest.fixture
+def store(db_path) -> SQLiteResponseIdStore:
+    return SQLiteResponseIdStore(db_path=db_path)
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent(store):
+    result = await store.get("non_existent_context")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_set_and_get(store):
+    await store.set("ctx_1", "resp_abc")
+    result = await store.get("ctx_1")
+    assert result == "resp_abc"
+
+
+@pytest.mark.asyncio
+async def test_set_overwrite(store):
+    await store.set("ctx_1", "resp_old")
+    await store.set("ctx_1", "resp_new")
+    result = await store.get("ctx_1")
+    assert result == "resp_new"
+
+
+@pytest.mark.asyncio
+async def test_delete(store):
+    await store.set("ctx_1", "resp_abc")
+    await store.delete("ctx_1")
+    result = await store.get("ctx_1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent(store):
+    # Should not raise
+    await store.delete("non_existent_context")
+
+
+@pytest.mark.asyncio
+async def test_delete_older_than(store, db_path):
+    # Insert a fresh record via the store
+    await store.set("ctx_new", "resp_new")
+
+    # Insert an old record directly into the database
+    old_time = datetime.now(timezone.utc) - timedelta(seconds=7200)
+    conn = sqlite3.connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO response_ids (context_id, response_id, updated_at) VALUES (?, ?, ?)",
+                ("ctx_old", "resp_old", old_time),
+            )
+    finally:
+        conn.close()
+
+    # Delete records older than 1 hour
+    await store.delete_older_than(3600)
+
+    # Old record should be gone
+    assert await store.get("ctx_old") is None
+    # New record should remain
+    assert await store.get("ctx_new") == "resp_new"

--- a/tests/sts/llm/test_openai_responses.py
+++ b/tests/sts/llm/test_openai_responses.py
@@ -60,7 +60,7 @@ async def test_openai_responses_service_simple():
     assert "[face:Angry]" not in full_voice, "Control tag was not removed from voice_text."
 
     # Check server-side context management (response_id should be stored)
-    assert context_id in service.response_ids, "response_id not stored for context."
+    assert await service.response_id_store.get(context_id) is not None, "response_id not stored for context."
 
     # Check context was saved locally
     histories = await service.context_manager.get_histories(context_id)
@@ -88,7 +88,7 @@ async def test_openai_responses_service_context_continuity():
     async for resp in service.chat_stream(context_id, "test_user", "私の好きな果物はマンゴーです。覚えておいてください。"):
         pass
 
-    first_response_id = service.response_ids.get(context_id)
+    first_response_id = await service.response_id_store.get(context_id)
     assert first_response_id is not None, "response_id should be set after first call."
 
     # Second call: ask about what was said before
@@ -101,7 +101,7 @@ async def test_openai_responses_service_context_continuity():
     assert "マンゴー" in full_text, f"Context was not maintained. Response: {full_text}"
 
     # response_id should have been updated
-    second_response_id = service.response_ids.get(context_id)
+    second_response_id = await service.response_id_store.get(context_id)
     assert second_response_id != first_response_id, "response_id should be updated after second call."
 
     await service.openai_client.close()
@@ -213,7 +213,7 @@ async def test_openai_responses_service_tool_calls_response_formatter():
     assert "Formatter: 1+1の計算結果は2です。" in full_text, f"Direct response not found in text: {full_text}"
 
     # Verify response_ids is valid after direct response (tool output must be sent to API)
-    assert context_id in service.response_ids, "response_id should be set after response_formatter call."
+    assert await service.response_id_store.get(context_id) is not None, "response_id should be set after response_formatter call."
 
     # Verify conversation can continue without "No tool output found" error
     collected_text2 = []
@@ -357,9 +357,11 @@ async def test_openai_responses_service_context_isolation():
     )
 
     # Verify each context has its own response_id
-    assert context_a in service.response_ids
-    assert context_b in service.response_ids
-    assert service.response_ids[context_a] != service.response_ids[context_b], \
+    response_id_a = await service.response_id_store.get(context_a)
+    response_id_b = await service.response_id_store.get(context_b)
+    assert response_id_a is not None
+    assert response_id_b is not None
+    assert response_id_a != response_id_b, \
         "Different contexts should have different response_ids."
 
     # Second round: ask each context about the stored information concurrently

--- a/tests/sts/llm/test_openai_responses_websocket.py
+++ b/tests/sts/llm/test_openai_responses_websocket.py
@@ -64,7 +64,7 @@ async def test_openai_responses_ws_service_simple():
     assert "[face:Angry]" not in full_voice, "Control tag was not removed from voice_text."
 
     # Check server-side context management (response_id should be stored)
-    assert context_id in service.response_ids, "response_id not stored for context."
+    assert await service.response_id_store.get(context_id) is not None, "response_id not stored for context."
 
     # Check context was saved locally
     histories = await service.context_manager.get_histories(context_id)
@@ -93,7 +93,7 @@ async def test_openai_responses_ws_service_context_continuity():
         if resp.error_info:
             pytest.fail(f"Error in first call: {resp.error_info}")
 
-    first_response_id = service.response_ids.get(context_id)
+    first_response_id = await service.response_id_store.get(context_id)
     assert first_response_id is not None, "response_id should be set after first call."
 
     # Second call: ask about what was said before
@@ -108,7 +108,7 @@ async def test_openai_responses_ws_service_context_continuity():
     assert "マンゴー" in full_text, f"Context was not maintained. Response: {full_text}"
 
     # response_id should have been updated
-    second_response_id = service.response_ids.get(context_id)
+    second_response_id = await service.response_id_store.get(context_id)
     assert second_response_id != first_response_id, "response_id should be updated after second call."
 
     await service._ws_pool.close()
@@ -224,7 +224,7 @@ async def test_openai_responses_ws_service_tool_calls_response_formatter():
     assert "Formatter: 1+1の計算結果は2です。" in full_text, f"Direct response not found in text: {full_text}"
 
     # Verify response_ids is valid after direct response (tool output must be sent to API)
-    assert context_id in service.response_ids, "response_id should be set after response_formatter call."
+    assert await service.response_id_store.get(context_id) is not None, "response_id should be set after response_formatter call."
 
     # Verify conversation can continue without "No tool output found" error
     collected_text2 = []
@@ -373,9 +373,11 @@ async def test_openai_responses_ws_service_context_isolation():
     assert not errors, f"Errors during setup: {errors}"
 
     # Verify each context has its own response_id
-    assert context_a in service.response_ids, f"response_id not set for context_a. response_ids={service.response_ids}"
-    assert context_b in service.response_ids, f"response_id not set for context_b. response_ids={service.response_ids}"
-    assert service.response_ids[context_a] != service.response_ids[context_b], \
+    response_id_a = await service.response_id_store.get(context_a)
+    response_id_b = await service.response_id_store.get(context_b)
+    assert response_id_a is not None, "response_id not set for context_a."
+    assert response_id_b is not None, "response_id not set for context_b."
+    assert response_id_a != response_id_b, \
         "Different contexts should have different response_ids."
 
     # Second round: ask each context about the stored information concurrently


### PR DESCRIPTION
Response IDs for OpenAI Responses API conversation continuity are now stored in SQLite/PostgreSQL instead of an in-memory dict, so conversations survive process restarts and can be shared across multiple server instances. The store is generic enough to be reused for other external service conversation IDs (e.g. Dify conversation_id).