### PR TITLE
Remove PyAudio from default dependencies

### DIFF
--- a/aiavatar/__init__.py
+++ b/aiavatar/__init__.py
@@ -1,14 +1,1 @@
-import logging
 from .adapter import AvatarControlRequest, AIAvatarRequest, AIAvatarResponse
-
-logger = logging.getLogger(__name__)
-
-
-try:
-    from .adapter.client import AIAvatarClientBase
-    from .adapter.local.client import AIAvatar
-except ModuleNotFoundError as mnferr:
-    if "pyaudio" in mnferr.msg:
-        logger.warning("PyAudio is not found in this environment. Import PortAudio and `pip install pyaudio` to use audio devices.")
-    else:
-        raise

--- a/aiavatar/adapter/local/__init__.py
+++ b/aiavatar/adapter/local/__init__.py
@@ -1,1 +1,22 @@
-from .client import AIAvatar
+def _raise_local_audio_import_error(exc: ModuleNotFoundError):
+    if exc.name == "pyaudio" or "pyaudio" in str(exc).lower():
+        raise ImportError(
+            "aiavatar.adapter.local is deprecated and requires PyAudio. "
+            "Install local audio dependencies with `pip install aiavatar[local-audio]`, "
+            "or use AIAvatarWebSocketClient for local Python audio clients."
+        ) from exc
+    raise exc
+
+
+def __getattr__(name: str):
+    try:
+        if name == "AIAvatar":
+            from .client import AIAvatar
+            return AIAvatar
+        if name == "AIAvatarLocalServer":
+            from .server import AIAvatarLocalServer
+            return AIAvatarLocalServer
+    except ModuleNotFoundError as exc:
+        _raise_local_audio_import_error(exc)
+
+    raise AttributeError(f"module 'aiavatar.adapter.local' has no attribute '{name}'")

--- a/aiavatar/adapter/local/client.py
+++ b/aiavatar/adapter/local/client.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import List
 from ...database import PoolProvider
 from ...sts.pipeline import STSPipeline
@@ -87,6 +88,12 @@ class AIAvatar(AIAvatarClientBase):
         cancel_echo = True,
         debug = False,
     ):
+        warnings.warn(
+            "aiavatar.adapter.local is deprecated. "
+            "Run AIAvatarWebSocketServer and connect with AIAvatarWebSocketClient for local Python audio clients.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(
             face_controller=face_controller,
             animation_controller=animation_controller,

--- a/aiavatar/adapter/local/server.py
+++ b/aiavatar/adapter/local/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import warnings
 from typing import List
 from ...database import PoolProvider
 from ...sts.models import STSRequest, STSResponse
@@ -76,6 +77,12 @@ class AIAvatarLocalServer(Adapter):
         # Debug
         debug: bool = False,
     ):
+        warnings.warn(
+            "AIAvatarLocalServer is deprecated. "
+            "Use AIAvatarWebSocketServer for the server side and AIAvatarWebSocketClient for local Python audio clients.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # Speech-to-Speech pipeline
         self.sts = sts or STSPipeline(
             # VAD

--- a/examples/local/run.py
+++ b/examples/local/run.py
@@ -1,7 +1,7 @@
 OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
 
 import asyncio
-from aiavatar import AIAvatar
+from aiavatar.adapter.local.client import AIAvatar
 
 aiavatar_app = AIAvatar(
     openai_api_key=OPENAI_API_KEY,

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -24,7 +24,7 @@ cd aiavatarkit/examples/websocket
 Install the required libraries.
 
 ```sh
-pip install aiavatar silero-vad fastapi uvicorn websockets
+pip install aiavatar
 ```
 
 Open `server.py` and set your OpenAI API key to `OPENAI_API_KEY`.

--- a/examples/websocket/client.py
+++ b/examples/websocket/client.py
@@ -2,6 +2,8 @@ import asyncio
 import os
 from aiavatar.adapter.websocket.client import AIAvatarWebSocketClient
 
+# This Python client uses local audio devices.
+# Install optional dependencies with: pip install "aiavatar[local-audio]"
 client = AIAvatarWebSocketClient(
     api_key=os.environ.get("AIAVATAR_API_KEY")
 )

--- a/examples/websocket/openclaw.md
+++ b/examples/websocket/openclaw.md
@@ -39,7 +39,7 @@ Configure your OpenClaw `gateway` settings as follows:
 Install dependencies:
 
 ```sh
-pip install aiavatar uvicorn fastapi websockets
+pip install aiavatar
 ```
 
 In `openclaw.py`, set your tokens:

--- a/examples/websocket/openclaw.py
+++ b/examples/websocket/openclaw.py
@@ -1,4 +1,4 @@
-# pip install aiavatar uvicorn fastapi websockets
+# pip install aiavatar
 import logging
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles

--- a/examples/websocket/server.py
+++ b/examples/websocket/server.py
@@ -1,4 +1,4 @@
-# pip install aiavatar silero-vad uvicorn
+# pip install aiavatar
 import os
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,22 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["examples*", "tests*"]),
     package_data={"aiavatar": ["admin/static/*"]},
-    install_requires=["httpx>=0.27.0", "openai>=1.55.3", "aiofiles>=24.1.0", "numpy>=2.2.3", "PyAudio>=0.2.14", "silero-vad>=6.0.0"],
+    install_requires=[
+        "httpx>=0.27.0",
+        "openai>=1.55.3",
+        "aiofiles>=24.1.0",
+        "numpy>=2.2.3",
+        "silero-vad>=6.0.0",
+        "websockets>=13.0",
+        "fastapi>=0.115.0",
+        "uvicorn>=0.30.0",
+    ],
+    extras_require={
+        "local-audio": ["PyAudio>=0.2.14"],
+        "local": ["PyAudio>=0.2.14"],
+        "smart-turn": ["onnxruntime>=1.23.0", "transformers>=4.48.0", "huggingface-hub>=0.26.0"],
+        "namo-turn": ["onnxruntime>=1.23.0", "transformers>=4.48.0", "huggingface-hub>=0.26.0"],
+    },
     license="Apache v2",
     classifiers=[
         "Programming Language :: Python :: 3"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -9,7 +9,8 @@ import httpx
 import numpy
 import pyautogui
 from aiavatar.sts.tts.voicevox import VoicevoxSpeechSynthesizer
-from aiavatar import AIAvatar, AIAvatarResponse
+from aiavatar import AIAvatarResponse
+from aiavatar.adapter.local.client import AIAvatar
 from aiavatar.animation import AnimationControllerDummy
 from aiavatar.face import FaceControllerDummy
 


### PR DESCRIPTION
Move local audio support behind the local-audio extra so the default install can run WebSocket servers without PyAudio.

Also update examples to use WebSocket by default, and mark the in-process local adapter as deprecated.