### PR TITLE
Support any harness backend in OpenClawTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -2648,39 +2648,27 @@ llm.add_tool(selfie_tool)
 ```python
 from aiavatar.sts.llm.tools.openclaw_tool import OpenClawTool
 
-# OpenClaw
+# OpenClaw (default harness)
 openclaw_tool = OpenClawTool(
     openclaw_api_key=OPENCLAW_API_KEY,
     openclaw_base_url=OPENCLAW_BASE_URL,
-    openclaw_session_key="agent:main:main",  # Set if you want to use a fixed session
-    debug=True
+    stream=True,
+    debug=True,
 )
 
 # Hermes
 openclaw_tool = OpenClawTool(
     openclaw_api_key=HERMES_API_KEY,
     openclaw_base_url=HERMES_BASE_URL,
-    openclaw_session_key_key="X-Hermes-Session-Id",
-    debug=True
+    harness="hermes",
+    stream=True,
+    debug=True,
 )
 
 llm.add_tool(openclaw_tool)
 ```
 
-When `stream=True` is set, you can monitor the agent's intermediate steps (tool usage, code execution, etc.) via the `on_stream_chunk` handler:
-
-```python
-openclaw_tool = OpenClawTool(
-    openclaw_api_key=OPENCLAW_API_KEY,
-    openclaw_base_url=OPENCLAW_BASE_URL,
-    stream=True
-)
-
-@openclaw_tool.on_stream_chunk
-async def handle_chunk(chunk):
-    if chunk.tool:
-        print(f"[{chunk.emoji}] {chunk.tool}: {chunk.label}")
-```
+The `harness` parameter selects the built-in request builder and response parser for each backend. Built-in harnesses are `"openclaw"` (default) and `"hermes"`. You can also register custom harnesses — see [Custom harness](#custom-harness) below.
 
 When `on_completed` is registered, OpenClaw runs asynchronously in the background — the avatar immediately acknowledges the request and notifies the user when the result is ready. The approach for delivering the result depends on your adapter.
 
@@ -2830,25 +2818,72 @@ openclaw_tool = OpenClawTool(
         "user_id_2": OpenClawConfig(
             openclaw_api_key=USER2_API_KEY,
             openclaw_base_url=USER2_HERMES_URL,
-            openclaw_session_key_key="X-Hermes-Session-Id",
-            openclaw_model="hermes-agent",
+            harness="hermes",
         ),
     },
     stream=True,
 )
 ```
 
-Per-user configs are merged with the tool-level defaults. Only the fields you specify are overridden. You can also manage configs at runtime:
+Per-user configs are merged with the tool-level defaults. Only the fields you specify are overridden — `harness` falls back to the tool-level default (`"openclaw"`). You can also manage configs at runtime:
 
 ```python
 # Add or update
 openclaw_tool.update_openclaw_config("user_id_3", OpenClawConfig(
     openclaw_api_key="new-key",
     openclaw_base_url="https://my-hermes.example.com",
+    harness="hermes",
 ))
 
 # Remove (reverts to tool defaults)
 openclaw_tool.delete_openclaw_config("user_id_3")
