### PR TITLE
Support OpenAI-style initial messages in GeminiService

### DIFF
--- a/aiavatar/sts/llm/gemini.py
+++ b/aiavatar/sts/llm/gemini.py
@@ -96,6 +96,12 @@ class GeminiService(LLMService):
         # Add initial messages (e.g. few-shot, preset turns)
         initial_msgs = await self._get_initial_messages(context_id, user_id, system_prompt_params)
         if initial_msgs:
+            for msg in initial_msgs:
+                # Convert OpenAI-style initial messages to Gemini format (text-only fallback)
+                if content := msg.get("content"):
+                    if isinstance(content, str):
+                        msg["parts"] = [{"text": content}]
+                        del msg["content"]
             messages.extend(initial_msgs)
 
         # Extract the history starting from the first message where the role is 'user'


### PR DESCRIPTION
Auto-convert initial messages with "content" key to Gemini's "parts" format in `compose_messages`, so OpenAI-style messages work without manual conversion.