### PR TITLE
Add audio filters: gate, EQ, AGC, recorder

### DIFF
--- a/aiavatar/sts/vad/filters/__init__.py
+++ b/aiavatar/sts/vad/filters/__init__.py
@@ -1,0 +1,5 @@
+from .base import AudioFilter
+from .near_field import NearFieldAudioGate
+from .eq import HighShelfFilter
+from .agc import AGCFilter
+from .debug import SessionAudioRecorder

--- a/aiavatar/sts/vad/filters/agc.py
+++ b/aiavatar/sts/vad/filters/agc.py
@@ -1,0 +1,132 @@
+import logging
+import math
+from typing import Dict, Optional
+
+import numpy as np
+
+from .base import AudioFilter
+
+logger = logging.getLogger(__name__)
+
+
+class AGCState:
+    def __init__(self):
+        self.gain_db: float = 0.0
+        self.last_applied_gain: float = 1.0
+        # Diagnostics
+        self.last_rms_db: Optional[float] = None
+        self.last_gain_db: float = 0.0
+
+
+class AGCFilter(AudioFilter):
+    """Automatic gain control that normalizes speech towards a target level.
+
+    Slowly raises the gain of quiet audio (e.g. telephony) towards
+    `target_rms_db` and quickly backs off when the input gets loud. Gain
+    adaptation only happens on chunks above `silence_rms_db`, so silence
+    (or audio attenuated by an upstream gate) does not pump the gain up.
+
+    A per-chunk peak limiter caps the applied gain so samples never clip,
+    and gain changes are ramped across each chunk to avoid zipper noise.
+
+    Place this AFTER NearFieldAudioGate: putting it before would amplify
+    far-field audio and break the gate's absolute level threshold
+    (min_rms_db).
+    """
+
+    def __init__(
+        self,
+        *,
+        target_rms_db: float = -20.0,
+        max_gain_db: float = 18.0,
+        min_gain_db: float = 0.0,
+        up_db_per_sec: float = 10.0,
+        down_db_per_sec: float = 60.0,
+        silence_rms_db: float = -55.0,
+        limiter_headroom_db: float = 1.0,
+        sample_rate: int = 16000,
+        channels: int = 1,
+    ):
+        self.target_rms_db = float(target_rms_db)
+        self.max_gain_db = float(max_gain_db)
+        self.min_gain_db = float(min_gain_db)
+        self.up_db_per_sec = max(0.0, float(up_db_per_sec))
+        self.down_db_per_sec = max(0.0, float(down_db_per_sec))
+        self.silence_rms_db = float(silence_rms_db)
+        self.limiter_headroom_db = max(0.0, float(limiter_headroom_db))
+        self.sample_rate = sample_rate
+        self.channels = max(1, int(channels))
+        self._states: Dict[str, AGCState] = {}
+
+    def get_config(self) -> dict:
+        return {
+            "target_rms_db": self.target_rms_db,
+            "max_gain_db": self.max_gain_db,
+            "min_gain_db": self.min_gain_db,
+            "up_db_per_sec": self.up_db_per_sec,
+            "down_db_per_sec": self.down_db_per_sec,
+            "silence_rms_db": self.silence_rms_db,
+            "limiter_headroom_db": self.limiter_headroom_db,
+            "sample_rate": self.sample_rate,
+            "channels": self.channels,
+        }
+
+    def get_diagnostics(self, session_id: str) -> Optional[dict]:
+        state = self._states.get(session_id)
+        if state is None:
+            return None
+        return {
+            "rms_db": state.last_rms_db,
+            "gain_db": state.last_gain_db,
+        }
+
+    def _get_state(self, session_id: str) -> AGCState:
+        state = self._states.get(session_id)
+        if state is None:
+            state = AGCState()
+            self._states[session_id] = state
+        return state
+
+    def process(self, samples: bytes, session_id: str) -> bytes:
+        usable_len = len(samples) - (len(samples) % 2)
+        if usable_len <= 0:
+            return samples
+
+        state = self._get_state(session_id)
+        audio = np.frombuffer(samples[:usable_len], dtype=np.int16).astype(np.float32)
+        duration = (len(audio) / self.channels) / self.sample_rate
+
+        rms = float(np.sqrt(np.mean(np.square(audio))))
+        rms_db = 20.0 * math.log10(max(rms, 1.0) / 32768.0)
+        state.last_rms_db = rms_db
+
+        # Adapt gain only while there is actual signal; hold during silence
+        if rms_db >= self.silence_rms_db:
+            desired_gain_db = min(self.max_gain_db, max(self.min_gain_db, self.target_rms_db - rms_db))
+            if desired_gain_db > state.gain_db:
+                state.gain_db = min(desired_gain_db, state.gain_db + self.up_db_per_sec * duration)
+            else:
+                state.gain_db = max(desired_gain_db, state.gain_db - self.down_db_per_sec * duration)
+
+        gain = 10.0 ** (state.gain_db / 20.0)
+
+        # Per-chunk peak limiter: never let the applied gain clip the samples
+        peak = float(np.abs(audio).max())
+        if peak > 0.0:
+            max_gain = (32767.0 * 10.0 ** (-self.limiter_headroom_db / 20.0)) / peak
+            gain = min(gain, max_gain)
+        state.last_gain_db = 20.0 * math.log10(max(gain, 1e-6))
+
+        # Ramp between the previous chunk's gain and this one to avoid zipper noise
+        if gain == state.last_applied_gain:
+            if gain != 1.0:
+                audio *= gain
+        else:
+            audio *= np.linspace(state.last_applied_gain, gain, audio.size, dtype=np.float32)
+        state.last_applied_gain = gain
+
+        processed = np.clip(audio, -32768.0, 32767.0).astype(np.int16)
+        return processed.tobytes() + samples[usable_len:]
+
+    def reset_session(self, session_id: str):
+        self._states.pop(session_id, None)

--- a/aiavatar/sts/vad/filters/base.py
+++ b/aiavatar/sts/vad/filters/base.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+
+
+class AudioFilter(ABC):
+    """Transforms audio samples (16-bit linear PCM) before VAD processing.
+
+    Filters are chained in order via SpeechDetector's `audio_filters`.
+    All downstream processing (VAD, recording, recognition) sees the
+    filtered audio, so the VAD logic itself stays untouched. Use this
+    for acoustic transforms such as gating, noise suppression, gain
+    normalization or target speech extraction.
+
+    A filter may hold audio back internally (e.g. a lookahead buffer)
+    and return fewer or more bytes than it received, including b"" while
+    warming up. The only requirement is that audio is conserved over the
+    session.
+    """
+
+    @abstractmethod
+    def process(self, samples: bytes, session_id: str) -> bytes:
+        pass
+
+    def reset_session(self, session_id: str):
+        """Called when the session is deleted. Override to release per-session state."""
+        pass
+
+    def get_config(self) -> dict:
+        return {}
+
+    def set_config(self, config: dict) -> dict:
+        allowed_keys = self.get_config().keys()
+        updated = {}
+        for k, v in config.items():
+            if v is None:
+                continue
+            if k not in allowed_keys:
+                continue
+            try:
+                setattr(self, k, v)
+                updated[k] = v
+            except Exception:
+                pass
+        return updated

