### PR TITLE
Update expected error message in test

### DIFF
--- a/tests/sts/llm/tools/test_openclaw_running_tasks.py
+++ b/tests/sts/llm/tools/test_openclaw_running_tasks.py
@@ -142,7 +142,7 @@ async def test_invoke_openclaw_removes_task_on_error():
 
         result = await tool.invoke_openclaw("fail", {"context_id": "ctx1", "user_id": "user1"})
 
-    assert result == {"answer": "Error"}
+    assert result == {"answer": "Error: API error"}
     # Task should be removed even on error
     assert tool.get_running_tasks(context_id="ctx1") == []
 


### PR DESCRIPTION
Adjust assertion in tests/sts/llm/tools/test_openclaw_running_tasks.py to expect "Error: API error" instead of "Error", reflecting the API now returning the underlying error message.