### PR TITLE
Add turn-end gate support to VAD

### DIFF
--- a/aiavatar/sts/vad/__init__.py
+++ b/aiavatar/sts/vad/__init__.py
@@ -1,2 +1,3 @@
 from .base import SpeechDetector, SpeechDetectorDummy
 from .standard import StandardSpeechDetector
+from .turn_end_gates import TurnEndDecision, TurnEndGate

--- a/aiavatar/sts/vad/silero.py
+++ b/aiavatar/sts/vad/silero.py
@@ -9,6 +9,7 @@ from typing import AsyncGenerator, Callable, List, Optional, Dict, Awaitable
 from . import SpeechDetector
 from .base import RecordingSessionBase
 from .filters.base import AudioFilter
+from .turn_end_gates.base import TurnEndGate
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +21,12 @@ class RecordingSession(RecordingSessionBase):
         self.vad_buffer: bytearray = bytearray()
         self.vad_iterator = vad_iterator
         self.is_speech_active: bool = False  # VAD state: True after 'start', False after 'end'
+        self.turn_end_gate_hold_active: bool = False
 
     def reset(self):
         super().reset()
         self.is_speech_active = False
+        self.turn_end_gate_hold_active = False
         self.amplitude_threshold = None
         # Reset VAD iterator state for next utterance
         if self.vad_iterator:
@@ -51,7 +54,9 @@ class SileroSpeechDetector(SpeechDetector):
         on_recording_started: Optional[Callable[[str], Awaitable[None]]] = None,
         on_recording_started_min_duration: float = 1.5,
         use_vad_iterator: bool = False,
-        audio_filters: Optional[List[AudioFilter]] = None
+        audio_filters: Optional[List[AudioFilter]] = None,
+        turn_end_gate: Optional[TurnEndGate] = None,
+        turn_end_gate_timeout: Optional[float] = 1.5
     ):
         super().__init__(
             sample_rate=sample_rate,
@@ -79,6 +84,8 @@ class SileroSpeechDetector(SpeechDetector):
         self.chunk_size = chunk_size
         self.model_pool_size = model_pool_size
         self.use_vad_iterator = use_vad_iterator
+        self.turn_end_gate = turn_end_gate
+        self.turn_end_gate_timeout = turn_end_gate_timeout
 
         # Initialize Silero VAD model pool
         self._init_silero_model(model_path)
@@ -96,6 +103,7 @@ class SileroSpeechDetector(SpeechDetector):
             "speech_probability_threshold": self.speech_probability_threshold,
             "chunk_size": self.chunk_size,
             "use_vad_iterator": self.use_vad_iterator,
+            "turn_end_gate_timeout": self.turn_end_gate_timeout,
         }
 
     def set_config(self, config: dict) -> dict:
@@ -237,6 +245,78 @@ class SileroSpeechDetector(SpeechDetector):
             logger.error(f"Error in Silero VAD detection: {e}")
             return False
 
+    async def _should_end_turn_with_gate(
+        self,
+        session: RecordingSession,
+        recorded_duration: float,
+        text: Optional[str] = None,
+    ) -> bool:
+        """Confirm a VAD turn-end candidate with the optional gate.
+
+        The gate is only consulted after silence_duration_threshold has already
+        been met. turn_end_gate_timeout forces completion after the configured
+        extra silence, even if the gate keeps returning should_end=False.
+        """
+        if self.turn_end_gate is None:
+            return True
+
+        hold_duration = max(0.0, session.silence_duration - self.silence_duration_threshold)
+        if self.turn_end_gate_timeout is not None and hold_duration >= self.turn_end_gate_timeout:
+            if self.debug:
+                logger.info(
+                    "Turn-end gate: FORCE timeout session=%s, hold_duration=%.3f, timeout=%.3f",
+                    session.session_id,
+                    hold_duration,
+                    self.turn_end_gate_timeout
+                )
+            return True
+
+        if session.turn_end_gate_hold_active:
+            return False
+
+        try:
+            decision = await self.turn_end_gate.should_end_turn(
+                audio=bytes(session.buffer),
+                sample_rate=self.sample_rate,
+                channels=self.channels,
+                recorded_duration=recorded_duration,
+                silence_duration=session.silence_duration,
+                session_id=session.session_id,
+                text=text,
+                session=session,
+            )
+        except Exception:
+            logger.error("Error in turn-end gate; ending turn with default behavior", exc_info=True)
+            return True
+
+        if isinstance(decision, bool):
+            should_end = decision
+            confidence = None
+            reason = None
+        else:
+            should_end = decision.should_end
+            confidence = decision.confidence
+            reason = decision.reason
+
+        if self.debug:
+            logger.info(
+                "Turn-end gate: %s session=%s, confidence=%s, reason=%s, hold_duration=%.3f",
+                "PASS" if should_end else "WAIT",
+                session.session_id,
+                confidence,
+                reason,
+                hold_duration
+            )
+        if not should_end:
+            session.turn_end_gate_hold_active = True
+            if self.debug and self.turn_end_gate_timeout is not None:
+                logger.info(
+                    "Turn-end gate: WAIT latched session=%s, will force after %.3f sec of additional silence",
+                    session.session_id,
+                    self.turn_end_gate_timeout
+                )
+        return should_end
+
     async def execute_on_speech_detected(self, recorded_data: bytes, recorded_duration: float, session_id: str):
         await self._execute_on_speech_detected(recorded_data, None, None, recorded_duration, session_id)
 
