### PR TITLE
Support multiple turn-end gates and add filler gate

### DIFF
--- a/aiavatar/sts/vad/silero.py
+++ b/aiavatar/sts/vad/silero.py
@@ -22,11 +22,15 @@ class RecordingSession(RecordingSessionBase):
         self.vad_iterator = vad_iterator
         self.is_speech_active: bool = False  # VAD state: True after 'start', False after 'end'
         self.turn_end_gate_hold_active: bool = False
+        self.turn_end_gate_hold_timeout: Optional[float] = None
+        self.turn_end_gate_hold_reasons: List[str] = []
 
     def reset(self):
         super().reset()
         self.is_speech_active = False
         self.turn_end_gate_hold_active = False
+        self.turn_end_gate_hold_timeout = None
+        self.turn_end_gate_hold_reasons = []
         self.amplitude_threshold = None
         # Reset VAD iterator state for next utterance
         if self.vad_iterator:
@@ -55,8 +59,7 @@ class SileroSpeechDetector(SpeechDetector):
         on_recording_started_min_duration: float = 1.5,
         use_vad_iterator: bool = False,
         audio_filters: Optional[List[AudioFilter]] = None,
-        turn_end_gate: Optional[TurnEndGate] = None,
-        turn_end_gate_timeout: Optional[float] = 1.5
+        turn_end_gates: Optional[List[TurnEndGate]] = None,
     ):
         super().__init__(
             sample_rate=sample_rate,
@@ -84,8 +87,7 @@ class SileroSpeechDetector(SpeechDetector):
         self.chunk_size = chunk_size
         self.model_pool_size = model_pool_size
         self.use_vad_iterator = use_vad_iterator
-        self.turn_end_gate = turn_end_gate
-        self.turn_end_gate_timeout = turn_end_gate_timeout
+        self.turn_end_gates = turn_end_gates or []
 
         # Initialize Silero VAD model pool
         self._init_silero_model(model_path)
@@ -103,7 +105,6 @@ class SileroSpeechDetector(SpeechDetector):
             "speech_probability_threshold": self.speech_probability_threshold,
             "chunk_size": self.chunk_size,
             "use_vad_iterator": self.use_vad_iterator,
-            "turn_end_gate_timeout": self.turn_end_gate_timeout,
         }
 
     def set_config(self, config: dict) -> dict:
@@ -251,71 +252,99 @@ class SileroSpeechDetector(SpeechDetector):
         recorded_duration: float,
         text: Optional[str] = None,
     ) -> bool:
-        """Confirm a VAD turn-end candidate with the optional gate.
+        """Confirm a VAD turn-end candidate with optional gates.
 