+```
+
+#### Custom harness
+
+You can register custom harnesses to support backends beyond OpenClaw and Hermes. A harness consists of a **request builder** and a **response parser**.
+
+The **request builder** constructs the extra kwargs passed to the API call. It returns a dict that may include `model`, `extra_headers`, `extra_body`, etc.
+
+```python
+@openclaw_tool.request_builder("my_harness")
+def my_request_builder(task_id, context_id):
+    # Use a previously stored session key if available, otherwise use context_id
+    session_key = openclaw_tool.get_session_key("my_harness", context_id) or context_id
+    result = {"model": "my-model"}
+    if session_key:
+        result["extra_body"] = {"session_id": session_key}
+    return result
+```
+
+The **response parser** processes each streaming chunk. It handles progress tracking, session key storage, and returns the content text (or `None`).
+
+```python
+@openclaw_tool.response_parser("my_harness")
+def my_response_parser(task_id, context_id, chunk):
+    # Store session key returned by the harness
+    if hasattr(chunk, "session_id") and chunk.session_id:
+        openclaw_tool.set_session_key("my_harness", context_id, chunk.session_id)
+
+    # Track progress
+    if hasattr(chunk, "tool") and chunk.tool:
+        openclaw_tool.add_progress(task_id, f"- {chunk.tool}\n")
+
+    # Return content
+    delta = chunk.choices[0].delta if chunk.choices else None
+    if delta and delta.content:
+        return delta.content
+    return None
+```
+
+Assign the custom harness to users via `OpenClawConfig`:
+
+```python
+openclaw_tool.update_openclaw_config("user_id", OpenClawConfig(
+    openclaw_api_key="key",
+    openclaw_base_url="https://my-backend.example.com",
+    harness="my_harness",
+))
 ```
 
 

--- a/aiavatar/sts/llm/tools/openclaw_tool.py
+++ b/aiavatar/sts/llm/tools/openclaw_tool.py
@@ -13,15 +13,11 @@ class OpenClawConfig:
         *,
         openclaw_api_key: str = None,
         openclaw_base_url: str = None,
-        openclaw_session_key: str = None,
-        openclaw_session_key_key: str = None,
-        openclaw_model: str = None
+        harness: str = None,
     ):
         self.openclaw_api_key = openclaw_api_key
         self.openclaw_base_url = openclaw_base_url
-        self.openclaw_session_key = openclaw_session_key
-        self.openclaw_session_key_key = openclaw_session_key_key
-        self.openclaw_model = openclaw_model
+        self.harness = harness
 
 
 class OpenClawTool(Tool):
@@ -30,10 +26,8 @@ class OpenClawTool(Tool):
         *,
         openclaw_api_key: str = None,
         openclaw_base_url: str = None,
-        openclaw_session_key: str = None,
-        openclaw_session_key_key: str = "x-openclaw-session-key",   # set "X-Hermes-Session-Id" for Hermes
-        openclaw_model: str = "openclaw",   # set "hermes-agent" for Hermes
         openclaw_configs: Dict[str, OpenClawConfig] = None,
+        harness: str = "openclaw",
         stream: bool = False,
         immediate_message: str = "Accepted. You will be notified when the response is ready.",
         timeout: int = 30000,
@@ -45,15 +39,21 @@ class OpenClawTool(Tool):
     ):
         self.openclaw_api_key = openclaw_api_key
         self.openclaw_base_url = openclaw_base_url
-        self.openclaw_session_key = openclaw_session_key
-        self.openclaw_session_key_key = openclaw_session_key_key
-        self.openclaw_model = openclaw_model
         self.openclaw_configs = openclaw_configs or {}
+        self.harness = harness
+        self._request_builders: Dict[str, Callable] = {
+            "openclaw": self._openclaw_request_builder,
+            "hermes": self._hermes_request_builder,
+        }
+        self._response_parsers: Dict[str, Callable] = {
+            "openclaw": self._openclaw_response_parser,
+            "hermes": self._hermes_response_parser,
+        }
         self.timeout = timeout
         self.stream = stream
         self.debug = debug
-        self._on_stream_chunk: Callable = None
         self._running_tasks: Dict[str, dict] = {}
+        self._session_key_map: Dict[str, str] = {}
 
         super().__init__(
             name or "send_query_to_openclaw",
@@ -78,9 +78,73 @@ class OpenClawTool(Tool):
             immediate_message=immediate_message
         )
 
-    def on_stream_chunk(self, func: Callable):
-        self._on_stream_chunk = func
-        return func
+    # Session key mapping
+
+    def get_session_key(self, harness: str, context_id: str) -> str:
+        return self._session_key_map.get(f"{harness}:{context_id}")
+
+    def set_session_key(self, harness: str, context_id: str, session_key: str):
+        self._session_key_map[f"{harness}:{context_id}"] = session_key
+
+    def delete_session_key(self, harness: str, context_id: str):
+        self._session_key_map.pop(f"{harness}:{context_id}", None)
+
+    def request_builder(self, key: str = None):
+        def decorator(func: Callable):
+            self._request_builders[key or self.harness] = func
+            return func
+        return decorator
+
+    def response_parser(self, func_or_key=None):
+        if callable(func_or_key):
+            self._response_parsers[self.harness] = func_or_key
+            return func_or_key
+        else:
+            key = func_or_key or self.harness
+            def decorator(func: Callable):
+                self._response_parsers[key] = func
+                return func
+            return decorator
+
+    @staticmethod
+    def _openclaw_request_builder(task_id: str, context_id: str) -> dict:
+        result = {"model": "openclaw"}
+        if context_id:
+            result["extra_headers"] = {"x-openclaw-session-key": context_id}
+        return result
+
+    @staticmethod
+    def _hermes_request_builder(task_id: str, context_id: str) -> dict:
+        result = {"model": "hermes-agent"}
+        if context_id:
+            result["extra_headers"] = {"X-Hermes-Session-Id": context_id}
+        return result
+
+    def _openclaw_response_parser(self, task_id: str, context_id: str, chunk) -> str:
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta and delta.content:
+            return delta.content
+        return None
+
+    def _hermes_response_parser(self, task_id: str, context_id: str, chunk) -> str:
+        # Progress tracking
+        if hasattr(chunk, "tool"):
+            progress_line = ""
+            if tool_name := chunk.tool:
+                emoji = chunk.emoji if hasattr(chunk, "emoji") else ""
+                progress_line = f"- {emoji} {tool_name}"
+                label = chunk.label if hasattr(chunk, "label") else ""
+                if label:
+                    progress_line += f": {label}"
+                progress_line += "\n"
+            if progress_line and task_id:
+                self.add_progress(task_id, progress_line)
+
+        # Extract content
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta and delta.content:
+            return delta.content
+        return None
 
     # Running tasks management
 
@@ -188,9 +252,7 @@ class OpenClawTool(Tool):
         user_config = self.openclaw_configs.get(user_id) or config
         config.openclaw_api_key = user_config.openclaw_api_key or self.openclaw_api_key
         config.openclaw_base_url = user_config.openclaw_base_url or self.openclaw_base_url
-        config.openclaw_session_key = user_config.openclaw_session_key or self.openclaw_session_key
-        config.openclaw_session_key_key = user_config.openclaw_session_key_key or self.openclaw_session_key_key
-        config.openclaw_model = user_config.openclaw_model or self.openclaw_model
+        config.harness = user_config.harness or self.harness
         return config
 
     def update_openclaw_config(self, user_id: str, config: OpenClawConfig):
@@ -206,6 +268,15 @@ class OpenClawTool(Tool):
             logger.info(f"Request to OpenClaw (from {user_id}): {query}")
 
         config = self.get_openclaw_config(user_id)
+        build_request = self._request_builders.get(
+            config.harness, self._openclaw_request_builder
+        )
+        parse_response = self._response_parsers.get(
+            config.harness, self._openclaw_response_parser
+        )
+        extra_kwargs = build_request(task_id, context_id)
+        model = extra_kwargs.pop("model", None)
+
         client = openai.AsyncClient(
             api_key=config.openclaw_api_key,
             base_url=config.openclaw_base_url,
@@ -216,39 +287,22 @@ class OpenClawTool(Tool):
             if self.stream:
                 stream = await client.chat.completions.create(
                     messages=[{"role": "user", "content": query}],
-                    model=config.openclaw_model,
+                    model=model,
                     stream=True,
-                    extra_headers={
-                        config.openclaw_session_key_key: context_id or config.openclaw_session_key
-                    }
+                    **extra_kwargs
                 )
                 chunks = []
                 async for chunk in stream:
-                    if task_id and hasattr(chunk, "tool"):
-                        progress_line = ""
-                        if tool := chunk.tool:
-                            emoji = chunk.emoji or ""
-                            progress_line = f"- {emoji} {tool}"
-                            if label := chunk.label:
-                                progress_line += f": {label}"
-                            progress_line += "\n"
-                        if progress_line:
-                            self.add_progress(task_id, progress_line)
-
-                    if self._on_stream_chunk:
-                        await self._on_stream_chunk(task_id, chunk)
-                    delta = chunk.choices[0].delta if chunk.choices else None
-                    if delta and delta.content:
-                        chunks.append(delta.content)
+                    content = parse_response(task_id, context_id, chunk)
+                    if content:
+                        chunks.append(content)
                 answer = "".join(chunks)
 
             else:
                 resp = await client.chat.completions.create(
                     messages=[{"role": "user", "content": query}],
-                    model=config.openclaw_model,
-                    extra_headers={
-                        config.openclaw_session_key_key: context_id or config.openclaw_session_key
-                    }
+                    model=model,
+                    **extra_kwargs
                 )
                 answer = resp.choices[0].message.content
         finally:

--- a/tests/sts/llm/tools/test_openclaw_running_tasks.py
+++ b/tests/sts/llm/tools/test_openclaw_running_tasks.py
@@ -189,25 +189,16 @@ def test_create_check_tool_custom_name():
 # --- Per-user OpenClaw config ---
 
 def test_get_openclaw_config_defaults_when_no_user_config():
-    tool = make_openclaw_tool(
-        openclaw_session_key="default-session",
-        openclaw_session_key_key="x-openclaw-session-key",
-        openclaw_model="openclaw",
-    )
+    tool = make_openclaw_tool()
     config = tool.get_openclaw_config("unknown_user")
 
     assert config.openclaw_api_key == "test-key"
     assert config.openclaw_base_url == "http://localhost:9999"
-    assert config.openclaw_session_key == "default-session"
-    assert config.openclaw_session_key_key == "x-openclaw-session-key"
-    assert config.openclaw_model == "openclaw"
+    assert config.harness == "openclaw"
 
 
 def test_get_openclaw_config_partial_override():
     tool = make_openclaw_tool(
-        openclaw_session_key="default-session",
-        openclaw_session_key_key="x-openclaw-session-key",
-        openclaw_model="openclaw",
         openclaw_configs={
             "user1": OpenClawConfig(
                 openclaw_api_key="user1-key",
@@ -221,23 +212,16 @@ def test_get_openclaw_config_partial_override():
     assert config.openclaw_api_key == "user1-key"
     assert config.openclaw_base_url == "http://user1-server:8000"
     # Falls back to tool defaults
-    assert config.openclaw_session_key == "default-session"
-    assert config.openclaw_session_key_key == "x-openclaw-session-key"
-    assert config.openclaw_model == "openclaw"
+    assert config.harness == "openclaw"
 
 
 def test_get_openclaw_config_full_override():
     tool = make_openclaw_tool(
-        openclaw_session_key="default-session",
-        openclaw_session_key_key="x-openclaw-session-key",
-        openclaw_model="openclaw",
         openclaw_configs={
             "user1": OpenClawConfig(
                 openclaw_api_key="user1-key",
                 openclaw_base_url="http://user1-hermes:8000",
-                openclaw_session_key="user1-session",
-                openclaw_session_key_key="X-Hermes-Session-Id",
-                openclaw_model="hermes-agent",
+                harness="hermes",
             ),
         },
     )
@@ -245,19 +229,14 @@ def test_get_openclaw_config_full_override():
 
     assert config.openclaw_api_key == "user1-key"
     assert config.openclaw_base_url == "http://user1-hermes:8000"
-    assert config.openclaw_session_key == "user1-session"
-    assert config.openclaw_session_key_key == "X-Hermes-Session-Id"
-    assert config.openclaw_model == "hermes-agent"
+    assert config.harness == "hermes"
 
 
 def test_get_openclaw_config_different_users_get_different_configs():
     tool = make_openclaw_tool(
-        openclaw_session_key="default-session",
-        openclaw_session_key_key="x-openclaw-session-key",
-        openclaw_model="openclaw",
         openclaw_configs={
             "user1": OpenClawConfig(openclaw_api_key="key-1", openclaw_base_url="http://server-1"),
-            "user2": OpenClawConfig(openclaw_api_key="key-2", openclaw_model="hermes-agent"),
+            "user2": OpenClawConfig(openclaw_api_key="key-2", harness="hermes"),
         },
     )
 
@@ -266,11 +245,11 @@ def test_get_openclaw_config_different_users_get_different_configs():
 
     assert c1.openclaw_api_key == "key-1"
     assert c1.openclaw_base_url == "http://server-1"
-    assert c1.openclaw_model == "openclaw"  # fallback
+    assert c1.harness == "openclaw"  # fallback
 
     assert c2.openclaw_api_key == "key-2"
     assert c2.openclaw_base_url == "http://localhost:9999"  # fallback
-    assert c2.openclaw_model == "hermes-agent"
+    assert c2.harness == "hermes"
 
 
 def test_update_openclaw_config():
@@ -317,15 +296,11 @@ def test_delete_openclaw_config_nonexistent_is_noop():
 async def test_call_openclaw_api_uses_user_config():
     """Verify that _call_openclaw_api creates a client with per-user config values."""
     tool = make_openclaw_tool(
-        openclaw_session_key="default-session",
-        openclaw_session_key_key="x-openclaw-session-key",
-        openclaw_model="openclaw",
         openclaw_configs={
             "user1": OpenClawConfig(
                 openclaw_api_key="user1-key",
                 openclaw_base_url="http://user1-server:8000",
-                openclaw_session_key_key="X-Hermes-Session-Id",
-                openclaw_model="hermes-agent",
+                harness="hermes",
             ),
         },
     )
@@ -347,7 +322,7 @@ async def test_call_openclaw_api_uses_user_config():
         base_url="http://user1-server:8000",
         timeout=30000,
     )
-    # API called with user1's model and header
+    # API called with hermes model and header
     call_kwargs = mock_client.chat.completions.create.call_args
     assert call_kwargs.kwargs["model"] == "hermes-agent"
     assert call_kwargs.kwargs["extra_headers"]["X-Hermes-Session-Id"] == "ctx1"
@@ -358,11 +333,7 @@ async def test_call_openclaw_api_uses_user_config():
 @pytest.mark.asyncio
 async def test_call_openclaw_api_falls_back_to_defaults():
     """Verify that _call_openclaw_api uses tool defaults for unknown users."""
-    tool = make_openclaw_tool(
-        openclaw_session_key="default-session",
-        openclaw_session_key_key="x-openclaw-session-key",
-        openclaw_model="openclaw",
-    )
+    tool = make_openclaw_tool()
 
     mock_resp = MagicMock()
     mock_resp.choices = [MagicMock()]
@@ -413,8 +384,6 @@ async def test_invoke_openclaw_rejects_unconfigured_user():
             "configured_user": OpenClawConfig(
                 openclaw_api_key="key",
                 openclaw_base_url="http://server:8000",
-                openclaw_session_key_key="x-openclaw-session-key",
-                openclaw_model="openclaw",
             ),
         },
         stream=False,
@@ -436,8 +405,6 @@ async def test_invoke_openclaw_allows_configured_user():
             "user1": OpenClawConfig(
                 openclaw_api_key="key",
                 openclaw_base_url="http://server:8000",
-                openclaw_session_key_key="x-openclaw-session-key",
-                openclaw_model="openclaw",
             ),
         },
         stream=False,
@@ -449,3 +416,146 @@ async def test_invoke_openclaw_allows_configured_user():
 
     assert result == {"answer": "success", "report_channel": None}
     mock_api.assert_awaited_once()
+
+
+# --- request_builder registry ---
+
+def test_request_builder_openclaw():
+    tool = make_openclaw_tool()
+    builder = tool._request_builders["openclaw"]
+    result = builder("task1", "ctx1")
+    assert result == {"model": "openclaw", "extra_headers": {"x-openclaw-session-key": "ctx1"}}
+
+
+def test_request_builder_openclaw_no_context_id():
+    tool = make_openclaw_tool()
+    builder = tool._request_builders["openclaw"]
+    result = builder("task1", "")
+    assert result == {"model": "openclaw"}
+    assert "extra_headers" not in result
+
+
+def test_request_builder_register_custom():
+    tool = make_openclaw_tool()
+
+    @tool.request_builder("custom")
+    def custom_builder(task_id, context_id):
+        return {"extra_body": {"session_id": context_id}}
+
+    assert "custom" in tool._request_builders
+    result = tool._request_builders["custom"]("task1", "ctx1")
+    assert result == {"extra_body": {"session_id": "ctx1"}}
+
+
+@pytest.mark.asyncio
+async def test_call_openclaw_api_uses_custom_request_builder():
+    tool = make_openclaw_tool(
+        openclaw_configs={
+            "user1": OpenClawConfig(
+                openclaw_api_key="key1",
+                openclaw_base_url="http://custom:8000",
+                harness="custom",
+            ),
+        },
+    )
+
+    @tool.request_builder("custom")
+    def custom_builder(task_id, context_id):
+        return {"model": "custom-model", "extra_body": {"session_id": context_id}}
+
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock()]
+    mock_resp.choices[0].message.content = "custom response"
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+    mock_client.close = AsyncMock()
+
+    with patch("aiavatar.sts.llm.tools.openclaw_tool.openai.AsyncClient", return_value=mock_client):
+        answer = await tool._call_openclaw_api("hello", "ctx1", "user1", "task1")
+
+    call_kwargs = mock_client.chat.completions.create.call_args
+    assert call_kwargs.kwargs["extra_body"] == {"session_id": "ctx1"}
+    assert "extra_headers" not in call_kwargs.kwargs
+    assert answer == "custom response"
+
+
+# --- response_parser registry ---
+
+def test_response_parser_register_with_key():
+    tool = make_openclaw_tool()
+
+    @tool.response_parser("hermes")
+    def hermes_parser(task_id, context_id, chunk):
+        return f"hermes: {chunk}\n"
+
+    assert "hermes" in tool._response_parsers
+    assert tool._response_parsers["hermes"]("task1", "ctx1", "step1") == "hermes: step1\n"
+
+
+def test_response_parser_backward_compat_no_key():
+    tool = make_openclaw_tool()
+
+    @tool.response_parser
+    def my_parser(task_id, context_id, chunk):
+        return f"custom: {chunk}\n"
+
+    assert tool._response_parsers["openclaw"] is my_parser
+    assert my_parser("task1", "ctx1", "step1") == "custom: step1\n"
+
+
+def test_get_openclaw_config_resolves_harness():
+    tool = make_openclaw_tool(
+        openclaw_configs={
+            "user1": OpenClawConfig(
+                openclaw_api_key="key1",
+                openclaw_base_url="http://server:8000",
+                harness="hermes",
+            ),
+        },
+    )
+    config = tool.get_openclaw_config("user1")
+    assert config.harness == "hermes"
+
+
+def test_get_openclaw_config_falls_back_to_tool_default_harness():
+    tool = make_openclaw_tool()
+    config = tool.get_openclaw_config("unknown_user")
+    assert config.harness == "openclaw"
+
+
+# --- hermes harness ---
+
+@pytest.mark.asyncio
+async def test_call_openclaw_api_hermes_uses_correct_header_and_model():
+    tool = make_openclaw_tool(
+        openclaw_configs={
+            "user1": OpenClawConfig(
+                openclaw_api_key="hermes-key",
+                openclaw_base_url="http://hermes:8000",
+                harness="hermes",
+            ),
+        },
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock()]
+    mock_resp.choices[0].message.content = "hermes response"
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+    mock_client.close = AsyncMock()
+
+    with patch("aiavatar.sts.llm.tools.openclaw_tool.openai.AsyncClient", return_value=mock_client):
+        answer = await tool._call_openclaw_api("hello", "ctx1", "user1", "task1")
+
+    call_kwargs = mock_client.chat.completions.create.call_args
+    assert call_kwargs.kwargs["model"] == "hermes-agent"
+    assert call_kwargs.kwargs["extra_headers"]["X-Hermes-Session-Id"] == "ctx1"
+    assert answer == "hermes response"
+
+
+def test_hermes_request_builder_registered():
+    tool = make_openclaw_tool()
+    assert "hermes" in tool._request_builders
+    assert "hermes" in tool._response_parsers


### PR DESCRIPTION
Request builders and response parsers are now pluggable per harness key, allowing `OpenClawTool` to connect to any backend beyond the built-in ones. OpenClaw and Hermes are pre-registered and work out of the box.