@@ -308,6 +388,7 @@ class SileroSpeechDetector(SpeechDetector):
 
             if speech_detected:
                 session.silence_duration = 0
+                session.turn_end_gate_hold_active = False
             else:
                 session.silence_duration += sample_duration
 
@@ -321,6 +402,9 @@ class SileroSpeechDetector(SpeechDetector):
                     if self.debug:
                         logger.info(f"Recording too short: {recorded_duration} sec")
                 else:
+                    if not await self._should_end_turn_with_gate(session, recorded_duration):
+                        return session.is_recording
+
                     if self.debug:
                         logger.info(f"Recording finished: {recorded_duration} sec")
                     recorded_data = bytes(session.buffer)

--- a/aiavatar/sts/vad/stream.py
+++ b/aiavatar/sts/vad/stream.py
@@ -4,6 +4,7 @@ import struct
 from typing import Callable, Optional, Dict, List, Awaitable
 from .silero import SileroSpeechDetector, RecordingSession as SileroRecordingSession
 from .filters.base import AudioFilter
+from .turn_end_gates.base import TurnEndGate
 from ..stt.base import SpeechRecognizer
 
 logger = logging.getLogger(__name__)
@@ -55,7 +56,9 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
         on_recording_started_min_duration: float = 1.5,
         on_recording_started_min_text_length: int = 2,
         use_vad_iterator: bool = False,
-        audio_filters: Optional[List[AudioFilter]] = None
+        audio_filters: Optional[List[AudioFilter]] = None,
+        turn_end_gate: Optional[TurnEndGate] = None,
+        turn_end_gate_timeout: Optional[float] = 1.5
     ):
         super().__init__(
             volume_db_threshold=volume_db_threshold,
@@ -74,7 +77,9 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
             on_recording_started=on_recording_started,
             on_recording_started_min_duration=on_recording_started_min_duration,
             use_vad_iterator=use_vad_iterator,
-            audio_filters=audio_filters
+            audio_filters=audio_filters,
+            turn_end_gate=turn_end_gate,
+            turn_end_gate_timeout=turn_end_gate_timeout
         )
         self.speech_recognizer = speech_recognizer
         self.segment_silence_threshold = segment_silence_threshold
@@ -122,6 +127,39 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
 
     async def execute_on_speech_detected(self, recorded_data: bytes, text: str, metadata: dict, recorded_duration: float, session_id: str):
         await self._execute_on_speech_detected(recorded_data, text, metadata, recorded_duration, session_id)
+
+    async def _wait_pending_recognition_task(self, session: RecordingSession, context: str):
+        task = session.pending_recognition_task
+        if task is None:
+            return
+
+        try:
+            await task
+        except asyncio.CancelledError:
+            current_task = asyncio.current_task()
+            if current_task is not None and current_task.cancelling():
+                raise
+            if self.debug:
+                logger.info(
+                    "Pending recognition task was cancelled while waiting %s: session=%s",
+                    context,
+                    session.session_id
+                )
+        except Exception:
+            logger.error(
+                "Error waiting for pending recognition %s",
+                context,
+                exc_info=True
+            )
+
+    async def _should_end_turn_with_gate(self, session: RecordingSession, recorded_duration: float) -> bool:
+        if self.turn_end_gate and session.pending_recognition_task is not None:
+            await self._wait_pending_recognition_task(session, "before turn-end gate")
+        return await super()._should_end_turn_with_gate(
+            session,
+            recorded_duration,
+            text=session.last_recognized_text,
+        )
 
     async def process_samples(self, samples: bytes, session_id: str) -> bool:
         if self.to_linear16:
@@ -195,6 +233,7 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
 
             if speech_detected:
                 session.silence_duration = 0
+                session.turn_end_gate_hold_active = False
                 session.segment_silence_duration = 0
                 # Reset fired flag when speech resumes
                 session.segment_fired = False
@@ -238,15 +277,14 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
                     if self.debug:
                         logger.info(f"Recording too short: {recorded_duration} sec")
                 else:
+                    if not await self._should_end_turn_with_gate(session, recorded_duration):
+                        return session.is_recording
+
                     if self.debug:
                         logger.info(f"Recording finished: {recorded_duration} sec")
 
                     # Wait for pending recognition task to complete
-                    if session.pending_recognition_task is not None:
-                        try:
-                            await session.pending_recognition_task
-                        except Exception as ex:
-                            logger.error("Error waiting for pending recognition", exc_info=True)
+                    await self._wait_pending_recognition_task(session, "before final recognition")
 
                     # Use last recognized text if available, otherwise run final recognition
                     final_text = session.last_recognized_text
@@ -279,11 +317,7 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
                     logger.info(f"Recording max duration reached: {session.record_duration} sec")
 
                 # Wait for pending recognition task to complete