--- a/aiavatar/sts/vad/filters/debug.py
+++ b/aiavatar/sts/vad/filters/debug.py
@@ -1,0 +1,195 @@
+from datetime import datetime
+import logging
+import os
+import re
+import time
+from typing import Dict, Iterable, Optional, Set
+import wave
+
+from .base import AudioFilter
+
+logger = logging.getLogger(__name__)
+
+
+class _SessionWavWriter:
+    """Writes one label's audio for one session, rotating files by duration."""
+
+    def __init__(self, directory: str, label: str, sample_rate: int, channels: int, max_file_duration: Optional[float]):
+        self.directory = directory
+        self.label = label
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.max_file_duration = max_file_duration
+        self.part = 0
+        self.frames_written = 0
+        self._writer: Optional[wave.Wave_write] = None
+
+    def _open_next(self):
+        self.part += 1
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        path = os.path.join(self.directory, f"{self.label}_{timestamp}_{self.part:03d}.wav")
+        self._writer = wave.open(path, "wb")
+        self._writer.setnchannels(self.channels)
+        self._writer.setsampwidth(2)
+        self._writer.setframerate(self.sample_rate)
+        self.frames_written = 0
+        logger.info(f"SessionAudioRecorder({self.label}) recording to {path}")
+
+    def write(self, samples: bytes):
+        if self._writer is None:
+            self._open_next()
+        elif self.max_file_duration is not None and self.frames_written / self.sample_rate >= self.max_file_duration:
+            self.close()
+            self._open_next()
+        self._writer.writeframes(samples)
+        self.frames_written += len(samples) // (2 * self.channels)
+
+    def close(self):
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            except Exception:
+                logger.error(f"SessionAudioRecorder({self.label}) failed to close writer", exc_info=True)
+            self._writer = None
+
+
+class _RecorderTap(AudioFilter):
+    """Pass-through tap that feeds audio into a SessionAudioRecorder."""
+
+    def __init__(self, recorder: "SessionAudioRecorder", label: str):
+        self.recorder = recorder
+        self.label = label
+
+    def process(self, samples: bytes, session_id: str) -> bytes:
+        self.recorder.write(session_id, self.label, samples)
+        return samples
+
+    def reset_session(self, session_id: str):
+        # Detector's delete_session reaches here: the session is over
+        self.recorder.finalize_session(session_id)
+
+
+class SessionAudioRecorder:
+    """Debug recorder that captures per-session audio continuously to WAV files.
+
+    Unlike RecordingSession (which is reset per utterance), this records for
+    the whole lifetime of a session ID. Place taps at any points of the
+    audio_filters chain to capture and compare the audio at those points,
+    e.g. raw vs gated:
+
+        recorder = SessionAudioRecorder("debug_audio")
+        detector = SileroStreamSpeechDetector(
+            ...,
+            audio_filters=[
+                recorder.tap("raw"),
+                NearFieldAudioGate(),
+                recorder.tap("gated"),
+            ]
+        )
+
+    Files are written under `directory/<session_id>/<label>_<timestamp>_<part>.wav`.
+    Audio is streamed to disk incrementally (not buffered in memory), so memory
+    usage stays constant regardless of session length.
+
+    Session end must be explicit: it happens automatically when the detector's
+    delete_session / finalize_session runs (e.g. on WebSocket disconnect), or
+    call finalize_session() / close() directly. As a safety net, sessions idle
+    longer than `session_ttl` seconds are finalized opportunistically so file
+    handles cannot leak when a session ends without cleanup.
+
+    Note: taps placed after a lookahead filter (e.g. NearFieldAudioGate)
+    receive audio delayed by its lookahead duration, so the "gated" file is
+    time-shifted and slightly shorter than the "raw" file.
+
+    Set `target_session_ids` to record only specific sessions (None records
+    all). The set can be mutated at runtime to start/stop capturing a
+    problematic session in production.
+    """
+
+    def __init__(
+        self,
+        directory: str,
+        *,
+        sample_rate: int = 16000,
+        channels: int = 1,
+        target_session_ids: Optional[Iterable[str]] = None,
+        max_file_duration: Optional[float] = None,
+        session_ttl: float = 3600.0,
+    ):
+        self.directory = directory
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.target_session_ids: Optional[Set[str]] = set(target_session_ids) if target_session_ids is not None else None
+        self.max_file_duration = max_file_duration
+        self.session_ttl = session_ttl
+        self._sessions: Dict[str, Dict[str, _SessionWavWriter]] = {}
+        self._last_activity: Dict[str, float] = {}
+        self._last_sweep: float = time.time()
+        os.makedirs(self.directory, exist_ok=True)
+
+    def tap(self, label: str) -> AudioFilter:
+        """Create a pass-through AudioFilter that records audio under the given label."""
+        return _RecorderTap(self, label)
+
+    def _session_directory(self, session_id: str) -> str:
+        safe_session_id = re.sub(r"[^\w.-]", "_", session_id)
+        path = os.path.join(self.directory, safe_session_id)
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def write(self, session_id: str, label: str, samples: bytes):
+        if self.target_session_ids is not None and session_id not in self.target_session_ids:
+            return
+        if not samples:
+            return
+
+        try:
+            now = time.time()
+            self._last_activity[session_id] = now
+
+            writers = self._sessions.get(session_id)
+            if writers is None:
+                writers = {}
+                self._sessions[session_id] = writers
+
+            writer = writers.get(label)
+            if writer is None:
+                writer = _SessionWavWriter(
+                    self._session_directory(session_id),
+                    label,
+                    self.sample_rate,
+                    self.channels,
+                    self.max_file_duration
+                )
+                writers[label] = writer
+
+            writer.write(samples)
+
+            self._sweep(now)
+
+        except Exception:
+            logger.error("SessionAudioRecorder failed to write audio", exc_info=True)
+
+    def _sweep(self, now: float):
+        # Opportunistic safety net: finalize sessions that ended without cleanup
+        if now - self._last_sweep < min(60.0, self.session_ttl):
+            return
+        self._last_sweep = now
+        for session_id, last_activity in list(self._last_activity.items()):
+            if now - last_activity >= self.session_ttl:
+                logger.warning(f"SessionAudioRecorder finalizing idle session: {session_id}")
+                self.finalize_session(session_id)
+
+    def finalize_session(self, session_id: str):
+        """Close and flush all files for the session. Called automatically via
+        the detector's delete_session / finalize_session."""
+        writers = self._sessions.pop(session_id, None)
+        self._last_activity.pop(session_id, None)
+        if writers:
+            for writer in writers.values():
+                writer.close()
+
+    def close(self):
+        """Finalize all sessions."""
+        for session_id in list(self._sessions.keys()):
+            self.finalize_session(session_id)

