### PR TITLE
Allow routing OpenClaw task results to a specific channel

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -432,6 +432,10 @@ The list of tools is as follows:
             if tool._on_submitted:
                 await tool._on_submitted(task_id, _metadata)
 
+            # Pass enriched metadata (with task_id, submitted_at) to the tool function
+            if "metadata" in arguments:
+                arguments["metadata"] = _metadata
+
             tool_result = tool.func(**arguments)
             if inspect.isawaitable(tool_result):
                 task = asyncio.ensure_future(tool_result)
@@ -463,7 +467,7 @@ The list of tools is as follows:
                     await tool._on_completed(None, _metadata)
 
             yield ToolCallResult(
-                data={"message": tool.immediate_message},
+                data={"message": tool.immediate_message, "task_id": task_id},
                 task_id=task_id,
                 deferred_callback=_wait_and_callback
             )

--- a/aiavatar/sts/llm/tools/openclaw_tool.py
+++ b/aiavatar/sts/llm/tools/openclaw_tool.py
@@ -65,7 +65,8 @@ class OpenClawTool(Tool):
                     "parameters": {
                         "type": "object",
                         "properties": {
-                            "query": {"type": "string"}
+                            "query": {"type": "string", "description": "The user's request or task description to send to OpenClaw for processing."},
+                            "report_channel": {"type": "string", "description": "The channel where the task results should be reported back."},
                         },
                         "required": ["query"]
                     },
@@ -84,12 +85,16 @@ class OpenClawTool(Tool):
     # Running tasks management
 
     def add_running_task(self, request: str, metadata: dict, progress: str = None) -> str:
-        task_id = str(uuid4())
+        task_id = metadata.get("task_id")
+        logger.info(f"add_running_task: task_id={task_id}")
+
+        task_id = metadata.get("task_id") or str(uuid4())
         self._running_tasks[task_id] = {
             "context_id": metadata.get("context_id"),
             "user_id": metadata.get("user_id"),
             "session_id": metadata.get("session_id"),
             "channel": metadata.get("channel"),
+            "report_channel": None,
             "request": request,
             "progress": progress or "",
         }
@@ -111,6 +116,43 @@ class OpenClawTool(Tool):
             self._running_tasks[task_id]["progress"] += progress
             if self.debug:
                 logger.info(f"OpenClaw progress: {progress}")
+
+    def set_report_channel(self, task_id: str, channel: str):
+
+        logger.info(f"set_report_channel: task_id={task_id}")
+
+        if running_task := self._running_tasks.get(task_id):
+            running_task["report_channel"] = channel
+
+    def create_set_report_channel_tool(self, name: str = "set_openclaw_report_channel", description: str = None) -> Tool:
+        openclaw_tool = self
+
+        async def set_channel(task_id: str, report_channel: str, metadata: dict = None):
+            if openclaw_tool._running_tasks.get(task_id):
+                openclaw_tool.set_report_channel(task_id, report_channel)
+                return {"message": f"Report channel for task {task_id} has been set to '{report_channel}'."}
+            else:
+                return {"message": f"Task {task_id} not found in running tasks."}
+
+        return Tool(
+            name=name,
+            spec={
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description or "Set the report channel for a running OpenClaw background task. Use this to change where the task results will be reported.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "task_id": {"type": "string", "description": "The ID of the running task."},
+                            "report_channel": {"type": "string", "description": "The channel where the task results should be reported."},
+                        },
+                        "required": ["task_id", "report_channel"]
+                    },
+                }
+            },
+            func=set_channel,
+        )
 
     def create_check_tool(self, name: str = "check_running_openclaw_tasks", description: str = None) -> Tool:
         openclaw_tool = self
@@ -216,21 +258,23 @@ class OpenClawTool(Tool):
             logger.info(f"Response from OpenClaw: {answer}")
         return answer
 
-    async def invoke_openclaw(self, query: str, metadata: dict = None):
+    async def invoke_openclaw(self, query: str, report_channel: str = None, metadata: dict = None):
         context_id = metadata.get("context_id", "")
         user_id = metadata.get("user_id", "")
 
         config = self.get_openclaw_config(user_id)
         if not config.openclaw_base_url:
             logger.warning(f"OpenClaw base_url is not configured for user: {user_id}")
-            return {"answer": "OpenClaw is not configured for this user. Please set up your OpenClaw connection first."}
+            return {"answer": "OpenClaw is not configured for this user. Please set up your OpenClaw connection first.", "report_channel": report_channel}
 
         task_id = self.add_running_task(request=query, metadata=metadata, progress="Start processing...\n")
         try:
             answer = await self._call_openclaw_api(query, context_id, user_id, task_id)
-            return {"answer": answer}
+            report_channel = self._running_tasks[task_id].get("report_channel") or report_channel
+            return {"answer": answer, "report_channel": report_channel}
         except Exception as ex:
             logger.exception("Error at invoke_openclaw")
-            return {"answer": f"Error: {ex}"}
+            report_channel = self._running_tasks.get(task_id, {}).get("report_channel") or report_channel
+            return {"answer": f"Error: {ex}", "report_channel": report_channel}
         finally:
             self.remove_running_task(task_id)