-                if session.pending_recognition_task is not None:
-                    try:
-                        await session.pending_recognition_task
-                    except Exception as ex:
-                        logger.error("Error waiting for pending recognition", exc_info=True)
+                await self._wait_pending_recognition_task(session, "at max duration")
 
                 # Use last recognized text if available
                 final_text = session.last_recognized_text

--- a/aiavatar/sts/vad/turn_end_gates/__init__.py
+++ b/aiavatar/sts/vad/turn_end_gates/__init__.py
@@ -1,0 +1,14 @@
+from .base import TurnEndDecision, TurnEndGate
+
+
+def __getattr__(name):
+    if name == "SmartTurnEndGate":
+        from .smart_turn import SmartTurnEndGate
+        return SmartTurnEndGate
+    if name == "NamoTurnEndGate":
+        from .namo_turn import NamoTurnEndGate
+        return NamoTurnEndGate
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["TurnEndDecision", "TurnEndGate", "SmartTurnEndGate", "NamoTurnEndGate"]

--- a/aiavatar/sts/vad/turn_end_gates/base.py
+++ b/aiavatar/sts/vad/turn_end_gates/base.py
@@ -1,0 +1,33 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class TurnEndDecision:
+    should_end: bool
+    confidence: Optional[float] = None
+    reason: Optional[str] = None
+
+
+class TurnEndGate(ABC):
+    """Optional confirmation gate for VAD turn-end candidates.
+
+    VAD implementations call this only after their normal turn-end candidate
+    condition is met, such as silence_duration_threshold for Silero.
+    """
+
+    @abstractmethod
+    async def should_end_turn(
+        self,
+        *,
+        audio: bytes,
+        sample_rate: int,
+        channels: int,
+        recorded_duration: float,
+        silence_duration: float,
+        session_id: str,
+        text: Optional[str] = None,
+        session: Any = None,
+    ) -> TurnEndDecision:
+        pass

