### PR TITLE
Fix concurrent WebSocket write crash and add transaction-based response management

### DIFF
--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -28,6 +28,8 @@ class WebSocketSessionData:
     def __init__(self):
         self.id = None
         self.data = {}
+        self.send_lock = asyncio.Lock()
+        self.active_transaction_id: Optional[str] = None
 
 
 class AIAvatarWebSocketServer(Adapter):
@@ -240,7 +242,7 @@ class AIAvatarWebSocketServer(Adapter):
             session_data.data["metadata"] = request.metadata
             self.sessions[session_data.id] = session_data
 
-            await self.handle_response(AIAvatarResponse(
+            await self.handle_response(STSResponse(
                 type="connected",
                 session_id=request.session_id,
                 user_id=request.user_id,
@@ -270,7 +272,7 @@ class AIAvatarWebSocketServer(Adapter):
                 user_id=request.user_id,
                 context_id=context_id,
                 text=request.text,
-                audio_data=request.audio_data,
+                audio_data=base64.b64decode(request.audio_data) if request.audio_data else None,
                 files=request.files,
                 system_prompt_params=request.system_prompt_params,
                 allow_merge=request.allow_merge,
@@ -308,11 +310,43 @@ class AIAvatarWebSocketServer(Adapter):
 
     # Response
     async def send_response(self, aiavatar_response: AIAvatarResponse):
-        await self.websockets[aiavatar_response.session_id].send_text(
-            aiavatar_response.model_dump_json()
-        )
+        session_data = self.sessions.get(aiavatar_response.session_id)
+        if not session_data:
+            return
+        async with session_data.send_lock:
+            if aiavatar_response.session_id in self.websockets:
+                await self.websockets[aiavatar_response.session_id].send_text(
+                    aiavatar_response.model_dump_json()
+                )
 
     async def handle_response(self, response: STSResponse):
+        session_data = self.sessions.get(response.session_id)
+
+        # On accepted: finalize old transaction and update active_transaction_id
+        if response.type == "accepted" and response.transaction_id and session_data:
+            if session_data.active_transaction_id and session_data.active_transaction_id != response.transaction_id:
+                # Send final for the old transaction
+                await self.send_response(AIAvatarResponse(
+                    type="final",
+                    session_id=response.session_id,
+                    user_id=response.user_id,
+                    context_id=response.context_id,
+                    text="",
+                    voice_text="",
+                    metadata={"interrupted": True}
+                ))
+            session_data.active_transaction_id = response.transaction_id
+
+        # Skip stale transaction responses
+        if response.transaction_id and session_data:
+            if response.transaction_id != session_data.active_transaction_id:
+                if self.debug:
+                    logger.info(
+                        "Skip stale response: type=%s, transaction=%s, active=%s",
+                        response.type, response.transaction_id, session_data.active_transaction_id
+                    )
+                return
+
         aiavatar_response = AIAvatarResponse(
             type=response.type,
             session_id=response.session_id,
@@ -364,6 +398,14 @@ class AIAvatarWebSocketServer(Adapter):
 
                     # Send audio data in chunks
                     for i in range(0, len(audio_data), self.response_audio_chunk_size):
+                        # Break if transaction is no longer active
+                        if session_data and response.transaction_id != session_data.active_transaction_id:
+                            if self.debug:
+                                logger.info(
+                                    "Break audio chunk loop: transaction=%s, active=%s",
+                                    response.transaction_id, session_data.active_transaction_id
+                                )
+                            break
                         # Encode chunk as base64
                         b64_chunk = base64.b64encode(audio_data[i:i + self.response_audio_chunk_size]).decode("utf-8")
                         chunk_response = AIAvatarResponse(

--- a/aiavatar/sts/models.py
+++ b/aiavatar/sts/models.py
@@ -31,6 +31,7 @@ class STSResponse:
     session_id: str = None
     user_id: str = None
     context_id: str = None
+    transaction_id: str = None
     text: str = None
     voice_text: str = None
     language: str = None

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -316,17 +316,18 @@ class STSPipeline:
             if not request.session_id:
                 raise ValueError("session_id is required but not provided")
 
+            start_time = time()
+            transaction_id = str(uuid4())
+
             # Notify client that request is accepted (fire and forget to avoid blocking pipeline latency)
             asyncio.create_task(self.handle_response(STSResponse(
                 type="accepted",
                 session_id=request.session_id,
+                transaction_id=transaction_id,
                 metadata={"block_barge_in": request.block_barge_in}
             )))
             for handler in self._on_accepted_handlers:
                 await handler(request)
-
-            start_time = time()
-            transaction_id = str(uuid4())
 
             performance = PerformanceRecord(
                 transaction_id=transaction_id,
@@ -356,6 +357,7 @@ class STSPipeline:
                         session_id=request.session_id,
                         user_id=request.user_id,
                         context_id=request.context_id,
+                        transaction_id=transaction_id,
                         metadata={"reason": "No speech recognized."}
                     )
                     return
@@ -380,6 +382,7 @@ class STSPipeline:
                         session_id=request.session_id,
                         user_id=request.user_id,
                         context_id=request.context_id,
+                        transaction_id=transaction_id,
                         metadata={"reason": reason}
                     )
                     return
@@ -448,6 +451,7 @@ class STSPipeline:
                 session_id=request.session_id,
                 user_id=request.user_id,
                 context_id=request.context_id,
+                transaction_id=transaction_id,
                 metadata={"request_text": request.text, "recognized_text": recognized_text}
             )
 
@@ -464,6 +468,7 @@ class STSPipeline:
                     session_id=request.session_id,
                     user_id=request.user_id,
                     context_id=request.context_id,
+                    transaction_id=transaction_id,
                     text=request.quick_response_text,
                     voice_text=request.quick_response_voice_text,
                     audio_data=request.quick_response_audio,
@@ -571,6 +576,7 @@ class STSPipeline:
                         session_id=request.session_id,
                         user_id=request.user_id,
                         context_id=llm_stream_chunk.context_id,
+                        transaction_id=transaction_id,
                         tool_call=llm_stream_chunk.tool_call,
                         structured_content=llm_stream_chunk.structured_content
                     )
@@ -586,6 +592,7 @@ class STSPipeline:
                     session_id=request.session_id,
                     user_id=request.user_id,
                     context_id=llm_stream_chunk.context_id,
+                    transaction_id=transaction_id,
                     text=llm_stream_chunk.text,
                     voice_text=llm_stream_chunk.voice_text,
                     language=language,
@@ -605,6 +612,7 @@ class STSPipeline:
                 session_id=request.session_id,
                 user_id=request.user_id,
                 context_id=request.context_id,
+                transaction_id=transaction_id,
                 text=(request.quick_response_text or "") + response_text,
                 voice_text=(request.quick_response_voice_text or "") + (performance.response_voice_text or "")
             )
@@ -637,6 +645,7 @@ class STSPipeline:
                 session_id=request.session_id,
                 user_id=request.user_id,
                 context_id=request.context_id,
+                transaction_id=transaction_id,
                 metadata={"error": "Error in processing Speech-to-Speech pipeline"}
             )
 

--- a/tests/adapter/websocket/test_transaction.py
+++ b/tests/adapter/websocket/test_transaction.py
@@ -1,0 +1,298 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from aiavatar.sts.models import STSResponse
+from aiavatar.adapter.websocket.server import AIAvatarWebSocketServer, WebSocketSessionData
+from aiavatar.adapter.models import AIAvatarResponse
+
+
+class MockWebSocket:
+    def __init__(self):
+        self.sent_messages = []
+
+    async def send_text(self, message: str):
+        self.sent_messages.append(message)
+
+
+def create_server_with_session(session_id: str, **kwargs):
+    """Create a minimal AIAvatarWebSocketServer with a session set up for testing."""
+    with patch.object(AIAvatarWebSocketServer, "__init__", lambda self, **kw: None):
+        server = AIAvatarWebSocketServer()
+
+    server.sessions = {}
+    server.websockets = {}
+    server.debug = kwargs.get("debug", False)
+    server.response_audio_chunk_size = kwargs.get("response_audio_chunk_size", 512)
+    server._on_response_handlers = []
+    server.control_tag_pattern = r'\[{tag}:(\w+)\]|<{tag}\s[^>]*{attr}=["\'](\w+)["\']'
+
+    # Set up session
+    session_data = WebSocketSessionData()
+    session_data.id = session_id
+    server.sessions[session_id] = session_data
+
+    # Set up websocket
+    ws = MockWebSocket()
+    server.websockets[session_id] = ws
+
+    return server, session_data, ws
+
+
+@pytest.mark.asyncio
+async def test_accepted_sets_active_transaction_id():
+    """Test that accepted response sets active_transaction_id on session"""
+    session_id = "test_session"
+    server, session_data, ws = create_server_with_session(session_id)
+
+    assert session_data.active_transaction_id is None
+
+    await server.handle_response(STSResponse(
+        type="accepted",
+        session_id=session_id,
+        transaction_id="txn_1",
+        metadata={"block_barge_in": False}
+    ))
+
+    assert session_data.active_transaction_id == "txn_1"
+
+
+@pytest.mark.asyncio
+async def test_new_accepted_sends_synthetic_final_for_old_transaction():
+    """Test that when a new accepted arrives, a synthetic final is sent for the old transaction"""
+    session_id = "test_session"
+    server, session_data, ws = create_server_with_session(session_id)
+
+    # Set initial transaction
+    session_data.active_transaction_id = "txn_old"
+
+    # New accepted arrives
+    await server.handle_response(STSResponse(
+        type="accepted",
+        session_id=session_id,
+        user_id="user_1",
+        context_id="ctx_1",
+        transaction_id="txn_new",
+        metadata={"block_barge_in": False}
+    ))
+
+    # Should have sent synthetic final + accepted
+    assert len(ws.sent_messages) == 2
+
+    # First message: synthetic final for old transaction
+    import json
+    final_msg = json.loads(ws.sent_messages[0])
+    assert final_msg["type"] == "final"
+    assert final_msg["session_id"] == session_id
+    assert final_msg["user_id"] == "user_1"
+    assert final_msg["context_id"] == "ctx_1"
+    assert final_msg["text"] == ""
+    assert final_msg["voice_text"] == ""
+    assert final_msg["metadata"]["interrupted"] is True
+
+    # Second message: accepted itself
+    accepted_msg = json.loads(ws.sent_messages[1])
+    assert accepted_msg["type"] == "accepted"
+
+    # active_transaction_id should be updated
+    assert session_data.active_transaction_id == "txn_new"
+
+
+@pytest.mark.asyncio
+async def test_no_synthetic_final_when_same_transaction():
+    """Test that no synthetic final is sent when accepted has the same transaction_id"""
+    session_id = "test_session"
+    server, session_data, ws = create_server_with_session(session_id)
+
+    session_data.active_transaction_id = "txn_1"
+
+    await server.handle_response(STSResponse(
+        type="accepted",
+        session_id=session_id,
+        transaction_id="txn_1",
+        metadata={"block_barge_in": False}
+    ))
+
+    # Should only send accepted, no synthetic final
+    assert len(ws.sent_messages) == 1
+    import json
+    msg = json.loads(ws.sent_messages[0])
+    assert msg["type"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_stale_response_skipped():
+    """Test that responses with non-matching transaction_id are skipped"""
+    session_id = "test_session"
+    server, session_data, ws = create_server_with_session(session_id)
+
+    session_data.active_transaction_id = "txn_2"
+
+    # Send a chunk response with old transaction_id
+    await server.handle_response(STSResponse(
+        type="chunk",
+        session_id=session_id,
+        transaction_id="txn_1",
+        text="stale text",
+        voice_text="stale voice",
+        metadata={}
+    ))
+
+    # Nothing should be sent
+    assert len(ws.sent_messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_stale_final_skipped():
+    """Test that even final responses with non-matching transaction_id are skipped"""
+    session_id = "test_session"
+    server, session_data, ws = create_server_with_session(session_id)
+
+    session_data.active_transaction_id = "txn_2"
+
+    await server.handle_response(STSResponse(
+        type="final",
+        session_id=session_id,
+        transaction_id="txn_1",
+        text="old final",
+        voice_text="old voice",
+    ))
+
+    # Stale final should be skipped
+    assert len(ws.sent_messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_response_without_transaction_id_passes_through():
+    """Test that responses without transaction_id (e.g. connected) are not skipped"""
+    session_id = "test_session"
+    server, session_data, ws = create_server_with_session(session_id)
+
+    session_data.active_transaction_id = "txn_1"
+
+    # connected response has no transaction_id
+    await server.handle_response(STSResponse(
+        type="connected",
+        session_id=session_id,
+        user_id="user_1",
+        context_id="ctx_1"
+    ))
+
+    # Should pass through
+    assert len(ws.sent_messages) == 1
+    import json
+    msg = json.loads(ws.sent_messages[0])
+    assert msg["type"] == "connected"
+
+
+@pytest.mark.asyncio
+async def test_active_response_passes_through():
+    """Test that responses with matching transaction_id are sent normally"""
+    session_id = "test_session"
+    server, session_data, ws = create_server_with_session(session_id)
+
+    session_data.active_transaction_id = "txn_1"
+
+    await server.handle_response(STSResponse(
+        type="chunk",
+        session_id=session_id,
+        transaction_id="txn_1",
+        text="hello",
+        voice_text="hello",
+        metadata={}
+    ))
+
+    assert len(ws.sent_messages) == 1
+    import json
+    msg = json.loads(ws.sent_messages[0])
+    assert msg["type"] == "chunk"
+    assert msg["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_send_lock_serializes_writes():
+    """Test that send_lock prevents concurrent writes"""
+    session_id = "test_session"
+    server, session_data, ws = create_server_with_session(session_id)
+
+    write_order = []
+    original_send_text = ws.send_text
+
+    async def slow_send_text(message: str):
+        import json
+        msg = json.loads(message)
+        write_order.append(f"start_{msg['type']}")
+        await asyncio.sleep(0.05)
+        write_order.append(f"end_{msg['type']}")
+        await original_send_text(message)
+
+    ws.send_text = slow_send_text
+
+    # Launch two sends concurrently
+    resp1 = AIAvatarResponse(type="chunk", session_id=session_id, text="first")
+    resp2 = AIAvatarResponse(type="final", session_id=session_id, text="second")
+
+    await asyncio.gather(
+        server.send_response(resp1),
+        server.send_response(resp2),
+    )
+
+    # With lock, writes should be serialized (no interleaving)
+    assert write_order[0] == "start_chunk" or write_order[0] == "start_final"
+    if write_order[0] == "start_chunk":
+        assert write_order[1] == "end_chunk"
+        assert write_order[2] == "start_final"
+        assert write_order[3] == "end_final"
+    else:
+        assert write_order[1] == "end_final"
+        assert write_order[2] == "start_chunk"
+        assert write_order[3] == "end_chunk"
+
+
+@pytest.mark.asyncio
+async def test_audio_chunk_loop_breaks_on_transaction_change():
+    """Test that audio chunk sending breaks when transaction_id changes mid-loop"""
+    session_id = "test_session"
+    server, session_data, ws = create_server_with_session(session_id, response_audio_chunk_size=100)
+
+    session_data.active_transaction_id = "txn_1"
+
+    # Create WAV audio data (512 bytes of PCM = 5+ chunks at 100 bytes each)
+    import io
+    import wave
+    pcm_data = b"\x00\x01" * 256  # 512 bytes of PCM data
+    wav_buffer = io.BytesIO()
+    with wave.open(wav_buffer, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(pcm_data)
+    wav_data = wav_buffer.getvalue()
+
+    # Track sends and change transaction after 2 chunks
+    send_count = 0
+    original_send_text = ws.send_text
+
+    async def tracking_send_text(message: str):
+        nonlocal send_count
+        send_count += 1
+        # After sending initial response + 2 audio chunks, simulate new transaction
+        if send_count == 3:
+            session_data.active_transaction_id = "txn_2"
+        await original_send_text(message)
+
+    ws.send_text = tracking_send_text
+
+    await server.handle_response(STSResponse(
+        type="chunk",
+        session_id=session_id,
+        transaction_id="txn_1",
+        text="audio chunk",
+        voice_text="audio chunk",
+        audio_data=wav_data,
+        metadata={}
+    ))
+
+    # Should have stopped early: 1 initial response + 2 audio chunks = 3
+    # (would be 1 + 6 without break since 512/100 = 6 chunks)
+    assert send_count < 7, f"Expected early break but sent {send_count} messages"
+    assert send_count == 3, f"Expected 3 sends (1 initial + 2 chunks before break), got {send_count}"

--- a/tests/sts/test_pipeline.py
+++ b/tests/sts/test_pipeline.py
@@ -1231,3 +1231,90 @@ async def test_insert_channel_tag_disabled():
     assert request.text == "Hello"
 
     await sts.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_transaction_id_in_responses():
+    """Test that all responses from a single invoke have a consistent non-None transaction_id"""
+    session_id = f"test_transaction_id_{str(uuid4())}"
+
+    sts = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=ChatGPTService(
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            model="gpt-4o-mini",
+        ),
+        tts=SpeechSynthesizerDummy(),
+        performance_recorder=SQLitePerformanceRecorder(),
+        debug=True
+    )
+
+    responses = []
+    async for response in sts.invoke(STSRequest(
+        session_id=session_id,
+        user_id="test_user",
+        context_id="test_context",
+        text="Hello"
+    )):
+        responses.append(response)
+
+    # All responses should have a non-None transaction_id
+    for response in responses:
+        assert response.transaction_id is not None, f"Response type={response.type} has no transaction_id"
+
+    # All responses should share the same transaction_id
+    transaction_ids = set(r.transaction_id for r in responses)
+    assert len(transaction_ids) == 1, f"Expected 1 unique transaction_id, got {len(transaction_ids)}: {transaction_ids}"
+
+    # Should have at least start and final
+    types = [r.type for r in responses]
+    assert "start" in types
+    assert "final" in types
+
+    await sts.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_transaction_id_differs_between_invokes():
+    """Test that different invocations produce different transaction_ids"""
+    session_id = f"test_transaction_id_differs_{str(uuid4())}"
+
+    sts = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=ChatGPTService(
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            model="gpt-4o-mini",
+        ),
+        tts=SpeechSynthesizerDummy(),
+        performance_recorder=SQLitePerformanceRecorder(),
+        debug=True
+    )
+
+    # First invoke
+    responses_1 = []
+    async for response in sts.invoke(STSRequest(
+        session_id=session_id,
+        user_id="test_user",
+        context_id="test_context",
+        text="Hello"
+    )):
+        responses_1.append(response)
+
+    # Second invoke
+    responses_2 = []
+    async for response in sts.invoke(STSRequest(
+        session_id=session_id,
+        user_id="test_user",
+        context_id="test_context",
+        text="World"
+    )):
+        responses_2.append(response)
+
+    # Each invoke should have its own transaction_id
+    txn_id_1 = responses_1[0].transaction_id
+    txn_id_2 = responses_2[0].transaction_id
+    assert txn_id_1 != txn_id_2, "Different invocations should produce different transaction_ids"
+
+    await sts.shutdown()


### PR DESCRIPTION
Add `transaction_id` to `STSResponse` and use it in the WebSocket adapter to prevent concurrent writes (via per-session Lock) and skip stale responses from interrupted transactions. Also fix base64 decoding of `audio_data` in the invoke path.
