### PR TITLE
Recover Responses API conversations from local history

### DIFF
--- a/aiavatar/sts/llm/openai_responses.py
+++ b/aiavatar/sts/llm/openai_responses.py
@@ -6,6 +6,10 @@ import openai as openai_module
 from . import LLMService, LLMResponse, ToolCall, Tool
 from .context_manager import ContextManager
 from .response_id_store import ResponseIdStore, SQLiteResponseIdStore
+from .openai_responses_recovery import (
+    build_recovery_input,
+    is_previous_response_not_found,
+)
 
 logger = getLogger(__name__)
 
@@ -194,7 +198,9 @@ class OpenAIResponsesService(LLMService):
         if self.debug:
             logger.info(f"Request to OpenAI Responses API: {response_params}")
 
-        # Send request
+        # Send request. If the server-side conversation is unavailable (for
+        # example after switching between OpenAI and Azure), rebuild it from
+        # the locally stored messages and retry once.
         try:
             stream_resp = await self.openai_client.responses.create(**response_params)
 
@@ -202,11 +208,54 @@ class OpenAIResponsesService(LLMService):
             response_json = None
             try:
                 response_json = aserr.response.json()
-            except:
+            except Exception:
                 pass
-            logger.warning(f"APIStatusError from OpenAI Responses API: {aserr}")
-            yield LLMResponse(context_id=context_id, error_info={"exception": aserr, "response_json": response_json})
-            return
+
+            can_recover = (
+                "previous_response_id" in response_params
+                and messages
+                and messages[-1].get("role") == "user"
+                and is_previous_response_not_found(response_json)
+            )
+            if can_recover:
+                previous_response_id = response_params.pop("previous_response_id")
+                logger.warning(
+                    "Previous response not found; rebuilding conversation from "
+                    f"local history and retrying: context_id={context_id}, "
+                    f"previous_response_id={previous_response_id}"
+                )
+                await self.response_id_store.delete(context_id)
+                response_params["input"] = await build_recovery_input(
+                    context_id,
+                    user_id,
+                    messages,
+                    system_prompt_params,
+                    self._get_initial_messages,
+                    self.context_manager,
+                )
+                try:
+                    stream_resp = await self.openai_client.responses.create(**response_params)
+                except openai_module.APIStatusError as retry_error:
+                    retry_response_json = None
+                    try:
+                        retry_response_json = retry_error.response.json()
+                    except Exception:
+                        pass
+                    logger.warning(
+                        f"APIStatusError from OpenAI Responses API after retry: {retry_error}"
+                    )
+                    yield LLMResponse(context_id=context_id, error_info={"exception": retry_error, "response_json": retry_response_json})
+                    return
+                except Exception as retry_error:
+                    logger.warning(
+                        f"Error from OpenAI Responses API after retry: {retry_error}"
+                    )
+                    yield LLMResponse(context_id=context_id, error_info={"exception": retry_error, "response_json": None})
+                    return
+            else:
+                logger.warning(f"APIStatusError from OpenAI Responses API: {aserr}")
+                yield LLMResponse(context_id=context_id, error_info={"exception": aserr, "response_json": response_json})
+                return
 
         except Exception as ex:
             logger.warning(f"Error from OpenAI Responses API: {ex}")