--- a/aiavatar/sts/vad/turn_end_gates/namo_turn.py
+++ b/aiavatar/sts/vad/turn_end_gates/namo_turn.py
@@ -1,0 +1,178 @@
+import asyncio
+import logging
+import threading
+from typing import Any, Optional
+
+import numpy as np
+import onnxruntime as ort
+from huggingface_hub import hf_hub_download
+from transformers import AutoTokenizer
+
+from .base import TurnEndDecision, TurnEndGate
+
+logger = logging.getLogger(__name__)
+
+
+_LANGUAGE_MAP = {
+    "ar": "Arabic",
+    "bn": "Bengali",
+    "zh": "Chinese",
+    "da": "Danish",
+    "nl": "Dutch",
+    "de": "German",
+    "en": "English",
+    "fi": "Finnish",
+    "fr": "French",
+    "hi": "Hindi",
+    "id": "Indonesian",
+    "it": "Italian",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "mr": "Marathi",
+    "no": "Norwegian",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "es": "Spanish",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "vi": "Vietnamese",
+}
+
+
+def get_namo_repo_id(language: Optional[str] = "ja") -> str:
+    if language is None:
+        return "videosdk-live/Namo-Turn-Detector-v1-Multilingual"
+    lang_name = _LANGUAGE_MAP.get(language.lower(), language.capitalize())
+    return f"videosdk-live/Namo-Turn-Detector-v1-{lang_name}"
+
+
+class NamoTurnEndGate(TurnEndGate):
+    """Text-based turn-end confirmation gate backed by Namo Turn Detector v1."""
+
+    def __init__(
+        self,
+        *,
+        language: Optional[str] = "ja",
+        repo_id: Optional[str] = None,
+        model_path: Optional[str] = None,
+        model_filename: str = "model_quant.onnx",
+        tokenizer: Any = None,
+        session: Any = None,
+        threshold: float = 0.5,
+        max_length: Optional[int] = None,
+        truncation_side: str = "left",
+        no_text_should_end: bool = True,
+        providers: Optional[list[str]] = None,
+        inter_op_num_threads: int = 1,
+        debug: bool = False,
+    ):
+        self.language = language
+        self.repo_id = repo_id or get_namo_repo_id(language)
+        self.threshold = threshold
+        self.no_text_should_end = no_text_should_end
+        self.max_length = max_length if max_length is not None else (8192 if language is None else 512)
+        self.truncation_side = truncation_side
+        self.debug = debug
+        self._lock = threading.Lock()
+
+        self.tokenizer = tokenizer or AutoTokenizer.from_pretrained(
+            self.repo_id,
+            truncation_side=self.truncation_side,
+        )
+
+        if session is None:
+            if model_path is None:
+                model_path = hf_hub_download(repo_id=self.repo_id, filename=model_filename)
+            session = self._build_session(
+                model_path=model_path,
+                providers=providers,
+                inter_op_num_threads=inter_op_num_threads,
+            )
+        self.session = session
+
+    def _build_session(
+        self,
+        *,
+        model_path: str,
+        providers: Optional[list[str]],
+        inter_op_num_threads: int,
+    ):
+        options = ort.SessionOptions()
+        options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
+        options.inter_op_num_threads = inter_op_num_threads
+        options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        kwargs = {"sess_options": options}
+        if providers:
+            kwargs["providers"] = providers
+        return ort.InferenceSession(model_path, **kwargs)
+
+    def _predict(self, text: str) -> tuple[int, float]:
+        inputs = self.tokenizer(
+            text,
+            truncation=True,
+            max_length=self.max_length,
+            return_tensors="np",
+        )
+        feed_dict = {
+            "input_ids": inputs["input_ids"],
+            "attention_mask": inputs["attention_mask"],
+        }
+        with self._lock:
+            outputs = self.session.run(None, feed_dict)
+        probabilities = self._softmax(np.asarray(outputs[0])[0])
+        predicted_label = int(np.argmax(probabilities))
+        confidence = float(np.max(probabilities))
+        return predicted_label, confidence
+
+    def _softmax(self, x: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
+        if axis is None:
+            axis = -1
+        exp_x = np.exp(x - np.max(x, axis=axis, keepdims=True))
+        return exp_x / np.sum(exp_x, axis=axis, keepdims=True)
+
+    async def should_end_turn(
+        self,
+        *,
+        audio: bytes,
+        sample_rate: int,
+        channels: int,
+        recorded_duration: float,
+        silence_duration: float,
+        session_id: str,
+        text: Optional[str] = None,
+        session: Any = None,
+    ) -> TurnEndDecision:
+        normalized_text = (text or "").strip()
+        if not normalized_text:
+            if self.debug:
+                logger.info(
+                    "Namo Turn: %s no_text session=%s, recorded_duration=%.3f, silence_duration=%.3f",
+                    "PASS complete" if self.no_text_should_end else "WAIT incomplete",
+                    session_id,
+                    recorded_duration,
+                    silence_duration,
+                )
+            return TurnEndDecision(
+                should_end=self.no_text_should_end,
+                confidence=None,
+                reason="namo_no_text",
+            )
+
+        predicted_label, confidence = await asyncio.to_thread(self._predict, normalized_text)
+        should_end = predicted_label == 1 and confidence >= self.threshold
+        if self.debug:
+            logger.info(
+                "Namo Turn: %s session=%s, label=%s, confidence=%.3f, threshold=%.3f, text=%r",
+                "PASS complete" if should_end else "WAIT incomplete",
+                session_id,
+                predicted_label,
+                confidence,
+                self.threshold,
+                normalized_text,
+            )
+        return TurnEndDecision(
+            should_end=should_end,
+            confidence=confidence,
+            reason="namo_end_of_turn" if should_end else "namo_not_end_of_turn",
+        )

--- a/aiavatar/sts/vad/turn_end_gates/smart_turn.py
+++ b/aiavatar/sts/vad/turn_end_gates/smart_turn.py
@@ -1,0 +1,166 @@
+import asyncio
+import logging
+import threading
+from typing import Any, Optional, Sequence
+
+import numpy as np
+import onnxruntime as ort
+from huggingface_hub import hf_hub_download
+from transformers import WhisperFeatureExtractor
+
+from .base import TurnEndDecision, TurnEndGate
+
+logger = logging.getLogger(__name__)
+
+
+class SmartTurnEndGate(TurnEndGate):
+    """Turn-end confirmation gate backed by pipecat-ai Smart Turn.
+
+    This gate is intended to run after a normal VAD silence threshold is met.
+    It accepts Linear16 PCM bytes from the current turn and runs Smart Turn on
+    the last max_audio_duration seconds, padding at the beginning when shorter.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_path: Optional[str] = None,
+        threshold: float = 0.5,
+        max_audio_duration: float = 8.0,
+        target_sample_rate: int = 16000,
+        providers: Optional[Sequence[str]] = None,
+        inter_op_num_threads: int = 1,
+        feature_extractor: Any = None,
+        session: Any = None,
+        hf_repo_id: str = "pipecat-ai/smart-turn-v3",
+        hf_filename: str = "smart-turn-v3.2-cpu.onnx",
+        debug: bool = False,
+    ):
+        self.threshold = threshold
+        self.max_audio_duration = max_audio_duration
+        self.target_sample_rate = target_sample_rate
+        self.debug = debug
+        self._lock = threading.Lock()
+
+        if feature_extractor is None:
+            feature_extractor = WhisperFeatureExtractor(chunk_length=max_audio_duration)
+        self.feature_extractor = feature_extractor
+
+        if session is None:
+            if model_path is None:
+                model_path = self._download_model_path(hf_repo_id, hf_filename)
+            session = self._build_session(
+                model_path=model_path,
+                providers=providers,
+                inter_op_num_threads=inter_op_num_threads,
+            )
+        self.session = session
+
+    def _download_model_path(self, repo_id: str, filename: str) -> str:
+        return hf_hub_download(repo_id=repo_id, filename=filename)
+
+    def _build_session(
+        self,
+        *,
+        model_path: str,
+        providers: Optional[Sequence[str]],
+        inter_op_num_threads: int,
+    ):
+        options = ort.SessionOptions()
+        options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
+        options.inter_op_num_threads = inter_op_num_threads
+        options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        kwargs = {"sess_options": options}
+        if providers:
+            kwargs["providers"] = list(providers)
+        return ort.InferenceSession(model_path, **kwargs)
+
+    def _linear16_to_float32(self, audio: bytes, channels: int) -> np.ndarray:
+        usable_len = len(audio) - (len(audio) % 2)
+        if usable_len <= 0:
+            return np.zeros(0, dtype=np.float32)
+
+        audio_int16 = np.frombuffer(audio[:usable_len], dtype=np.int16)
+        if channels > 1:
+            frame_count = len(audio_int16) // channels
+            audio_int16 = audio_int16[:frame_count * channels]
+            audio_float = audio_int16.reshape(-1, channels).astype(np.float32).mean(axis=1)
+            return audio_float / 32768.0
+
+        return audio_int16.astype(np.float32) / 32768.0
+
+    def _resample_if_needed(self, audio: np.ndarray, sample_rate: int) -> np.ndarray:
+        if sample_rate == self.target_sample_rate or len(audio) == 0:
+            return audio.astype(np.float32, copy=False)
+
+        duration = len(audio) / float(sample_rate)
+        target_len = max(1, int(round(duration * self.target_sample_rate)))
+        source_positions = np.linspace(0.0, len(audio) - 1, num=len(audio), dtype=np.float32)
+        target_positions = np.linspace(0.0, len(audio) - 1, num=target_len, dtype=np.float32)
+        return np.interp(target_positions, source_positions, audio).astype(np.float32)
+
+    def _fit_audio_duration(self, audio: np.ndarray) -> np.ndarray:
+        max_samples = int(self.max_audio_duration * self.target_sample_rate)
+        if max_samples <= 0:
+            raise ValueError("max_audio_duration must be greater than 0")
+
+        if len(audio) > max_samples:
+            return audio[-max_samples:].astype(np.float32, copy=False)
+        if len(audio) < max_samples:
+            padding = max_samples - len(audio)
+            return np.pad(audio, (padding, 0), mode="constant", constant_values=0).astype(np.float32)
+        return audio.astype(np.float32, copy=False)
+
+    def _prepare_audio(self, audio: bytes, sample_rate: int, channels: int) -> np.ndarray:
+        waveform = self._linear16_to_float32(audio, max(1, channels))
+        waveform = self._resample_if_needed(waveform, sample_rate)
+        return self._fit_audio_duration(waveform)
+
+    def _predict_probability(self, waveform: np.ndarray) -> float:
+        inputs = self.feature_extractor(
+            waveform,
+            sampling_rate=self.target_sample_rate,
+            return_tensors="np",
+            padding="max_length",
+            max_length=int(self.max_audio_duration * self.target_sample_rate),
+            truncation=True,
+            do_normalize=True,
+        )
+        input_features = inputs.input_features.squeeze(0).astype(np.float32)
+        input_features = np.expand_dims(input_features, axis=0)
+
+        with self._lock:
+            outputs = self.session.run(None, {"input_features": input_features})
+        return float(np.asarray(outputs[0]).squeeze().item())
+
+    async def should_end_turn(
+        self,
+        *,
+        audio: bytes,
+        sample_rate: int,
+        channels: int,
+        recorded_duration: float,
+        silence_duration: float,
+        session_id: str,
+        text: Optional[str] = None,
+        session: Any = None,
+    ) -> TurnEndDecision:
+        waveform = self._prepare_audio(audio, sample_rate, channels)
+        probability = await asyncio.to_thread(self._predict_probability, waveform)
+        should_end = probability >= self.threshold
+        if self.debug:
+            logger.info(
+                "Smart Turn: %s session=%s, probability=%.3f, threshold=%.3f, recorded_duration=%.3f, silence_duration=%.3f, audio_bytes=%s",
+                "PASS complete" if should_end else "WAIT incomplete",
+                session_id,
+                probability,
+                self.threshold,
+                recorded_duration,
+                silence_duration,
+                len(audio),
+            )
+        return TurnEndDecision(
+            should_end=should_end,
+            confidence=probability,
+            reason="smart_turn_complete" if should_end else "smart_turn_incomplete",
+        )

--- a/tests/sts/vad/test_turn_end_gate.py
+++ b/tests/sts/vad/test_turn_end_gate.py
@@ -1,0 +1,455 @@
+import asyncio
+import importlib
+import sys
+from types import SimpleNamespace
+import threading
+
+import numpy as np
+import pytest
+
+from aiavatar.sts.stt.base import SpeechRecognizer
+from aiavatar.sts.vad.silero import SileroSpeechDetector
+from aiavatar.sts.vad.stream import SileroStreamSpeechDetector
+from aiavatar.sts.vad.turn_end_gates import TurnEndDecision, TurnEndGate
+
+
+class DummyVADIterator:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def reset_states(self):
+        pass
+
+
+def fake_init_silero_model(self, model_path=None):
+    self.model_pool = [object()]
+    self.model_locks = [threading.Lock()]
+    self.VADIteratorClass = DummyVADIterator
+
+
+class AlwaysHoldGate(TurnEndGate):
+    def __init__(self):
+        self.calls = []
+
+    async def should_end_turn(self, **kwargs):
+        self.calls.append(kwargs)
+        return TurnEndDecision(should_end=False, confidence=0.1, reason="hold")
+
+
+class HoldThenEndGate(TurnEndGate):
+    def __init__(self):
+        self.calls = 0
+
+    async def should_end_turn(self, **kwargs):
+        self.calls += 1
+        return TurnEndDecision(
+            should_end=self.calls > 1,
+            confidence=0.9 if self.calls > 1 else 0.1,
+            reason="jitter",
+        )
+
+
+class DummySpeechRecognizer(SpeechRecognizer):
+    async def transcribe(self, data: bytes) -> str:
+        return "こんにちは"
+
+
+def detect_non_silent(audio_bytes: bytes, session) -> bool:
+    return any(audio_bytes)
+
+
+class FakeFeatureExtractor:
+    def __init__(self):
+        self.waveforms = []
+
+    def __call__(self, waveform, **kwargs):
+        self.waveforms.append((waveform, kwargs))
+        return SimpleNamespace(input_features=np.ones((1, 80, 3000), dtype=np.float32))
+
+
+class FakeOnnxSession:
+    def __init__(self, probability: float):
+        self.probability = probability
+        self.inputs = []
+
+    def run(self, output_names, inputs):
+        self.inputs.append(inputs)
+        return [np.asarray([[self.probability]], dtype=np.float32)]
+
+
+class FakeNamoTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, text, **kwargs):
+        self.calls.append((text, kwargs))
+        return {
+            "input_ids": np.asarray([[1, 2, 3]], dtype=np.int64),
+            "attention_mask": np.asarray([[1, 1, 1]], dtype=np.int64),
+        }
+
+
+class FakeNamoSession:
+    def __init__(self, logits):
+        self.logits = np.asarray([logits], dtype=np.float32)
+        self.inputs = []
+
+    def run(self, output_names, inputs):
+        self.inputs.append(inputs)
+        return [self.logits]
+
+
+def import_smart_turn_with_fake_dependencies(monkeypatch):
+    fake_ort = SimpleNamespace(
+        SessionOptions=lambda: SimpleNamespace(),
+        ExecutionMode=SimpleNamespace(ORT_SEQUENTIAL="ORT_SEQUENTIAL"),
+        GraphOptimizationLevel=SimpleNamespace(ORT_ENABLE_ALL="ORT_ENABLE_ALL"),
+        InferenceSession=lambda *args, **kwargs: FakeOnnxSession(probability=0.5),
+    )
+    fake_transformers = SimpleNamespace(WhisperFeatureExtractor=FakeFeatureExtractor)
+    fake_huggingface_hub = SimpleNamespace(hf_hub_download=lambda repo_id, filename: filename)
+
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_huggingface_hub)
+    sys.modules.pop("aiavatar.sts.vad.turn_end_gates.smart_turn", None)
+    return importlib.import_module("aiavatar.sts.vad.turn_end_gates.smart_turn").SmartTurnEndGate
+
+
+def import_namo_turn_with_fake_dependencies(monkeypatch):
+    tokenizer_calls = []
+
+    fake_ort = SimpleNamespace(
+        SessionOptions=lambda: SimpleNamespace(),
+        ExecutionMode=SimpleNamespace(ORT_SEQUENTIAL="ORT_SEQUENTIAL"),
+        GraphOptimizationLevel=SimpleNamespace(ORT_ENABLE_ALL="ORT_ENABLE_ALL"),
+        InferenceSession=lambda *args, **kwargs: FakeNamoSession([0.0, 1.0]),
+    )
+    fake_transformers = SimpleNamespace(
+        AutoTokenizer=SimpleNamespace(
+            from_pretrained=lambda repo_id, **kwargs: (
+                tokenizer_calls.append((repo_id, kwargs)) or FakeNamoTokenizer()
+            )
+        )
+    )
+    fake_huggingface_hub = SimpleNamespace(hf_hub_download=lambda repo_id, filename: filename)
+
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_huggingface_hub)
+    sys.modules.pop("aiavatar.sts.vad.turn_end_gates.namo_turn", None)
+    NamoTurnEndGate = importlib.import_module("aiavatar.sts.vad.turn_end_gates.namo_turn").NamoTurnEndGate
+    return NamoTurnEndGate, tokenizer_calls
+
+
+@pytest.mark.asyncio
+async def test_silero_turn_end_gate_holds_until_timeout(monkeypatch):
+    monkeypatch.setattr(SileroSpeechDetector, "_init_silero_model", fake_init_silero_model)
+    gate = AlwaysHoldGate()
+    detector = SileroSpeechDetector(
+        silence_duration_threshold=0.2,
+        turn_end_gate=gate,
+        turn_end_gate_timeout=0.3,
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+
+    detected = []
+
+    @detector.on_speech_detected
+    async def on_speech_detected(recorded_data, text, metadata, recorded_duration, session_id):
+        detected.append((recorded_data, recorded_duration, session_id))
+
+    session_id = "silero_gate"
+    speech_chunk = b"\x01\x00" * 1600
+    silence_chunk = b"\x00\x00" * 1600
+
+    await detector.process_samples(speech_chunk, session_id)
+    await detector.process_samples(speech_chunk, session_id)
+    for _ in range(4):
+        await detector.process_samples(silence_chunk, session_id)
+
+    await asyncio.sleep(0)
+    assert detected == []
+    assert len(gate.calls) >= 1
+    assert detector.get_session(session_id).is_recording is True
+
+    await detector.process_samples(silence_chunk, session_id)
+    await asyncio.sleep(0.05)
+
+    assert len(detected) == 1
+    assert detected[0][2] == session_id
+    assert detector.get_session(session_id).is_recording is False
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_end_gate_holds_until_timeout(monkeypatch):
+    monkeypatch.setattr(SileroSpeechDetector, "_init_silero_model", fake_init_silero_model)
+    gate = AlwaysHoldGate()
+    detector = SileroStreamSpeechDetector(
+        speech_recognizer=DummySpeechRecognizer(),
+        silence_duration_threshold=0.2,
+        segment_silence_threshold=10.0,
+        turn_end_gate=gate,
+        turn_end_gate_timeout=0.3,
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+
+    detected = []
+
+    @detector.on_speech_detected
+    async def on_speech_detected(recorded_data, text, metadata, recorded_duration, session_id):
+        detected.append((recorded_data, text, recorded_duration, session_id))
+
+    session_id = "stream_gate"
+    speech_chunk = b"\x01\x00" * 1600
+    silence_chunk = b"\x00\x00" * 1600
+
+    await detector.process_samples(speech_chunk, session_id)
+    await detector.process_samples(speech_chunk, session_id)
+    for _ in range(4):
+        await detector.process_samples(silence_chunk, session_id)
+
+    await asyncio.sleep(0)
+    assert detected == []
+    assert len(gate.calls) >= 1
+    assert detector.get_session(session_id).is_recording is True
+
+    await detector.process_samples(silence_chunk, session_id)
+    await asyncio.sleep(0.05)
+
+    assert len(detected) == 1
+    assert detected[0][1] == "こんにちは"
+    assert detected[0][3] == session_id
+    assert detector.get_session(session_id).is_recording is False
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_end_gate_receives_recognized_text(monkeypatch):
+    monkeypatch.setattr(SileroSpeechDetector, "_init_silero_model", fake_init_silero_model)
+    gate = AlwaysHoldGate()
+    detector = SileroStreamSpeechDetector(
+        speech_recognizer=DummySpeechRecognizer(),
+        silence_duration_threshold=0.2,
+        segment_silence_threshold=0.1,
+        turn_end_gate=gate,
+        turn_end_gate_timeout=0.3,
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+
+    session_id = "stream_gate_text"
+    speech_chunk = b"\x01\x00" * 1600
+    silence_chunk = b"\x00\x00" * 1600
+
+    await detector.process_samples(speech_chunk, session_id)
+    await detector.process_samples(speech_chunk, session_id)
+    for _ in range(3):
+        await detector.process_samples(silence_chunk, session_id)
+
+    assert gate.calls
+    assert gate.calls[0]["text"] == "こんにちは"
+
+
+@pytest.mark.asyncio
+async def test_stream_wait_pending_recognition_ignores_cancelled_recognition_task(monkeypatch):
+    monkeypatch.setattr(SileroSpeechDetector, "_init_silero_model", fake_init_silero_model)
+    detector = SileroStreamSpeechDetector(
+        speech_recognizer=DummySpeechRecognizer(),
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    session = detector.get_session("cancelled_pending_recognition")
+
+    async def wait_forever():
+        await asyncio.Event().wait()
+
+    session.pending_recognition_task = asyncio.create_task(wait_forever())
+    session.pending_recognition_task.cancel()
+
+    await detector._wait_pending_recognition_task(session, "in test")
+    assert session.pending_recognition_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_silero_turn_end_gate_latches_first_hold_until_timeout(monkeypatch):
+    monkeypatch.setattr(SileroSpeechDetector, "_init_silero_model", fake_init_silero_model)
+    gate = HoldThenEndGate()
+    detector = SileroSpeechDetector(
+        silence_duration_threshold=0.2,
+        turn_end_gate=gate,
+        turn_end_gate_timeout=0.3,
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+
+    detected = []
+
+    @detector.on_speech_detected
+    async def on_speech_detected(recorded_data, text, metadata, recorded_duration, session_id):
+        detected.append((recorded_data, recorded_duration, session_id))
+
+    session_id = "silero_latched_gate"
+    speech_chunk = b"\x01\x00" * 1600
+    silence_chunk = b"\x00\x00" * 1600
+
+    await detector.process_samples(speech_chunk, session_id)
+    await detector.process_samples(speech_chunk, session_id)
+    for _ in range(4):
+        await detector.process_samples(silence_chunk, session_id)
+
+    await asyncio.sleep(0)
+    assert detected == []
+    assert gate.calls == 1
+    assert detector.get_session(session_id).is_recording is True
+
+    await detector.process_samples(silence_chunk, session_id)
+    await asyncio.sleep(0.05)
+
+    assert len(detected) == 1
+    assert gate.calls == 1
+    assert detected[0][2] == session_id
+
+
+@pytest.mark.asyncio
+async def test_smart_turn_end_gate_converts_audio_and_returns_decision(monkeypatch):
+    SmartTurnEndGate = import_smart_turn_with_fake_dependencies(monkeypatch)
+    feature_extractor = FakeFeatureExtractor()
+    onnx_session = FakeOnnxSession(probability=0.75)
+    gate = SmartTurnEndGate(
+        threshold=0.5,
+        feature_extractor=feature_extractor,
+        session=onnx_session,
+    )
+
+    audio = (np.ones(1600, dtype=np.int16) * 1000).tobytes()
+    decision = await gate.should_end_turn(
+        audio=audio,
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=0.1,
+        silence_duration=0.5,
+        session_id="smart_turn",
+    )
+
+    assert decision.should_end is True
+    assert decision.confidence == pytest.approx(0.75)
+    assert decision.reason == "smart_turn_complete"
+    assert len(feature_extractor.waveforms) == 1
+    waveform, kwargs = feature_extractor.waveforms[0]
+    assert waveform.dtype == np.float32
+    assert len(waveform) == 8 * 16000
+    assert waveform[-1] == pytest.approx(1000 / 32768.0)
+    assert kwargs["sampling_rate"] == 16000
+    assert "input_features" in onnx_session.inputs[0]
+
+
+@pytest.mark.asyncio
+async def test_smart_turn_end_gate_marks_incomplete_below_threshold(monkeypatch):
+    SmartTurnEndGate = import_smart_turn_with_fake_dependencies(monkeypatch)
+    gate = SmartTurnEndGate(
+        threshold=0.5,
+        feature_extractor=FakeFeatureExtractor(),
+        session=FakeOnnxSession(probability=0.25),
+    )
+
+    decision = await gate.should_end_turn(
+        audio=b"\x00\x00" * 1600,
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=0.1,
+        silence_duration=0.5,
+        session_id="smart_turn",
+    )
+
+    assert decision.should_end is False
+    assert decision.confidence == pytest.approx(0.25)
+    assert decision.reason == "smart_turn_incomplete"
+
+
+@pytest.mark.asyncio
+async def test_namo_turn_end_gate_marks_complete_from_label_one(monkeypatch):
+    NamoTurnEndGate, _ = import_namo_turn_with_fake_dependencies(monkeypatch)
+    tokenizer = FakeNamoTokenizer()
+    session = FakeNamoSession([0.1, 2.0])
+    gate = NamoTurnEndGate(tokenizer=tokenizer, session=session, threshold=0.5)
+
+    decision = await gate.should_end_turn(
+        audio=b"",
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=1.0,
+        silence_duration=0.5,
+        session_id="namo_turn",
+        text="こんにちは。",
+    )
+
+    assert decision.should_end is True
+    assert decision.confidence > 0.5
+    assert decision.reason == "namo_end_of_turn"
+    assert tokenizer.calls[0][0] == "こんにちは。"
+    assert "input_ids" in session.inputs[0]
+
+
+@pytest.mark.asyncio
+async def test_namo_turn_end_gate_marks_incomplete_from_label_zero(monkeypatch):
+    NamoTurnEndGate, _ = import_namo_turn_with_fake_dependencies(monkeypatch)
+    gate = NamoTurnEndGate(
+        tokenizer=FakeNamoTokenizer(),
+        session=FakeNamoSession([2.0, 0.1]),
+        threshold=0.5,
+    )
+
+    decision = await gate.should_end_turn(
+        audio=b"",
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=1.0,
+        silence_duration=0.5,
+        session_id="namo_turn",
+        text="えっと、この間さ",
+    )
+
+    assert decision.should_end is False
+    assert decision.confidence > 0.5
+    assert decision.reason == "namo_not_end_of_turn"
+
+
+@pytest.mark.asyncio
+async def test_namo_turn_end_gate_no_text_defaults_to_complete(monkeypatch):
+    NamoTurnEndGate, _ = import_namo_turn_with_fake_dependencies(monkeypatch)
+    gate = NamoTurnEndGate(
+        tokenizer=FakeNamoTokenizer(),
+        session=FakeNamoSession([2.0, 0.1]),
+    )
+
+    decision = await gate.should_end_turn(
+        audio=b"",
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=1.0,
+        silence_duration=0.5,
+        session_id="namo_turn",
+        text=None,
+    )
+
+    assert decision.should_end is True
+    assert decision.confidence is None
+    assert decision.reason == "namo_no_text"
+
+
+def test_namo_turn_end_gate_tokenizer_truncates_from_left(monkeypatch):
+    NamoTurnEndGate, tokenizer_calls = import_namo_turn_with_fake_dependencies(monkeypatch)
+    NamoTurnEndGate(session=FakeNamoSession([0.0, 1.0]))
+
+    assert tokenizer_calls
+    assert tokenizer_calls[0][1]["truncation_side"] == "left"


### PR DESCRIPTION
Introduce an optional turn-end confirmation gate for VAD turn-end candidates.

Adds a new aiavatar/sts/vad/turn_end_gates package with TurnEndDecision/TurnEndGate base types and two implementations:

- SmartTurnEndGate (audio-based ONNX model)
- NamoTurnEndGate (text-based ONNX model/tokenizer)

Integrates gates into SileroSpeechDetector and SileroStreamSpeechDetector: sessions now track a turn_end_gate_hold_active latch, gates are consulted after silence thresholds, a configurable timeout forces completion, and stream detector waits for pending recognition tasks before invoking the gate.