-        The gate is only consulted after silence_duration_threshold has already
-        been met. turn_end_gate_timeout forces completion after the configured
-        extra silence, even if the gate keeps returning should_end=False.
+        Gates are only consulted after silence_duration_threshold has already
+        been met. All gates must pass to end the turn. If any gate waits, its
+        timeout controls when the turn is forced to end.
         """
-        if self.turn_end_gate is None:
+        if not self.turn_end_gates:
             return True
 
         hold_duration = max(0.0, session.silence_duration - self.silence_duration_threshold)
-        if self.turn_end_gate_timeout is not None and hold_duration >= self.turn_end_gate_timeout:
-            if self.debug:
-                logger.info(
-                    "Turn-end gate: FORCE timeout session=%s, hold_duration=%.3f, timeout=%.3f",
-                    session.session_id,
-                    hold_duration,
-                    self.turn_end_gate_timeout
-                )
-            return True
-
         if session.turn_end_gate_hold_active:
+            timeout = session.turn_end_gate_hold_timeout
+            if timeout is not None and hold_duration >= timeout:
+                if self.debug:
+                    logger.info(
+                        "Turn-end gates: FORCE timeout session=%s, hold_duration=%.3f, timeout=%.3f, reasons=%s",
+                        session.session_id,
+                        hold_duration,
+                        timeout,
+                        session.turn_end_gate_hold_reasons,
+                    )
+                return True
             return False
 
+        decisions = []
         try:
-            decision = await self.turn_end_gate.should_end_turn(
-                audio=bytes(session.buffer),
-                sample_rate=self.sample_rate,
-                channels=self.channels,
-                recorded_duration=recorded_duration,
-                silence_duration=session.silence_duration,
-                session_id=session.session_id,
-                text=text,
-                session=session,
-            )
+            for gate in self.turn_end_gates:
+                decision = await gate.should_end_turn(
+                    audio=bytes(session.buffer),
+                    sample_rate=self.sample_rate,
+                    channels=self.channels,
+                    recorded_duration=recorded_duration,
+                    silence_duration=session.silence_duration,
+                    session_id=session.session_id,
+                    text=text,
+                    session=session,
+                )
+                decisions.append((gate, decision))
         except Exception:
             logger.error("Error in turn-end gate; ending turn with default behavior", exc_info=True)
             return True
 
-        if isinstance(decision, bool):
-            should_end = decision
-            confidence = None
-            reason = None
-        else:
-            should_end = decision.should_end
-            confidence = decision.confidence
-            reason = decision.reason
+        wait_decisions = []
+        for gate, decision in decisions:
+            if isinstance(decision, bool):
+                should_end = decision
+                confidence = None
+                reason = None
+                timeout = None
+            else:
+                should_end = decision.should_end
+                confidence = decision.confidence
+                reason = decision.reason
+                timeout = decision.timeout
 
-        if self.debug:
-            logger.info(
-                "Turn-end gate: %s session=%s, confidence=%s, reason=%s, hold_duration=%.3f",
-                "PASS" if should_end else "WAIT",
-                session.session_id,
-                confidence,
-                reason,
-                hold_duration
-            )
-        if not should_end:
-            session.turn_end_gate_hold_active = True
-            if self.debug and self.turn_end_gate_timeout is not None:
+            if self.debug:
                 logger.info(
-                    "Turn-end gate: WAIT latched session=%s, will force after %.3f sec of additional silence",
+                    "Turn-end gate[%s]: %s session=%s, confidence=%s, reason=%s, timeout=%s, hold_duration=%.3f",
+                    gate.__class__.__name__,
+                    "PASS" if should_end else "WAIT",
                     session.session_id,
-                    self.turn_end_gate_timeout
+                    confidence,
+                    reason,
+                    timeout,
+                    hold_duration,
                 )
-        return should_end
+
+            if not should_end:
+                wait_decisions.append((reason, timeout))
+
+        if not wait_decisions:
+            return True
+
+        timeout_values = [timeout for _, timeout in wait_decisions if timeout is not None]
+        effective_timeout = None if len(timeout_values) != len(wait_decisions) else max(timeout_values)
+        session.turn_end_gate_hold_active = True
+        session.turn_end_gate_hold_timeout = effective_timeout
+        session.turn_end_gate_hold_reasons = [reason or "wait" for reason, _ in wait_decisions]
+        if self.debug:
+            if effective_timeout is None:
+                logger.info(
+                    "Turn-end gates: WAIT latched session=%s, no force timeout, reasons=%s",
+                    session.session_id,
+                    session.turn_end_gate_hold_reasons,
+                )
+            else:
+                logger.info(
+                    "Turn-end gates: WAIT latched session=%s, will force after %.3f sec of additional silence, reasons=%s",
+                    session.session_id,
+                    effective_timeout,
+                    session.turn_end_gate_hold_reasons,
+                )
+        return False
 
     async def execute_on_speech_detected(self, recorded_data: bytes, recorded_duration: float, session_id: str):
         await self._execute_on_speech_detected(recorded_data, None, None, recorded_duration, session_id)
@@ -389,6 +418,8 @@ class SileroSpeechDetector(SpeechDetector):
             if speech_detected:
                 session.silence_duration = 0
                 session.turn_end_gate_hold_active = False
+                session.turn_end_gate_hold_timeout = None
+                session.turn_end_gate_hold_reasons = []
             else:
                 session.silence_duration += sample_duration
 

--- a/aiavatar/sts/vad/stream.py
+++ b/aiavatar/sts/vad/stream.py
@@ -57,8 +57,7 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
         on_recording_started_min_text_length: int = 2,
         use_vad_iterator: bool = False,
         audio_filters: Optional[List[AudioFilter]] = None,
-        turn_end_gate: Optional[TurnEndGate] = None,
-        turn_end_gate_timeout: Optional[float] = 1.5
+        turn_end_gates: Optional[List[TurnEndGate]] = None,
     ):
         super().__init__(
             volume_db_threshold=volume_db_threshold,
@@ -78,8 +77,7 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
             on_recording_started_min_duration=on_recording_started_min_duration,
             use_vad_iterator=use_vad_iterator,
             audio_filters=audio_filters,
-            turn_end_gate=turn_end_gate,
-            turn_end_gate_timeout=turn_end_gate_timeout
+            turn_end_gates=turn_end_gates,
         )
         self.speech_recognizer = speech_recognizer
         self.segment_silence_threshold = segment_silence_threshold
@@ -153,7 +151,7 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
             )
 
     async def _should_end_turn_with_gate(self, session: RecordingSession, recorded_duration: float) -> bool:
-        if self.turn_end_gate and session.pending_recognition_task is not None:
+        if self.turn_end_gates and session.pending_recognition_task is not None:
             await self._wait_pending_recognition_task(session, "before turn-end gate")
         return await super()._should_end_turn_with_gate(
             session,
@@ -234,6 +232,8 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
             if speech_detected:
                 session.silence_duration = 0
                 session.turn_end_gate_hold_active = False
+                session.turn_end_gate_hold_timeout = None
+                session.turn_end_gate_hold_reasons = []
                 session.segment_silence_duration = 0
                 # Reset fired flag when speech resumes
                 session.segment_fired = False

--- a/aiavatar/sts/vad/turn_end_gates/__init__.py
+++ b/aiavatar/sts/vad/turn_end_gates/__init__.py
@@ -1,14 +1,2 @@
 from .base import TurnEndDecision, TurnEndGate
-
-
-def __getattr__(name):
-    if name == "SmartTurnEndGate":
-        from .smart_turn import SmartTurnEndGate
-        return SmartTurnEndGate
-    if name == "NamoTurnEndGate":
-        from .namo_turn import NamoTurnEndGate
-        return NamoTurnEndGate
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-__all__ = ["TurnEndDecision", "TurnEndGate", "SmartTurnEndGate", "NamoTurnEndGate"]
+from .filler import FillerOnlyTurnEndGate

--- a/aiavatar/sts/vad/turn_end_gates/base.py
+++ b/aiavatar/sts/vad/turn_end_gates/base.py
@@ -8,6 +8,7 @@ class TurnEndDecision:
     should_end: bool
     confidence: Optional[float] = None
     reason: Optional[str] = None
+    timeout: Optional[float] = None
 
 
 class TurnEndGate(ABC):

--- a/aiavatar/sts/vad/turn_end_gates/filler.py
+++ b/aiavatar/sts/vad/turn_end_gates/filler.py
@@ -1,0 +1,110 @@
+import logging
+import unicodedata
+from typing import Any, Iterable, Optional
+
+from .base import TurnEndDecision, TurnEndGate
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_JA_FILLERS = [
+    "あ",
+    "あの",
+    "あのね",
+    "あのさ",
+    "え",
+    "ええ",
+    "えー",
+    "えっと",
+    "えと",
+    "ええと",
+    "えーと",
+    "うーん",
+    "ん",
+    "んー",
+    "まあ",
+    "その",
+    "なんか",
+]
+
+DEFAULT_EN_FILLERS = [
+    "uh",
+    "um",
+    "umm",
+    "erm",
+    "er",
+    "ah",
+    "uhh",
+    "hmm",
+    "hmmm",
+    "well",
+    "like",
+    "you know",
+    "i mean",
+]
+
+
+class FillerOnlyTurnEndGate(TurnEndGate):
+    """Wait longer when the recognized text is only a filler phrase."""
+
+    def __init__(
+        self,
+        *,
+        fillers: Optional[Iterable[str]] = None,
+        timeout: Optional[float] = 5.0,
+        no_text_should_end: bool = True,
+        debug: bool = False,
+    ):
+        self.fillers = list(fillers) if fillers is not None else list(DEFAULT_JA_FILLERS + DEFAULT_EN_FILLERS)
+        self.normalized_fillers = {self.normalize_text(filler) for filler in self.fillers}
+        self.timeout = timeout
+        self.no_text_should_end = no_text_should_end
+        self.debug = debug
+
+    @staticmethod
+    def normalize_text(text: str) -> str:
+        normalized = unicodedata.normalize("NFKC", text).lower()
+        chars = []
+        for ch in normalized:
+            category = unicodedata.category(ch)
+            if category[0] in {"P", "S", "Z"}:
+                continue
+            chars.append(ch)
+        return "".join(chars).rstrip("ーｰ〜~")
+
+    async def should_end_turn(
+        self,
+        *,
+        audio: bytes,
+        sample_rate: int,
+        channels: int,
+        recorded_duration: float,
+        silence_duration: float,
+        session_id: str,
+        text: Optional[str] = None,
+        session: Any = None,
+    ) -> TurnEndDecision:
+        normalized_text = self.normalize_text(text or "")
+        if not normalized_text:
+            should_end = self.no_text_should_end
+            reason = "filler_no_text"
+        else:
+            should_end = normalized_text not in self.normalized_fillers
+            reason = "filler_only" if not should_end else "not_filler_only"
+
+        if self.debug:
+            logger.info(
+                "Filler Turn: %s session=%s, text=%r, normalized=%r, timeout=%s",
+                "PASS complete" if should_end else "WAIT filler_only",
+                session_id,
+                text,
+                normalized_text,
+                self.timeout,
+            )
+
+        return TurnEndDecision(
+            should_end=should_end,
+            confidence=1.0,
+            reason=reason,
+            timeout=None if should_end else self.timeout,
+        )

--- a/aiavatar/sts/vad/turn_end_gates/namo_turn.py
+++ b/aiavatar/sts/vad/turn_end_gates/namo_turn.py
@@ -62,6 +62,7 @@ class NamoTurnEndGate(TurnEndGate):
         threshold: float = 0.5,
         max_length: Optional[int] = None,
         truncation_side: str = "left",
+        timeout: Optional[float] = 1.5,
         no_text_should_end: bool = True,
         providers: Optional[list[str]] = None,
         inter_op_num_threads: int = 1,
@@ -73,6 +74,7 @@ class NamoTurnEndGate(TurnEndGate):
         self.no_text_should_end = no_text_should_end
         self.max_length = max_length if max_length is not None else (8192 if language is None else 512)
         self.truncation_side = truncation_side
+        self.timeout = timeout
         self.debug = debug
         self._lock = threading.Lock()
 
@@ -157,6 +159,7 @@ class NamoTurnEndGate(TurnEndGate):
                 should_end=self.no_text_should_end,
                 confidence=None,
                 reason="namo_no_text",
+                timeout=None if self.no_text_should_end else self.timeout,
             )
 
         predicted_label, confidence = await asyncio.to_thread(self._predict, normalized_text)
@@ -175,4 +178,5 @@ class NamoTurnEndGate(TurnEndGate):
             should_end=should_end,
             confidence=confidence,
             reason="namo_end_of_turn" if should_end else "namo_not_end_of_turn",
+            timeout=None if should_end else self.timeout,
         )

--- a/aiavatar/sts/vad/turn_end_gates/smart_turn.py
+++ b/aiavatar/sts/vad/turn_end_gates/smart_turn.py
@@ -28,6 +28,7 @@ class SmartTurnEndGate(TurnEndGate):
         threshold: float = 0.5,
         max_audio_duration: float = 8.0,
         target_sample_rate: int = 16000,
+        timeout: Optional[float] = 1.5,
         providers: Optional[Sequence[str]] = None,
         inter_op_num_threads: int = 1,
         feature_extractor: Any = None,
@@ -39,6 +40,7 @@ class SmartTurnEndGate(TurnEndGate):
         self.threshold = threshold
         self.max_audio_duration = max_audio_duration
         self.target_sample_rate = target_sample_rate
+        self.timeout = timeout
         self.debug = debug
         self._lock = threading.Lock()
 
@@ -163,4 +165,5 @@ class SmartTurnEndGate(TurnEndGate):
             should_end=should_end,
             confidence=probability,
             reason="smart_turn_complete" if should_end else "smart_turn_incomplete",
+            timeout=None if should_end else self.timeout,
         )

--- a/tests/sts/vad/test_turn_end_gate.py
+++ b/tests/sts/vad/test_turn_end_gate.py
@@ -10,7 +10,7 @@ import pytest
 from aiavatar.sts.stt.base import SpeechRecognizer
 from aiavatar.sts.vad.silero import SileroSpeechDetector
 from aiavatar.sts.vad.stream import SileroStreamSpeechDetector
-from aiavatar.sts.vad.turn_end_gates import TurnEndDecision, TurnEndGate
+from aiavatar.sts.vad.turn_end_gates import FillerOnlyTurnEndGate, TurnEndDecision, TurnEndGate
 
 
 class DummyVADIterator:
@@ -28,17 +28,19 @@ def fake_init_silero_model(self, model_path=None):
 
 
 class AlwaysHoldGate(TurnEndGate):
-    def __init__(self):
+    def __init__(self, timeout=0.3):
         self.calls = []
+        self.timeout = timeout
 
     async def should_end_turn(self, **kwargs):
         self.calls.append(kwargs)
-        return TurnEndDecision(should_end=False, confidence=0.1, reason="hold")
+        return TurnEndDecision(should_end=False, confidence=0.1, reason="hold", timeout=self.timeout)
 
 
 class HoldThenEndGate(TurnEndGate):
-    def __init__(self):
+    def __init__(self, timeout=0.3):
         self.calls = 0
+        self.timeout = timeout
 
     async def should_end_turn(self, **kwargs):
         self.calls += 1
@@ -46,7 +48,17 @@ class HoldThenEndGate(TurnEndGate):
             should_end=self.calls > 1,
             confidence=0.9 if self.calls > 1 else 0.1,
             reason="jitter",
+            timeout=None if self.calls > 1 else self.timeout,
         )
+
+
+class AlwaysPassGate(TurnEndGate):
+    def __init__(self):
+        self.calls = []
+
+    async def should_end_turn(self, **kwargs):
+        self.calls.append(kwargs)
+        return TurnEndDecision(should_end=True, confidence=0.9, reason="pass")
 
 
 class DummySpeechRecognizer(SpeechRecognizer):
@@ -148,8 +160,7 @@ async def test_silero_turn_end_gate_holds_until_timeout(monkeypatch):
     gate = AlwaysHoldGate()
     detector = SileroSpeechDetector(
         silence_duration_threshold=0.2,
-        turn_end_gate=gate,
-        turn_end_gate_timeout=0.3,
+        turn_end_gates=[gate],
         min_duration=0.1,
         sample_rate=16000,
         chunk_size=1,
@@ -192,8 +203,7 @@ async def test_stream_turn_end_gate_holds_until_timeout(monkeypatch):
         speech_recognizer=DummySpeechRecognizer(),
         silence_duration_threshold=0.2,
         segment_silence_threshold=10.0,
-        turn_end_gate=gate,
-        turn_end_gate_timeout=0.3,
+        turn_end_gates=[gate],
         min_duration=0.1,
         sample_rate=16000,
         chunk_size=1,
@@ -237,8 +247,7 @@ async def test_stream_turn_end_gate_receives_recognized_text(monkeypatch):
         speech_recognizer=DummySpeechRecognizer(),
         silence_duration_threshold=0.2,
         segment_silence_threshold=0.1,
-        turn_end_gate=gate,
-        turn_end_gate_timeout=0.3,
+        turn_end_gates=[gate],
         min_duration=0.1,
         sample_rate=16000,
         chunk_size=1,
@@ -284,8 +293,7 @@ async def test_silero_turn_end_gate_latches_first_hold_until_timeout(monkeypatch
     gate = HoldThenEndGate()
     detector = SileroSpeechDetector(
         silence_duration_threshold=0.2,
-        turn_end_gate=gate,
-        turn_end_gate_timeout=0.3,
+        turn_end_gates=[gate],
         min_duration=0.1,
         sample_rate=16000,
         chunk_size=1,
@@ -318,6 +326,130 @@ async def test_silero_turn_end_gate_latches_first_hold_until_timeout(monkeypatch
     assert len(detected) == 1
     assert gate.calls == 1
     assert detected[0][2] == session_id
+
+
+@pytest.mark.asyncio
+async def test_silero_turn_end_gates_wait_if_any_gate_waits(monkeypatch):
+    monkeypatch.setattr(SileroSpeechDetector, "_init_silero_model", fake_init_silero_model)
+    pass_gate = AlwaysPassGate()
+    hold_gate = AlwaysHoldGate(timeout=0.3)
+    detector = SileroSpeechDetector(
+        silence_duration_threshold=0.2,
+        turn_end_gates=[pass_gate, hold_gate],
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+
+    session_id = "silero_multiple_gates"
+    speech_chunk = b"\x01\x00" * 1600
+    silence_chunk = b"\x00\x00" * 1600
+
+    await detector.process_samples(speech_chunk, session_id)
+    await detector.process_samples(speech_chunk, session_id)
+    for _ in range(4):
+        await detector.process_samples(silence_chunk, session_id)
+
+    assert pass_gate.calls
+    assert hold_gate.calls
+    session = detector.get_session(session_id)
+    assert session.is_recording is True
+    assert session.turn_end_gate_hold_reasons == ["hold"]
+
+
+@pytest.mark.asyncio
+async def test_filler_only_turn_end_gate_ignores_punctuation():
+    gate = FillerOnlyTurnEndGate(fillers=["えっと"], timeout=5.0)
+
+    decision = await gate.should_end_turn(
+        audio=b"",
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=0.5,
+        silence_duration=0.5,
+        session_id="filler",
+        text=" えっと。 ",
+    )
+
+    assert decision.should_end is False
+    assert decision.timeout == 5.0
+    assert decision.reason == "filler_only"
+
+
+@pytest.mark.asyncio
+async def test_filler_only_turn_end_gate_ignores_prolonged_sound_mark():
+    gate = FillerOnlyTurnEndGate(fillers=["あの"], timeout=5.0)
+
+    decision = await gate.should_end_turn(
+        audio=b"",
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=0.5,
+        silence_duration=0.5,
+        session_id="filler",
+        text="あのー。",
+    )
+
+    assert decision.should_end is False
+    assert decision.timeout == 5.0
+    assert decision.reason == "filler_only"
+
+
+@pytest.mark.asyncio
+async def test_filler_only_turn_end_gate_passes_non_filler_text():
+    gate = FillerOnlyTurnEndGate(fillers=["えっと"], timeout=5.0)
+
+    decision = await gate.should_end_turn(
+        audio=b"",
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=0.5,
+        silence_duration=0.5,
+        session_id="filler",
+        text="えっと、今日は行きます。",
+    )
+
+    assert decision.should_end is True
+    assert decision.timeout is None
+    assert decision.reason == "not_filler_only"
+
+
+@pytest.mark.asyncio
+async def test_filler_only_turn_end_gate_default_does_not_treat_un_as_filler():
+    gate = FillerOnlyTurnEndGate(timeout=5.0)
+
+    decision = await gate.should_end_turn(
+        audio=b"",
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=0.5,
+        silence_duration=0.5,
+        session_id="filler",
+        text="うん。",
+    )
+
+    assert decision.should_end is True
+    assert decision.reason == "not_filler_only"
+
+
+@pytest.mark.asyncio
+async def test_filler_only_turn_end_gate_default_english_fillers():
+    gate = FillerOnlyTurnEndGate(timeout=5.0)
+
+    decision = await gate.should_end_turn(
+        audio=b"",
+        sample_rate=16000,
+        channels=1,
+        recorded_duration=0.5,
+        silence_duration=0.5,
+        session_id="filler",
+        text="Um...",
+    )
+
+    assert decision.should_end is False
+    assert decision.timeout == 5.0
+    assert decision.reason == "filler_only"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Replace the single turn_end_gate/turn_end_gate_timeout API with support for a list of turn_end_gates. The detector now queries all gates and only ends a turn when all gates pass; if any gate requests a WAIT the session latches a hold state with reasons and an effective timeout (forced only if all waiting gates provide timeouts).

Also introduced a new FillerOnlyTurnEndGate implementation (with normalization and default JA/EN filler lists).