--- a/tests/sts/llm/test_tool_background.py
+++ b/tests/sts/llm/test_tool_background.py
@@ -90,9 +90,10 @@ async def test_immediate_background():
     async for tr in svc.execute_tool("test_tool", {"query": "hello"}, {"context_id": "c1", "user_id": "u1"}):
         results.append(tr)
 
-    # Should return immediately with immediate_message
+    # Should return immediately with immediate_message and task_id
     assert len(results) == 1
-    assert results[0].data == {"message": tool.immediate_message}
+    assert results[0].data["message"] == tool.immediate_message
+    assert results[0].data["task_id"] == results[0].task_id
     assert results[0].task_id is not None
     assert results[0].is_final is True
     assert results[0].deferred_callback is not None
@@ -203,7 +204,8 @@ async def test_timeout_falls_back_to_background():
 
     # Should return immediate_message (timed out)
     assert len(results) == 1
-    assert results[0].data == {"message": tool.immediate_message}
+    assert results[0].data["message"] == tool.immediate_message
+    assert results[0].data["task_id"] == results[0].task_id
     assert results[0].task_id is not None
     assert results[0].deferred_callback is not None
 
@@ -281,6 +283,9 @@ async def test_metadata_passed_to_func():
     assert len(received_metadata) == 1
     assert received_metadata[0]["context_id"] == "c1"
     assert received_metadata[0]["user_id"] == "u1"
+    # Enriched metadata includes task_id and submitted_at for background tools
+    assert "task_id" in received_metadata[0]
+    assert "submitted_at" in received_metadata[0]
 
 
 # --- Background tasks are cleaned up ---
@@ -339,7 +344,7 @@ async def test_custom_immediate_message():
     async for tr in svc.execute_tool("test_tool", {"query": "hi"}, {"context_id": "c1", "user_id": "u1"}):
         results.append(tr)
 
-    assert results[0].data == {"message": "Working on it..."}
+    assert results[0].data["message"] == "Working on it..."
 
 
 # --- Async generator (streaming, no on_completed) ---

--- a/tests/sts/llm/tools/test_openclaw_running_tasks.py
+++ b/tests/sts/llm/tools/test_openclaw_running_tasks.py
@@ -104,9 +104,9 @@ async def test_invoke_openclaw_registers_and_removes_task():
     with patch.object(tool, "_call_openclaw_api", new_callable=AsyncMock) as mock_api:
         mock_api.return_value = "sunny"
 
-        result = await tool.invoke_openclaw("weather?", {"context_id": "ctx1", "user_id": "user1"})
+        result = await tool.invoke_openclaw("weather?", metadata={"context_id": "ctx1", "user_id": "user1"})
 
-    assert result == {"answer": "sunny"}
+    assert result == {"answer": "sunny", "report_channel": None}
     # Task should be removed after completion
     assert tool.get_running_tasks(context_id="ctx1") == []
 
@@ -122,7 +122,7 @@ async def test_invoke_openclaw_task_visible_during_execution():
         return "result"
 
     with patch.object(tool, "_call_openclaw_api", side_effect=mock_api):
-        await tool.invoke_openclaw("do something", {"context_id": "ctx1", "user_id": "user1"})
+        await tool.invoke_openclaw("do something", metadata={"context_id": "ctx1", "user_id": "user1"})
 
     # Task was visible during execution
     assert len(captured_tasks) == 1
@@ -140,9 +140,9 @@ async def test_invoke_openclaw_removes_task_on_error():
     with patch.object(tool, "_call_openclaw_api", new_callable=AsyncMock) as mock_api:
         mock_api.side_effect = RuntimeError("API error")
 
-        result = await tool.invoke_openclaw("fail", {"context_id": "ctx1", "user_id": "user1"})
+        result = await tool.invoke_openclaw("fail", metadata={"context_id": "ctx1", "user_id": "user1"})
 
-    assert result == {"answer": "Error: API error"}
+    assert result == {"answer": "Error: API error", "report_channel": None}
     # Task should be removed even on error
     assert tool.get_running_tasks(context_id="ctx1") == []
 
@@ -420,9 +420,10 @@ async def test_invoke_openclaw_rejects_unconfigured_user():
         stream=False,
     )
 
-    result = await tool.invoke_openclaw("hello", {"context_id": "ctx1", "user_id": "unknown_user"})
+    result = await tool.invoke_openclaw("hello", metadata={"context_id": "ctx1", "user_id": "unknown_user"})
 
     assert "not configured" in result["answer"].lower()
+    assert result["report_channel"] is None
     # No running task should remain
     assert tool.get_running_tasks(user_id="unknown_user") == []
 
@@ -444,7 +445,7 @@ async def test_invoke_openclaw_allows_configured_user():
 
     with patch.object(tool, "_call_openclaw_api", new_callable=AsyncMock) as mock_api:
         mock_api.return_value = "success"
-        result = await tool.invoke_openclaw("hello", {"context_id": "ctx1", "user_id": "user1"})
+        result = await tool.invoke_openclaw("hello", metadata={"context_id": "ctx1", "user_id": "user1"})
 
-    assert result == {"answer": "success"}
+    assert result == {"answer": "success", "report_channel": None}
     mock_api.assert_awaited_once()


### PR DESCRIPTION
Users and LLM can now specify which channel (e.g. LINE, SMS, phone) receives OpenClaw task results via `report_channel` parameter. The channel can also be changed while a task is running using the new `set_openclaw_report_channel` tool.