### PR TITLE
Add local model cache options for VAD and turn-end gates

### DIFF
--- a/aiavatar/sts/vad/silero.py
+++ b/aiavatar/sts/vad/silero.py
@@ -51,7 +51,10 @@ class SileroSpeechDetector(SpeechDetector):
         preroll_buffer_count: int = 5,
         to_linear16: Optional[Callable[[bytes], bytes]] = None,
         debug: bool = False,
+        # Backward-compatible custom JIT model override. Prefer hub_cache_path
+        # for fully local Silero VAD model + utils loading.
         model_path: Optional[str] = None,
+        hub_cache_path: Optional[str] = None,
         speech_probability_threshold: float = 0.5,
         chunk_size: int = 512,
         model_pool_size: int = 1,
@@ -90,7 +93,7 @@ class SileroSpeechDetector(SpeechDetector):
         self.turn_end_gates = turn_end_gates or []
 
         # Initialize Silero VAD model pool
-        self._init_silero_model(model_path)
+        self._init_silero_model(model_path, hub_cache_path)
 
     def get_config(self) -> dict:
         return {
@@ -140,52 +143,57 @@ class SileroSpeechDetector(SpeechDetector):
             self.amplitude_threshold = None
             logger.debug("Volume threshold disabled (set to None)")
 
-    def _init_silero_model(self, model_path: Optional[str] = None):
+    def _init_silero_model(self, model_path: Optional[str] = None, hub_cache_path: Optional[str] = None):
         """Initialize Silero VAD model pool"""
         try:
             # Initialize model pool and locks
             self.model_pool = []
             self.model_locks = []
-            
-            for i in range(self.model_pool_size):
-                if model_path:
-                    model = torch.jit.load(model_path)
-                    # Load utils from local hub cache to avoid network access and "Using cache" log
-                    hub_cache = os.path.join(torch.hub.get_dir(), "snakers4_silero-vad_master")
-                    if os.path.isdir(hub_cache):
-                        _, utils = torch.hub.load(
-                            repo_or_dir=hub_cache,
-                            model="silero_vad",
-                            source="local",
-                        )
-                    else:
-                        _, utils = torch.hub.load(
-                            repo_or_dir="snakers4/silero-vad",
-                            model="silero_vad",
-                            force_reload=False,
-                            onnx=False
-                        )
-                else:
-                    # Load default Silero VAD model
-                    model, utils = torch.hub.load(
+
+            if hub_cache_path:
+                if not os.path.isdir(hub_cache_path):
+                    raise FileNotFoundError(f"Silero VAD hub cache path not found: {hub_cache_path}")
+
+                def load_hub_model_and_utils():
+                    return torch.hub.load(
+                        repo_or_dir=hub_cache_path,
+                        model="silero_vad",
+                        source="local",
+                        onnx=False,
+                    )
+            else:
+                def load_hub_model_and_utils():
+                    # Load default Silero VAD model. torch.hub uses its cache when available.
+                    return torch.hub.load(
                         repo_or_dir="snakers4/silero-vad",
                         model="silero_vad",
                         force_reload=False,
-                        onnx=False
+                        onnx=False,
                     )
+
+            hub_model, utils = load_hub_model_and_utils()
+
+            self.get_speech_timestamps = utils[0]
+            self.save_audio = utils[1]
+            self.read_audio = utils[2]
+            self.VADIterator = utils[3]
+            self.collect_chunks = utils[4]
+            # Store VAD iterator class for per-session creation
+            self.VADIteratorClass = self.VADIterator
+            
+            for i in range(self.model_pool_size):
+                if model_path:
+                    # Keep model_path as a backward-compatible override for
+                    # callers that pass a custom JIT model file.
+                    model = torch.jit.load(model_path)
+                else:
+                    if i == 0:
+                        model = hub_model
+                    else:
+                        model, _ = load_hub_model_and_utils()
                 
                 self.model_pool.append(model)
                 self.model_locks.append(threading.Lock())
-                
-                # Store utility functions (same for all models)
-                if i == 0:  # Only need to store once
-                    self.get_speech_timestamps = utils[0]
-                    self.save_audio = utils[1]
-                    self.read_audio = utils[2]
-                    self.VADIterator = utils[3]
-                    self.collect_chunks = utils[4]
-                    # Store VAD iterator class for per-session creation
-                    self.VADIteratorClass = self.VADIterator
             
             logger.info(f"Silero VAD model pool initialized successfully with {self.model_pool_size} models")
             

--- a/aiavatar/sts/vad/stream.py
+++ b/aiavatar/sts/vad/stream.py
@@ -48,7 +48,10 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
         preroll_buffer_count: int = 5,
         to_linear16: Optional[Callable[[bytes], bytes]] = None,
         debug: bool = False,
+        # Backward-compatible custom JIT model override. Prefer hub_cache_path
+        # for fully local Silero VAD model + utils loading.
         model_path: Optional[str] = None,
+        hub_cache_path: Optional[str] = None,
         speech_probability_threshold: float = 0.5,
         chunk_size: int = 512,
         model_pool_size: int = 1,
@@ -70,6 +73,7 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
             to_linear16=to_linear16,
             debug=debug,
             model_path=model_path,
+            hub_cache_path=hub_cache_path,
             speech_probability_threshold=speech_probability_threshold,
             chunk_size=chunk_size,
             model_pool_size=model_pool_size,

--- a/aiavatar/sts/vad/turn_end_gates/namo_turn.py
+++ b/aiavatar/sts/vad/turn_end_gates/namo_turn.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import threading
 from typing import Any, Optional
 
@@ -55,7 +56,10 @@ class NamoTurnEndGate(TurnEndGate):
         *,
         language: Optional[str] = "ja",
         repo_id: Optional[str] = None,
+        # Local ONNX model path. When set, Namo does not download the model.
         model_path: Optional[str] = None,
+        # Local tokenizer directory. When set, Namo does not load tokenizer files from Hugging Face.
+        tokenizer_path: Optional[str] = None,
         model_filename: str = "model_quant.onnx",
         tokenizer: Any = None,
         session: Any = None,
@@ -78,10 +82,15 @@ class NamoTurnEndGate(TurnEndGate):
         self.debug = debug
         self._lock = threading.Lock()
 
-        self.tokenizer = tokenizer or AutoTokenizer.from_pretrained(
-            self.repo_id,
-            truncation_side=self.truncation_side,
-        )
+        if tokenizer is None:
+            tokenizer_source = tokenizer_path or self.repo_id
+            if tokenizer_path and not os.path.isdir(tokenizer_path):
+                raise FileNotFoundError(f"Namo tokenizer path not found: {tokenizer_path}")
+            tokenizer = AutoTokenizer.from_pretrained(
+                tokenizer_source,
+                truncation_side=self.truncation_side,
+            )
+        self.tokenizer = tokenizer
 
         if session is None:
             if model_path is None:

--- a/aiavatar/sts/vad/turn_end_gates/smart_turn.py
+++ b/aiavatar/sts/vad/turn_end_gates/smart_turn.py
@@ -24,6 +24,7 @@ class SmartTurnEndGate(TurnEndGate):
     def __init__(
         self,
         *,
+        # Local ONNX model path. When set, Smart Turn does not download the model.
         model_path: Optional[str] = None,
         threshold: float = 0.5,
         max_audio_duration: float = 8.0,

--- a/tests/sts/vad/test_silero.py
+++ b/tests/sts/vad/test_silero.py
@@ -391,6 +391,80 @@ def test_model_initialization(detector):
     assert detector.model_pool[0] is not None
 
 
+def test_hub_cache_path_loads_from_local_hub(monkeypatch):
+    """
+    Test that hub_cache_path uses torch.hub local source and does not load from remote.
+    """
+    calls = []
+
+    def fake_hub_load(**kwargs):
+        calls.append(kwargs)
+        return object(), [object(), object(), object(), object(), object()]
+
+    monkeypatch.setattr("aiavatar.sts.vad.silero.os.path.isdir", lambda path: True)
+    monkeypatch.setattr("aiavatar.sts.vad.silero.torch.hub.load", fake_hub_load)
+
+    detector = SileroSpeechDetector(hub_cache_path="/models/silero-vad", model_pool_size=2)
+
+    assert len(detector.model_pool) == 2
+    assert len(calls) == 2
+    assert all(call["repo_or_dir"] == "/models/silero-vad" for call in calls)
+    assert all(call["source"] == "local" for call in calls)
+    assert all("force_reload" not in call for call in calls)
+
+
+def test_hub_cache_path_missing_raises(monkeypatch):
+    """
+    Test that hub_cache_path fails fast when the local path does not exist.
+    """
+    hub_load_called = False
+
+    def fake_hub_load(**kwargs):
+        nonlocal hub_load_called
+        hub_load_called = True
+        return object(), [object(), object(), object(), object(), object()]
+
+    monkeypatch.setattr("aiavatar.sts.vad.silero.os.path.isdir", lambda path: False)
+    monkeypatch.setattr("aiavatar.sts.vad.silero.torch.hub.load", fake_hub_load)
+
+    with pytest.raises(FileNotFoundError):
+        SileroSpeechDetector(hub_cache_path="/missing/silero-vad")
+
+    assert hub_load_called is False
+
+
+def test_model_path_overrides_hub_model(monkeypatch):
+    """
+    Test that model_path replaces the hub-loaded model while keeping hub utilities.
+    """
+    hub_model = object()
+    jit_models = [object(), object()]
+    hub_calls = []
+    jit_calls = []
+
+    def fake_hub_load(**kwargs):
+        hub_calls.append(kwargs)
+        return hub_model, [object(), object(), object(), object(), object()]
+
+    def fake_jit_load(path):
+        jit_calls.append(path)
+        return jit_models[len(jit_calls) - 1]
+
+    monkeypatch.setattr("aiavatar.sts.vad.silero.os.path.isdir", lambda path: True)
+    monkeypatch.setattr("aiavatar.sts.vad.silero.torch.hub.load", fake_hub_load)
+    monkeypatch.setattr("aiavatar.sts.vad.silero.torch.jit.load", fake_jit_load)
+
+    detector = SileroSpeechDetector(
+        hub_cache_path="/models/silero-vad",
+        model_path="/models/custom.jit",
+        model_pool_size=2,
+    )
+
+    assert detector.model_pool == jit_models
+    assert jit_calls == ["/models/custom.jit", "/models/custom.jit"]
+    assert len(hub_calls) == 1
+
+
 def test_model_pool_size():
     """
     Test model pool initialization with different sizes.

--- a/tests/sts/vad/test_turn_end_gate.py
+++ b/tests/sts/vad/test_turn_end_gate.py
@@ -21,7 +21,7 @@ class DummyVADIterator:
         pass
 
 
-def fake_init_silero_model(self, model_path=None):
+def fake_init_silero_model(self, model_path=None, hub_cache_path=None):
     self.model_pool = [object()]
     self.model_locks = [threading.Lock()]
     self.VADIteratorClass = DummyVADIterator
@@ -508,6 +508,23 @@ async def test_smart_turn_end_gate_marks_incomplete_below_threshold(monkeypatch)
     assert decision.reason == "smart_turn_incomplete"
 
 
+def test_smart_turn_end_gate_model_path_skips_download(monkeypatch):
+    SmartTurnEndGate = import_smart_turn_with_fake_dependencies(monkeypatch)
+    module = sys.modules["aiavatar.sts.vad.turn_end_gates.smart_turn"]
+
+    def fail_download(repo_id, filename):
+        raise AssertionError("hf_hub_download should not be called when model_path is set")
+
+    monkeypatch.setattr(module, "hf_hub_download", fail_download)
+
+    gate = SmartTurnEndGate(
+        model_path="/models/smart-turn.onnx",
+        feature_extractor=FakeFeatureExtractor(),
+    )
+
+    assert gate.session is not None
+
+
 @pytest.mark.asyncio
 async def test_namo_turn_end_gate_marks_complete_from_label_one(monkeypatch):
     NamoTurnEndGate, _ = import_namo_turn_with_fake_dependencies(monkeypatch)
@@ -585,3 +602,29 @@ def test_namo_turn_end_gate_tokenizer_truncates_from_left(monkeypatch):
 
     assert tokenizer_calls
     assert tokenizer_calls[0][1]["truncation_side"] == "left"
+
+
+def test_namo_turn_end_gate_tokenizer_path_loads_local_tokenizer(monkeypatch):
+    NamoTurnEndGate, tokenizer_calls = import_namo_turn_with_fake_dependencies(monkeypatch)
+    monkeypatch.setattr("aiavatar.sts.vad.turn_end_gates.namo_turn.os.path.isdir", lambda path: True)
+
+    gate = NamoTurnEndGate(
+        model_path="/models/namo/model_quant.onnx",
+        tokenizer_path="/models/namo/tokenizer",
+    )
+
+    assert gate.session is not None
+    assert tokenizer_calls
+    assert tokenizer_calls[0][0] == "/models/namo/tokenizer"
+    assert tokenizer_calls[0][1]["truncation_side"] == "left"
+
+
+def test_namo_turn_end_gate_missing_tokenizer_path_raises(monkeypatch):
+    NamoTurnEndGate, _ = import_namo_turn_with_fake_dependencies(monkeypatch)
+    monkeypatch.setattr("aiavatar.sts.vad.turn_end_gates.namo_turn.os.path.isdir", lambda path: False)
+
+    with pytest.raises(FileNotFoundError):
+        NamoTurnEndGate(
+            model_path="/models/namo/model_quant.onnx",
+            tokenizer_path="/missing/namo/tokenizer",
+        )


### PR DESCRIPTION
Add hub_cache_path support for Silero VAD so model and utils can be loaded from a local torch hub cache without network access. Keep model_path as a backward-compatible custom JIT override, and propagate hub_cache_path through the stream detector.

Add local model/tokenizer path support documentation for SmartTurn and Namo turn-end gates, including tokenizer_path for Namo.