--- a/aiavatar/sts/vad/filters/eq.py
+++ b/aiavatar/sts/vad/filters/eq.py
@@ -1,0 +1,113 @@
+import logging
+import math
+from typing import Dict, List
+
+import numpy as np
+
+from .base import AudioFilter
+
+logger = logging.getLogger(__name__)
+
+
+class HighShelfFilter(AudioFilter):
+    """Biquad high-shelf EQ that boosts (or cuts) frequencies above the cutoff.
+
+    Intended to recover intelligibility of fricatives (sibilants like /s/)
+    on band-limited audio such as telephony: what little energy remains in
+    the 2-3.4 kHz range gets emphasized so the recognizer can use it.
+
+    Note: this can only emphasize what is present in the signal. Telephony
+    audio carries nothing above about 3.4 kHz, and no EQ can restore it.
+
+    Coefficients follow the RBJ Audio EQ Cookbook. The filter is stateful
+    per session so chunk boundaries are seamless.
+    """
+
+    def __init__(
+        self,
+        *,
+        gain_db: float = 6.0,
+        cutoff_hz: float = 2000.0,
+        slope: float = 1.0,
+        sample_rate: int = 16000,
+        channels: int = 1,
+    ):
+        self.gain_db = float(gain_db)
+        self.cutoff_hz = float(cutoff_hz)
+        self.slope = float(slope)
+        self.sample_rate = sample_rate
+        self.channels = max(1, int(channels))
+        # (z1, z2) per channel per session
+        self._states: Dict[str, List[List[float]]] = {}
+        self._update_coefficients()
+
+    def _update_coefficients(self):
+        A = 10.0 ** (self.gain_db / 40.0)
+        w0 = 2.0 * math.pi * self.cutoff_hz / self.sample_rate
+        cos_w0 = math.cos(w0)
+        sin_w0 = math.sin(w0)
+        alpha = sin_w0 / 2.0 * math.sqrt((A + 1.0 / A) * (1.0 / self.slope - 1.0) + 2.0)
+        sqrt_a2_alpha = 2.0 * math.sqrt(A) * alpha
+
+        b0 = A * ((A + 1.0) + (A - 1.0) * cos_w0 + sqrt_a2_alpha)
+        b1 = -2.0 * A * ((A - 1.0) + (A + 1.0) * cos_w0)
+        b2 = A * ((A + 1.0) + (A - 1.0) * cos_w0 - sqrt_a2_alpha)
+        a0 = (A + 1.0) - (A - 1.0) * cos_w0 + sqrt_a2_alpha
+        a1 = 2.0 * ((A - 1.0) - (A + 1.0) * cos_w0)
+        a2 = (A + 1.0) - (A - 1.0) * cos_w0 - sqrt_a2_alpha
+
+        self._b0 = b0 / a0
+        self._b1 = b1 / a0
+        self._b2 = b2 / a0
+        self._a1 = a1 / a0
+        self._a2 = a2 / a0
+
+    def get_config(self) -> dict:
+        return {
+            "gain_db": self.gain_db,
+            "cutoff_hz": self.cutoff_hz,
+            "slope": self.slope,
+            "sample_rate": self.sample_rate,
+            "channels": self.channels,
+        }
+
+    def set_config(self, config: dict) -> dict:
+        updated = super().set_config(config)
+        if updated:
+            self._update_coefficients()
+        return updated
+
+    def _get_state(self, session_id: str) -> List[List[float]]:
+        state = self._states.get(session_id)
+        if state is None:
+            state = [[0.0, 0.0] for _ in range(self.channels)]
+            self._states[session_id] = state
+        return state
+
+    def process(self, samples: bytes, session_id: str) -> bytes:
+        usable_len = len(samples) - (len(samples) % 2)
+        if usable_len <= 0:
+            return samples
+
+        state = self._get_state(session_id)
+        audio = np.frombuffer(samples[:usable_len], dtype=np.int16).astype(np.float64).tolist()
+
+        b0, b1, b2, a1, a2 = self._b0, self._b1, self._b2, self._a1, self._a2
+        channels = self.channels
+        # Direct Form II Transposed, per channel state for interleaved samples
+        for ch in range(channels):
+            z1, z2 = state[ch]
+            for i in range(ch, len(audio), channels):
+                x = audio[i]
+                y = b0 * x + z1
+                z1 = b1 * x - a1 * y + z2
+                z2 = b2 * x - a2 * y
+                audio[i] = y
+            state[ch][0] = z1
+            state[ch][1] = z2
+
+        filtered = np.clip(np.asarray(audio), -32768.0, 32767.0).astype(np.int16)
+        return filtered.tobytes() + samples[usable_len:]
+
+    def reset_session(self, session_id: str):
+        self._states.pop(session_id, None)