--- a/aiavatar/sts/llm/openai_responses_recovery.py
+++ b/aiavatar/sts/llm/openai_responses_recovery.py
@@ -1,0 +1,43 @@
+from typing import Awaitable, Callable, Dict, List
+
+
+def is_previous_response_not_found(error: dict) -> bool:
+    """Return True when an API error says previous_response_id no longer exists."""
+    if not isinstance(error, dict):
+        return False
+
+    error = error.get("error", error)
+    if not isinstance(error, dict):
+        return False
+
+    code = str(error.get("code") or "").lower()
+    param = str(error.get("param") or "").lower()
+    message = str(error.get("message") or "").lower()
+    is_not_found = (
+        "not_found" in code
+        or "not found" in message
+        or "does not exist" in message
+    )
+    refers_to_previous_response = (
+        param == "previous_response_id"
+        or "previous_response_id" in code
+        or "previous_response_id" in message
+        or "previous response" in message
+    )
+    return is_not_found and refers_to_previous_response
+
+
+async def build_recovery_input(
+    context_id: str,
+    user_id: str,
+    current_input: List[Dict],
+    system_prompt_params: Dict,
+    get_initial_messages: Callable[..., Awaitable[List[Dict]]],
+    context_manager,
+) -> List[Dict]:
+    """Rebuild a Responses API input from the locally persisted conversation."""
+    initial_messages = await get_initial_messages(
+        context_id, user_id, system_prompt_params
+    )
+    histories = await context_manager.get_histories(context_id)
+    return list(initial_messages or []) + histories + current_input

--- a/aiavatar/sts/llm/openai_responses_websocket.py
+++ b/aiavatar/sts/llm/openai_responses_websocket.py
@@ -9,6 +9,10 @@ import websockets
 from . import LLMService, LLMResponse, ToolCall, Tool
 from .context_manager import ContextManager
 from .response_id_store import ResponseIdStore, SQLiteResponseIdStore
+from .openai_responses_recovery import (
+    build_recovery_input,
+    is_previous_response_not_found,
+)
 
 logger = getLogger(__name__)
 
@@ -269,6 +273,39 @@ class OpenAIResponsesWebSocketService(LLMService):
             async with self._ws_pool.connection() as ws:
                 current_input = messages
                 suppress_output = False
+                recovery_attempted = False
+
+                async def try_recovery(error: dict, ws_message: dict, output_received: bool) -> bool:
+                    nonlocal current_input, recovery_attempted
+                    can_recover = (
+                        not recovery_attempted
+                        and not output_received
+                        and "previous_response_id" in ws_message
+                        and current_input is messages
+                        and messages
+                        and messages[-1].get("role") == "user"
+                        and is_previous_response_not_found(error)
+                    )
+                    if not can_recover:
+                        return False
+
+                    previous_response_id = ws_message["previous_response_id"]
+                    logger.warning(
+                        "Previous response not found; rebuilding conversation from "
+                        f"local history and retrying: context_id={context_id}, "
+                        f"previous_response_id={previous_response_id}"
+                    )
+                    await self.response_id_store.delete(context_id)
+                    current_input = await build_recovery_input(
+                        context_id,
+                        user_id,
+                        messages,
+                        system_prompt_params,
+                        self._get_initial_messages,
+                        self.context_manager,
+                    )
+                    recovery_attempted = True
+                    return True
 
                 while True:
                     # Build response.create message
@@ -292,6 +329,8 @@ class OpenAIResponsesWebSocketService(LLMService):
                     # Receive and process events until response completes
                     tool_calls: List[ToolCall] = []
                     tool_call_map: Dict[int, int] = {}
+                    retry_with_history = False
+                    output_received = False
 
                     while True:
                         raw = await ws.recv()
@@ -299,6 +338,7 @@ class OpenAIResponsesWebSocketService(LLMService):
                         event_type = event.get("type")
 
                         if event_type == "response.output_text.delta":
+                            output_received = True
                             if not suppress_output:
                                 yield LLMResponse(context_id=context_id, text=event.get("delta", ""))
 
@@ -323,15 +363,24 @@ class OpenAIResponsesWebSocketService(LLMService):
                         elif event_type == "response.failed":
                             resp = event.get("response", {})
                             error = resp.get("error", {})
+                            if await try_recovery(error, ws_message, output_received):
+                                retry_with_history = True
+                                break
                             logger.warning(f"Response failed from OpenAI Responses API (WebSocket): {error}")
                             yield LLMResponse(context_id=context_id, error_info={"exception": Exception(error.get("message", "Unknown error")), "response_json": resp})
                             return
 
                         elif event_type == "error":
                             error = event.get("error", {})