--- a/aiavatar/sts/vad/filters/near_field.py
+++ b/aiavatar/sts/vad/filters/near_field.py
@@ -1,0 +1,295 @@
+from collections import deque
+import logging
+import math
+from typing import Dict, Optional
+
+import numpy as np
+
+from .base import AudioFilter
+
+logger = logging.getLogger(__name__)
+
+
+class NearFieldGateState:
+    def __init__(self, closed_gain: float, initial_ambient_db: float):
+        # Lookahead delay line: [samples, duration, gain] entries not yet emitted
+        self.pending: deque = deque()
+        self.pending_duration: float = 0.0
+        # Ambient noise floor estimation: (rms_db, duration) entries
+        self.rms_history: deque = deque()
+        self.rms_history_duration: float = 0.0
+        self.elapsed: float = 0.0
+        self.is_open: bool = False
+        self.open_streak_duration: float = 0.0
+        self.not_passing_duration: float = 0.0
+        self.last_emitted_gain: float = closed_gain
+        # Diagnostics
+        self.last_rms_db: Optional[float] = None
+        self.last_ambient_db: float = initial_ambient_db
+        self.last_snr_db: Optional[float] = None
+        self.last_gate_reason: str = "not_checked"
+
+
+class NearFieldAudioGate(AudioFilter):
+    """Acoustic gate that attenuates far-field audio before it reaches the VAD.
+
+    Instead of overriding the VAD verdict, this filter controls what audio
+    flows downstream: audio judged as coming from the main (near-field)
+    speaker passes through unchanged, everything else is attenuated by
+    `closed_gain`. The VAD and recording pipeline behave exactly as usual,
+    but they only "hear" the main speaker — so far-field speech neither
+    starts a recording nor contaminates the audio sent to the recognizer.
+
+    The near/far decision compares each chunk's RMS level against a
+    dynamically estimated ambient noise floor (a low percentile of recent
+    quiet-chunk RMS history). The gate opens when the SNR stays above
+    `open_snr_db_threshold` for `open_min_duration`, and closes when the
+    open condition keeps failing for `close_min_duration`.
+
+    Opening the gate takes `open_min_duration`, so the filter delays its
+    output by `lookahead_duration`: when the gate opens, chunks still in
+    the delay line — including the speech onset — are released at full
+    gain. Keep `lookahead_duration >= open_min_duration` so the beginning
+    of utterances is never clipped. The whole pipeline is delayed by
+    `lookahead_duration` (120 ms by default) as a trade-off.
+
+    Gain transitions are crossfaded over one chunk to avoid clicks.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        sample_rate: int = 16000,
+        channels: int = 1,
+        closed_gain: float = 0.05,
+        lookahead_duration: float = 0.12,
+        min_rms_db: Optional[float] = -42.0,
+        open_snr_db_threshold: float = 12.0,
+        close_snr_db_threshold: float = 6.0,
+        open_min_duration: float = 0.06,
+        close_min_duration: float = 0.4,
+        ambient_window_duration: float = 2.5,
+        ambient_percentile: float = 25.0,
+        initial_ambient_db: float = -65.0,
+        calibration_duration: float = 0.0,
+        update_ambient_with_rejected_speech: bool = True,
+        ambient_max_rise_db_per_update: Optional[float] = 3.0,
+        debug: bool = False,
+    ):
+        self.enabled = enabled
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.closed_gain = max(0.0, min(1.0, float(closed_gain)))
+        self.lookahead_duration = max(0.0, float(lookahead_duration))
+        self.min_rms_db = min_rms_db
+        self.open_snr_db_threshold = float(open_snr_db_threshold)
+        self.close_snr_db_threshold = float(close_snr_db_threshold)
+        self.open_min_duration = max(0.0, float(open_min_duration))
+        self.close_min_duration = max(0.0, float(close_min_duration))
+        self.ambient_window_duration = max(0.1, float(ambient_window_duration))
+        self.ambient_percentile = float(ambient_percentile)
+        self.initial_ambient_db = float(initial_ambient_db)
+        self.calibration_duration = max(0.0, float(calibration_duration))
+        self.update_ambient_with_rejected_speech = update_ambient_with_rejected_speech
+        self.ambient_max_rise_db_per_update = ambient_max_rise_db_per_update
+        self.debug = debug
+        self._states: Dict[str, NearFieldGateState] = {}
+
+    def get_config(self) -> dict:
+        return {
+            "enabled": self.enabled,
+            "sample_rate": self.sample_rate,
+            "channels": self.channels,
+            "closed_gain": self.closed_gain,
+            "lookahead_duration": self.lookahead_duration,
+            "min_rms_db": self.min_rms_db,
+            "open_snr_db_threshold": self.open_snr_db_threshold,
+            "close_snr_db_threshold": self.close_snr_db_threshold,
+            "open_min_duration": self.open_min_duration,
+            "close_min_duration": self.close_min_duration,
+            "ambient_window_duration": self.ambient_window_duration,
+            "ambient_percentile": self.ambient_percentile,
+            "initial_ambient_db": self.initial_ambient_db,
+            "calibration_duration": self.calibration_duration,
+            "update_ambient_with_rejected_speech": self.update_ambient_with_rejected_speech,
+            "ambient_max_rise_db_per_update": self.ambient_max_rise_db_per_update,
+            "debug": self.debug,
+        }
+
+    def get_diagnostics(self, session_id: str) -> Optional[dict]:
+        state = self._states.get(session_id)
+        if state is None:
+            return None
+        return {
+            "rms_db": state.last_rms_db,
+            "ambient_db": state.last_ambient_db,
+            "snr_db": state.last_snr_db,
+            "is_open": state.is_open,
+            "gate_reason": state.last_gate_reason,
+            "pending_duration": state.pending_duration,
+        }
+
+    def _get_state(self, session_id: str) -> NearFieldGateState:
+        state = self._states.get(session_id)
+        if state is None:
+            state = NearFieldGateState(self.closed_gain, self.initial_ambient_db)
+            self._states[session_id] = state
+        return state
+
+    def _rms_dbfs(self, samples: bytes) -> float:
+        usable_len = len(samples) - (len(samples) % 2)
+        if usable_len <= 0:
+            return -120.0
+
+        audio = np.frombuffer(samples[:usable_len], dtype=np.int16)
+        if audio.size == 0:
+            return -120.0
+
+        rms = float(np.sqrt(np.mean(np.square(audio.astype(np.float32)))))
+        return 20.0 * math.log10(max(rms, 1.0) / 32768.0)
+
+    def _ambient_db(self, state: NearFieldGateState) -> float:
+        if not state.rms_history:
+            return self.initial_ambient_db
+        percentile = min(100.0, max(0.0, self.ambient_percentile))
+        values = np.asarray([v for v, _ in state.rms_history], dtype=np.float32)
+        return float(np.percentile(values, percentile))
+
+    def _update_ambient(self, state: NearFieldGateState, rms_db: float, duration: float):
+        ambient_db = self._ambient_db(state)
+        if self.ambient_max_rise_db_per_update is not None:
+            max_rms_db = ambient_db + float(self.ambient_max_rise_db_per_update)
+            rms_db = min(float(rms_db), max_rms_db)
+
+        state.rms_history.append((float(rms_db), duration))
+        state.rms_history_duration += duration
+        while state.rms_history and state.rms_history_duration > self.ambient_window_duration:
+            _, dropped_duration = state.rms_history.popleft()
+            state.rms_history_duration -= dropped_duration
+        state.last_ambient_db = self._ambient_db(state)
+
+    def _apply_gain(self, samples: bytes, from_gain: float, to_gain: float) -> bytes:
+        if from_gain == 1.0 and to_gain == 1.0:
+            return samples
+
+        usable_len = len(samples) - (len(samples) % 2)
+        if usable_len <= 0:
+            return samples
+
+        audio = np.frombuffer(samples[:usable_len], dtype=np.int16).astype(np.float32)
+        if from_gain == to_gain:
+            audio *= to_gain
+        else:
+            # Crossfade over the chunk to avoid clicks at gate transitions
+            audio *= np.linspace(from_gain, to_gain, audio.size, dtype=np.float32)
+        return np.clip(audio, -32768.0, 32767.0).astype(np.int16).tobytes() + samples[usable_len:]
+
+    def _emit(self, state: NearFieldGateState, flush: bool = False) -> bytes:
+        output = bytearray()
+        while state.pending:
+            if not flush and state.pending_duration - state.pending[0][1] < self.lookahead_duration:
+                # Keep at least lookahead_duration buffered
+                break
+            samples, duration, gain = state.pending.popleft()
+            state.pending_duration -= duration
+            output.extend(self._apply_gain(samples, state.last_emitted_gain, gain))
+            state.last_emitted_gain = gain
+        return bytes(output)
+
+    def process(self, samples: bytes, session_id: str) -> bytes:
+        state = self._get_state(session_id)
+
+        if not self.enabled:
+            state.last_gate_reason = "disabled"
+            # Flush any buffered audio, then pass through without delay
+            return self._emit(state, flush=True) + samples
+
+        duration = (len(samples) / 2) / (self.sample_rate * self.channels)
+        state.elapsed += duration
+
+        rms_db = self._rms_dbfs(samples)
+        ambient_db = self._ambient_db(state)
+        snr_db = rms_db - ambient_db
+
+        state.last_rms_db = rms_db
+        state.last_ambient_db = ambient_db
+        state.last_snr_db = snr_db
+
+        in_calibration = state.elapsed <= self.calibration_duration
+        passes_min_rms = self.min_rms_db is None or rms_db >= self.min_rms_db
+        passes_snr = snr_db >= self.open_snr_db_threshold
+        passes = passes_min_rms and passes_snr and not in_calibration
+        is_quiet = snr_db < self.close_snr_db_threshold
+
+        if state.is_open:
+            if passes:
+                state.not_passing_duration = 0.0
+            else:
+                state.not_passing_duration += duration
+                if is_quiet:
+                    # Keep the ambient estimate updated with quiet chunks
+                    # between the main speaker's words
+                    self._update_ambient(state, rms_db, duration)
+                if state.not_passing_duration >= self.close_min_duration:
+                    state.is_open = False
+                    state.open_streak_duration = 0.0
+            state.last_gate_reason = "open" if state.is_open else "closed"
+        else:
+            if in_calibration:
+                self._update_ambient(state, rms_db, duration)
+                state.open_streak_duration = 0.0
+                state.last_gate_reason = "calibrating"
+            elif passes:
+                state.open_streak_duration += duration
+                if state.open_streak_duration >= self.open_min_duration:
+                    state.is_open = True
+                    state.not_passing_duration = 0.0
+                    # Retroactively release the buffered chunks — they contain
+                    # the onset of the utterance
+                    for entry in state.pending:
+                        entry[2] = 1.0
+                    state.last_gate_reason = "open"
+                else:
+                    state.last_gate_reason = "waiting_open_duration"
+            else:
+                state.open_streak_duration = 0.0
+                if is_quiet or self.update_ambient_with_rejected_speech:
+                    self._update_ambient(state, rms_db, duration)
+                if not passes_min_rms:
+                    state.last_gate_reason = "below_min_rms"
+                elif not passes_snr:
+                    state.last_gate_reason = "below_snr"
+                else:
+                    state.last_gate_reason = "closed"
+
+        gain = 1.0 if state.is_open else self.closed_gain
+        state.pending.append([samples, duration, gain])
+        state.pending_duration += duration
+
+        output = self._emit(state)
+
+        if self.debug:
+            logger.debug(
+                "near-field audio gate: open=%s reason=%s rms_db=%.1f ambient_db=%.1f snr_db=%.1f pending=%.3fs out_bytes=%s session=%s",
+                state.is_open,
+                state.last_gate_reason,
+                rms_db,
+                ambient_db,
+                snr_db,
+                state.pending_duration,
+                len(output),
+                session_id,
+            )
+
+        return output
+
+    def flush(self, session_id: str) -> bytes:
+        """Emit all buffered audio for the session without waiting for lookahead."""
+        state = self._states.get(session_id)
+        if state is None:
+            return b""
+        return self._emit(state, flush=True)
+
+    def reset_session(self, session_id: str):
+        self._states.pop(session_id, None)

--- a/aiavatar/sts/vad/silero.py
+++ b/aiavatar/sts/vad/silero.py
@@ -5,9 +5,10 @@ import os
 import struct
 import threading
 import torch
-from typing import AsyncGenerator, Callable, Optional, Dict, Awaitable
+from typing import AsyncGenerator, Callable, List, Optional, Dict, Awaitable
 from . import SpeechDetector
 from .base import RecordingSessionBase
+from .filters.base import AudioFilter
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +50,14 @@ class SileroSpeechDetector(SpeechDetector):
         model_pool_size: int = 1,
         on_recording_started: Optional[Callable[[str], Awaitable[None]]] = None,
         on_recording_started_min_duration: float = 1.5,
-        use_vad_iterator: bool = False
+        use_vad_iterator: bool = False,
+        audio_filters: Optional[List[AudioFilter]] = None
     ):
         super().__init__(
             sample_rate=sample_rate,
             on_recording_started_min_duration=on_recording_started_min_duration
         )
+        self.audio_filters = audio_filters or []
         self._volume_db_threshold = volume_db_threshold
         if volume_db_threshold is not None:
             self.amplitude_threshold = 32767 * (10 ** (self.volume_db_threshold / 20.0))
@@ -241,7 +244,15 @@ class SileroSpeechDetector(SpeechDetector):
         if self.to_linear16:
             samples = self.to_linear16(samples)
 
+        # Apply acoustic filters (near-field gate, noise suppression, etc.)
+        for audio_filter in self.audio_filters:
+            samples = audio_filter.process(samples, session_id)
+
         session = self.get_session(session_id)
+
+        if not samples:
+            # A filter is holding audio back (e.g. lookahead buffer warming up)
+            return session.is_recording
 
         if self.should_mute():
             session.reset()
@@ -397,6 +408,11 @@ class SileroSpeechDetector(SpeechDetector):
         if session_id in self.recording_sessions:
             self.recording_sessions[session_id].reset()
             del self.recording_sessions[session_id]
+        for audio_filter in self.audio_filters:
+            try:
+                audio_filter.reset_session(session_id)
+            except Exception:
+                logger.error("Error resetting audio filter session state", exc_info=True)
 
     def get_session_data(self, session_id: str, key: str):
         session = self.recording_sessions.get(session_id)

--- a/aiavatar/sts/vad/stream.py
+++ b/aiavatar/sts/vad/stream.py
@@ -3,6 +3,7 @@ import logging
 import struct
 from typing import Callable, Optional, Dict, List, Awaitable
 from .silero import SileroSpeechDetector, RecordingSession as SileroRecordingSession
+from .filters.base import AudioFilter
 from ..stt.base import SpeechRecognizer
 
 logger = logging.getLogger(__name__)
@@ -53,7 +54,8 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
         on_recording_started: Optional[Callable[[str], Awaitable[None]]] = None,
         on_recording_started_min_duration: float = 1.5,
         on_recording_started_min_text_length: int = 2,
-        use_vad_iterator: bool = False
+        use_vad_iterator: bool = False,
+        audio_filters: Optional[List[AudioFilter]] = None
     ):
         super().__init__(
             volume_db_threshold=volume_db_threshold,
@@ -71,7 +73,8 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
             model_pool_size=model_pool_size,
             on_recording_started=on_recording_started,
             on_recording_started_min_duration=on_recording_started_min_duration,
-            use_vad_iterator=use_vad_iterator
+            use_vad_iterator=use_vad_iterator,
+            audio_filters=audio_filters
         )
         self.speech_recognizer = speech_recognizer
         self.segment_silence_threshold = segment_silence_threshold
@@ -124,7 +127,15 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
         if self.to_linear16:
             samples = self.to_linear16(samples)
 
+        # Apply acoustic filters (near-field gate, noise suppression, etc.)
+        for audio_filter in self.audio_filters:
+            samples = audio_filter.process(samples, session_id)
+
         session = self.get_session(session_id)
+
+        if not samples:
+            # A filter is holding audio back (e.g. lookahead buffer warming up)
+            return session.is_recording
 
         if self.should_mute():
             session.reset()

--- a/tests/sts/vad/test_filters.py
+++ b/tests/sts/vad/test_filters.py
@@ -1,0 +1,399 @@
+import math
+import struct
+import wave
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from aiavatar.sts.vad.filters import AudioFilter, NearFieldAudioGate, HighShelfFilter, AGCFilter, SessionAudioRecorder
+
+SAMPLE_RATE = 16000
+CHUNK_SAMPLES = 512
+CHUNK_DURATION = CHUNK_SAMPLES / SAMPLE_RATE  # 0.032 sec
+
+
+def make_chunk(amplitude: int, samples: int = CHUNK_SAMPLES) -> bytes:
+    """Generate a sine wave chunk with the given peak amplitude"""
+    frames = []
+    for i in range(samples):
+        value = int(amplitude * math.sin(2 * math.pi * 220 * i / SAMPLE_RATE))
+        frames.append(struct.pack("<h", value))
+    return b"".join(frames)
+
+
+def max_amplitude(pcm: bytes) -> int:
+    if len(pcm) < 2:
+        return 0
+    return int(np.abs(np.frombuffer(pcm, dtype=np.int16)).max())
+
+
+def make_gate(**kwargs) -> NearFieldAudioGate:
+    params = dict(
+        sample_rate=SAMPLE_RATE,
+        closed_gain=0.05,
+        lookahead_duration=0.12,     # about 4 chunks
+        min_rms_db=-42.0,
+        open_snr_db_threshold=12.0,
+        close_snr_db_threshold=6.0,
+        open_min_duration=0.06,      # about 2 chunks
+        close_min_duration=0.4,
+        ambient_window_duration=2.5,
+        initial_ambient_db=-65.0,
+    )
+    params.update(kwargs)
+    return NearFieldAudioGate(**params)
+
+
+def feed_chunks(gate: NearFieldAudioGate, chunks, session_id: str = "session1") -> bytes:
+    output = bytearray()
+    for chunk in chunks:
+        output.extend(gate.process(chunk, session_id))
+    return bytes(output)
+
+
+def build_ambient(gate: NearFieldAudioGate, amplitude: int = 30, chunks: int = 60, session_id: str = "session1") -> bytes:
+    """Feed quiet chunks to settle the ambient noise floor"""
+    return feed_chunks(gate, [make_chunk(amplitude)] * chunks, session_id)
+
+
+def test_audio_is_conserved_through_lookahead():
+    gate = make_gate()
+    quiet = make_chunk(30)
+
+    emitted = 0
+    for _ in range(20):
+        emitted += len(gate.process(quiet, "session1"))
+
+    pending = gate.get_diagnostics("session1")["pending_duration"]
+    assert emitted + int(pending * SAMPLE_RATE) * 2 == len(quiet) * 20
+    # Delay line holds at least lookahead_duration
+    assert pending >= gate.lookahead_duration
+
+    emitted += len(gate.flush("session1"))
+    assert emitted == len(quiet) * 20
+
+
+def test_far_speech_is_attenuated():
+    gate = make_gate()
+    build_ambient(gate)
+
+    far = make_chunk(300)  # about -43 dBFS: below min_rms_db
+    output = feed_chunks(gate, [far] * 20)
+    output += gate.flush("session1")
+
+    assert gate.get_diagnostics("session1")["is_open"] is False
+    # Trailing part of output is the far speech, attenuated by closed_gain
+    far_part = output[-len(far) * 10:]
+    assert max_amplitude(far_part) <= 300 * 0.05 + 2
+
+
+def test_near_speech_passes_with_onset_preserved():
+    gate = make_gate()
+    build_ambient(gate)
+
+    loud = make_chunk(8000)
+    output = feed_chunks(gate, [loud] * 10)
+    output += gate.flush("session1")
+
+    assert gate.get_diagnostics("session1")["is_open"] is True
+    # The loud region is the last 10 chunks of the output
+    loud_part = np.abs(np.frombuffer(output[-len(loud) * 10:], dtype=np.int16))
+    assert loud_part.max() >= 8000 * 0.9
+    # Onset preservation: even the FIRST loud chunk was released (mostly) open
+    # thanks to the lookahead buffer. Allow for the crossfade ramp.
+    first_chunk = loud_part[:CHUNK_SAMPLES]
+    assert first_chunk.max() >= 8000 * 0.5
+
+
+def test_gate_closes_after_silence_and_rejects_far_speech_again():
+    gate = make_gate()
+    build_ambient(gate)
+
+    loud = make_chunk(8000)
+    quiet = make_chunk(30)
+    far = make_chunk(300)
+
+    feed_chunks(gate, [loud] * 10)
+    assert gate.get_diagnostics("session1")["is_open"] is True
+
+    # Silence longer than close_min_duration (0.4 sec = about 13 chunks)
+    feed_chunks(gate, [quiet] * 20)
+    assert gate.get_diagnostics("session1")["is_open"] is False
+
+    # Far speech afterwards stays attenuated
+    output = feed_chunks(gate, [far] * 20)
+    output += gate.flush("session1")
+    assert gate.get_diagnostics("session1")["is_open"] is False
+    far_part = output[-len(far) * 10:]
+    assert max_amplitude(far_part) <= 300 * 0.05 + 2
+
+
+def test_gate_survives_short_pauses_within_turn():
+    gate = make_gate()
+    build_ambient(gate)
+
+    loud = make_chunk(8000)
+    quiet = make_chunk(30)
+
+    feed_chunks(gate, [loud] * 10)
+    # Short pause (about 0.19 sec) < close_min_duration (0.4 sec)
+    feed_chunks(gate, [quiet] * 6)
+    assert gate.get_diagnostics("session1")["is_open"] is True
+    # Speech resumes without needing to re-open
+    feed_chunks(gate, [loud] * 3)
+    assert gate.get_diagnostics("session1")["is_open"] is True
+
+
+def test_low_snr_speech_is_rejected():
+    gate = make_gate(
+        min_rms_db=None,  # SNR only
+        ambient_max_rise_db_per_update=None,  # Let ambient follow the noisy environment immediately
+        calibration_duration=2.0,  # Learn the noisy environment before judging (required when noise is present from the start)
+    )
+    # Noisy environment from the start: ambient around -32 dBFS
+    build_ambient(gate, amplitude=1200, chunks=80)
+
+    # Speech only about 6 dB above ambient
+    low_snr = make_chunk(2400)
+    feed_chunks(gate, [low_snr] * 20)
+    assert gate.get_diagnostics("session1")["is_open"] is False
+    assert gate.get_diagnostics("session1")["gate_reason"] == "below_snr"
+
+    # Speech well above ambient opens the gate
+    loud = make_chunk(16000)
+    feed_chunks(gate, [loud] * 5)
+    assert gate.get_diagnostics("session1")["is_open"] is True
+
+
+def test_disabled_gate_passes_audio_through_without_delay():
+    gate = make_gate(enabled=False)
+    chunk = make_chunk(300)
+    assert gate.process(chunk, "session1") == chunk
+
+
+def test_sessions_are_isolated_and_resettable():
+    gate = make_gate()
+    build_ambient(gate, session_id="session1")
+
+    loud = make_chunk(8000)
+    feed_chunks(gate, [loud] * 10, session_id="session1")
+    assert gate.get_diagnostics("session1")["is_open"] is True
+
+    # Another session starts closed with its own ambient state
+    feed_chunks(gate, [loud] * 1, session_id="session2")
+    assert gate.get_diagnostics("session2")["is_open"] is False
+
+    gate.reset_session("session1")
+    assert gate.get_diagnostics("session1") is None
+    assert gate.get_diagnostics("session2") is not None
+
+
+def test_set_config():
+    gate = make_gate()
+    updated = gate.set_config({"open_snr_db_threshold": 6.0, "unknown_key": 1})
+    assert updated == {"open_snr_db_threshold": 6.0}
+    assert gate.open_snr_db_threshold == 6.0
+
+
+def read_wav_frames(path: Path) -> int:
+    with wave.open(str(path), "rb") as f:
+        return f.getnframes()
+
+
+def test_recorder_captures_raw_and_gated_pair(tmp_path: Path):
+    recorder = SessionAudioRecorder(str(tmp_path), sample_rate=SAMPLE_RATE)
+    gate = make_gate()
+    chain = [recorder.tap("raw"), gate, recorder.tap("gated")]
+
+    quiet = make_chunk(30)
+    loud = make_chunk(8000)
+    fed = 0
+    for chunk in [quiet] * 60 + [loud] * 10:
+        samples = chunk
+        for f in chain:
+            samples = f.process(samples, "session1")
+        fed += 1
+
+    recorder.finalize_session("session1")
+
+    raw_files = list((tmp_path / "session1").glob("raw_*.wav"))
+    gated_files = list((tmp_path / "session1").glob("gated_*.wav"))
+    assert len(raw_files) == 1
+    assert len(gated_files) == 1
+
+    # Raw file holds everything; gated file lacks the audio still pending
+    # in the gate's lookahead buffer
+    raw_frames = read_wav_frames(raw_files[0])
+    gated_frames = read_wav_frames(gated_files[0])
+    pending_frames = int(gate.get_diagnostics("session1")["pending_duration"] * SAMPLE_RATE)
+    assert raw_frames == CHUNK_SAMPLES * fed
+    assert gated_frames == raw_frames - pending_frames
+
+
+def test_recorder_records_across_utterance_resets(tmp_path: Path):
+    """Recording continues for the whole session, not per utterance"""
+    recorder = SessionAudioRecorder(str(tmp_path), sample_rate=SAMPLE_RATE)
+    tap = recorder.tap("raw")
+
+    # Two "utterances" with silence between: still one continuous file
+    for chunk in [make_chunk(8000)] * 5 + [make_chunk(0)] * 30 + [make_chunk(8000)] * 5:
+        tap.process(chunk, "session1")
+    recorder.finalize_session("session1")
+
+    raw_files = list((tmp_path / "session1").glob("raw_*.wav"))
+    assert len(raw_files) == 1
+    assert read_wav_frames(raw_files[0]) == CHUNK_SAMPLES * 40
+
+
+def test_recorder_target_session_filtering(tmp_path: Path):
+    recorder = SessionAudioRecorder(str(tmp_path), sample_rate=SAMPLE_RATE, target_session_ids=["target"])
+    tap = recorder.tap("raw")
+    chunk = make_chunk(8000)
+
+    tap.process(chunk, "other")
+    tap.process(chunk, "target")
+
+    # Sessions can be added at runtime
+    recorder.target_session_ids.add("other")
+    tap.process(chunk, "other")
+
+    recorder.close()
+    assert not (tmp_path / "other").exists() or read_wav_frames(next((tmp_path / "other").glob("raw_*.wav"))) == CHUNK_SAMPLES
+    assert read_wav_frames(next((tmp_path / "target").glob("raw_*.wav"))) == CHUNK_SAMPLES
+
+
+def test_recorder_rotates_files_by_duration(tmp_path: Path):
+    recorder = SessionAudioRecorder(
+        str(tmp_path),
+        sample_rate=SAMPLE_RATE,
+        max_file_duration=CHUNK_DURATION * 3  # Rotate every 3 chunks
+    )
+    tap = recorder.tap("raw")
+    for _ in range(7):
+        tap.process(make_chunk(8000), "session1")
+    recorder.close()
+
+    raw_files = sorted((tmp_path / "session1").glob("raw_*.wav"))
+    assert len(raw_files) == 3  # 3 + 3 + 1 chunks
+    assert sum(read_wav_frames(p) for p in raw_files) == CHUNK_SAMPLES * 7
+
+
+def test_recorder_finalizes_via_tap_reset_session(tmp_path: Path):
+    """Detector's delete_session propagates to taps and closes the files"""
+    recorder = SessionAudioRecorder(str(tmp_path), sample_rate=SAMPLE_RATE)
+    tap = recorder.tap("raw")
+    tap.process(make_chunk(8000), "session1")
+
+    tap.reset_session("session1")
+
+    assert "session1" not in recorder._sessions
+    # File header is finalized and readable
+    assert read_wav_frames(next((tmp_path / "session1").glob("raw_*.wav"))) == CHUNK_SAMPLES
+
+
+def test_recorder_ttl_sweep_finalizes_stale_sessions(tmp_path: Path):
+    import time as time_module
+    recorder = SessionAudioRecorder(str(tmp_path), sample_rate=SAMPLE_RATE, session_ttl=10.0)
+    tap = recorder.tap("raw")
+
+    tap.process(make_chunk(8000), "stale")
+    # Simulate a session that ended without cleanup long ago
+    recorder._last_activity["stale"] = time_module.time() - 100
+    recorder._last_sweep = time_module.time() - 100
+
+    tap.process(make_chunk(8000), "active")
+
+    assert "stale" not in recorder._sessions
+    assert "active" in recorder._sessions
+    recorder.close()
+
+
+def make_sine(freq: float, amplitude: int, samples: int) -> bytes:
+    frames = []
+    for i in range(samples):
+        value = int(amplitude * math.sin(2 * math.pi * freq * i / SAMPLE_RATE))
+        frames.append(struct.pack("<h", value))
+    return b"".join(frames)
+
+
+def rms_db(pcm: bytes) -> float:
+    audio = np.frombuffer(pcm, dtype=np.int16).astype(np.float32)
+    rms = float(np.sqrt(np.mean(np.square(audio))))
+    return 20.0 * math.log10(max(rms, 1.0) / 32768.0)
+
+
+def test_high_shelf_boosts_high_frequencies_only():
+    eq = HighShelfFilter(gain_db=6.0, cutoff_hz=2000.0, sample_rate=SAMPLE_RATE)
+
+    # 3000 Hz (above cutoff): boosted by about +6 dB
+    high = make_sine(3000, 4000, SAMPLE_RATE)  # 1 sec
+    out_high = eq.process(high, "s_high")
+    assert 4.5 <= rms_db(out_high[3200:]) - rms_db(high[3200:]) <= 7.5  # Skip filter transient
+
+    # 300 Hz (below cutoff): nearly unchanged
+    low = make_sine(300, 4000, SAMPLE_RATE)
+    out_low = eq.process(low, "s_low")
+    assert abs(rms_db(out_low[3200:]) - rms_db(low[3200:])) <= 1.0
+
+
+def test_high_shelf_is_seamless_across_chunks():
+    """Chunked processing gives identical output to whole-buffer processing"""
+    signal = make_sine(2500, 8000, CHUNK_SAMPLES * 10)
+
+    eq1 = HighShelfFilter(sample_rate=SAMPLE_RATE)
+    whole = eq1.process(signal, "s")
+
+    eq2 = HighShelfFilter(sample_rate=SAMPLE_RATE)
+    chunked = bytearray()
+    for i in range(0, len(signal), CHUNK_SAMPLES * 2):
+        chunked.extend(eq2.process(signal[i:i + CHUNK_SAMPLES * 2], "s"))
+
+    assert bytes(chunked) == whole
+
+
+def test_agc_raises_quiet_audio_towards_target():
+    agc = AGCFilter(target_rms_db=-20.0, max_gain_db=18.0, up_db_per_sec=10.0, sample_rate=SAMPLE_RATE)
+    quiet = make_sine(440, 1000, CHUNK_SAMPLES)  # about -33 dBFS rms
+
+    first = agc.process(quiet, "s")
+    # Gain ramps up slowly: the first chunk is nearly unchanged
+    assert rms_db(first) < -30.0
+
+    for _ in range(int(3.0 / CHUNK_DURATION)):  # 3 seconds
+        out = agc.process(quiet, "s")
+    assert -22.0 <= rms_db(out) <= -18.0  # Settled near target
+
+
+def test_agc_does_not_clip_loud_audio():
+    agc = AGCFilter(target_rms_db=-3.0, max_gain_db=18.0, up_db_per_sec=1000.0, sample_rate=SAMPLE_RATE)
+    loud = make_sine(440, 30000, CHUNK_SAMPLES)
+
+    for _ in range(30):
+        out = agc.process(loud, "s")
+    audio = np.frombuffer(out, dtype=np.int16)
+    # Peak limiter keeps samples below full scale (1 dB headroom)
+    assert int(np.abs(audio).max()) <= 30000 + 1
+
+
+def test_agc_holds_gain_during_silence():
+    agc = AGCFilter(target_rms_db=-20.0, silence_rms_db=-55.0, sample_rate=SAMPLE_RATE)
+    quiet = make_sine(440, 1000, CHUNK_SAMPLES)
+    silence = b"\x00\x00" * CHUNK_SAMPLES
+
+    for _ in range(30):
+        agc.process(quiet, "s")
+    gain_after_speech = agc.get_diagnostics("s")["gain_db"]
+
+    for _ in range(100):
+        agc.process(silence, "s")
+    # Silence must not pump the gain towards max
+    assert abs(agc.get_diagnostics("s")["gain_db"] - gain_after_speech) <= 1.0
+
+
+def test_filter_interfaces(tmp_path: Path):
+    recorder = SessionAudioRecorder(str(tmp_path))
+    assert isinstance(recorder.tap("raw"), AudioFilter)
+    assert issubclass(NearFieldAudioGate, AudioFilter)
+    assert issubclass(HighShelfFilter, AudioFilter)
+    assert issubclass(AGCFilter, AudioFilter)


### PR DESCRIPTION
Introduce a filters subsystem for VAD audio preprocessing and debugging.

Adds AudioFilter base plus implementations:
- NearFieldAudioGate (lookahead-based near/far gate with ambient estimation)
- HighShelfFilter (stateful biquad high-shelf EQ)
- AGCFilter (automatic gain control with per-chunk limiter and ramping)
- SessionAudioRecorder (tap-based WAV writer with rotation/TTL)