+                            if await try_recovery(error, ws_message, output_received):
+                                retry_with_history = True
+                                break
                             logger.warning(f"Error from OpenAI Responses API (WebSocket): {error}")
                             yield LLMResponse(context_id=context_id, error_info={"exception": Exception(error.get("message", "Unknown error")), "response_json": event})
                             return
+
+                    if retry_with_history:
+                        continue
 
                     # No tool calls — done
                     if not tool_calls:

--- a/tests/sts/llm/test_openai_responses_recovery.py
+++ b/tests/sts/llm/test_openai_responses_recovery.py
@@ -1,0 +1,113 @@
+import configparser
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import openai
+import pytest
+
+from aiavatar.sts.llm.openai_responses import OpenAIResponsesService
+from aiavatar.sts.llm.openai_responses_websocket import (
+    OpenAIResponsesWebSocketService,
+)
+
+
+def get_pytest_env(name: str) -> str:
+    if value := os.getenv(name):
+        return value
+    config = configparser.ConfigParser()
+    config.read(Path(__file__).parents[3] / "pytest.ini")
+    for line in config.get("pytest", "env", fallback="").splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == name:
+            return value.strip()
+    return None
+
+
+OPENAI_API_KEY = get_pytest_env("OPENAI_API_KEY")
+
+
+async def collect_response(service, context_id: str, text: str) -> str:
+    chunks = []
+    async for response in service.chat_stream(context_id, "test_user", text):
+        if response.error_info:
+            pytest.fail(f"Unexpected API error: {response.error_info}")
+        if response.text:
+            chunks.append(response.text)
+    return "".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_http_service_recovers_deleted_response_with_local_history(tmp_path):
+    service = OpenAIResponsesService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="短く回答してください。",
+        model="gpt-4.1",
+        temperature=0.0,
+        db_connection_str=str(tmp_path / "http_recovery.db"),
+    )
+    context_id = f"test_http_recovery_{uuid4()}"
+
+    try:
+        await collect_response(
+            service,
+            context_id,
+            "合言葉はアボカドです。覚えてください。",
+        )
+        deleted_response_id = await service.response_id_store.get(context_id)
+        assert deleted_response_id
+
+        # Make the stored previous_response_id genuinely unavailable on the API.
+        await service.openai_client.responses.delete(deleted_response_id)
+
+        recovered_text = await collect_response(
+            service,
+            context_id,
+            "合言葉は何ですか？合言葉だけ答えてください。",
+        )
+        recovered_response_id = await service.response_id_store.get(context_id)
+
+        assert "アボカド" in recovered_text
+        assert recovered_response_id
+        assert recovered_response_id != deleted_response_id
+    finally:
+        await service.openai_client.close()
+
+
+@pytest.mark.asyncio
+async def test_websocket_service_recovers_deleted_response_with_local_history(tmp_path):
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key=OPENAI_API_KEY,
+        system_prompt="短く回答してください。",
+        model="gpt-5.4-mini",
+        reasoning_effort="none",
+        db_connection_str=str(tmp_path / "websocket_recovery.db"),
+    )
+    rest_client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY)
+    context_id = f"test_websocket_recovery_{uuid4()}"
+
+    try:
+        await collect_response(
+            service,
+            context_id,
+            "合言葉はアボカドです。覚えてください。",
+        )
+        deleted_response_id = await service.response_id_store.get(context_id)
+        assert deleted_response_id
+
+        # WebSocket responses can be deleted through the REST Responses API.
+        await rest_client.responses.delete(deleted_response_id)
+
+        recovered_text = await collect_response(
+            service,
+            context_id,
+            "合言葉は何ですか？合言葉だけ答えてください。",
+        )
+        recovered_response_id = await service.response_id_store.get(context_id)
+
+        assert "アボカド" in recovered_text
+        assert recovered_response_id
+        assert recovered_response_id != deleted_response_id
+    finally:
+        await service._ws_pool.close()
+        await rest_client.close()


### PR DESCRIPTION
Retry HTTP and WebSocket requests with locally stored conversation history when a previous response is no longer available.