### PR TITLE
Measure performance from user speech end

### DIFF
--- a/aiavatar/sts/models.py
+++ b/aiavatar/sts/models.py
@@ -1,14 +1,16 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Dict, Any
+from uuid import uuid4
 from .llm import ToolCall
 
 
-@dataclass
+@dataclass(kw_only=True)
 class STSRequest:
     type: str = "start"
     session_id: str = None
     user_id: str = None
     context_id: str = None
+    transaction_id: str = field(default_factory=lambda: str(uuid4()))
     text: str = None
     audio_data: bytes = None
     audio_duration: float = 0
@@ -25,7 +27,7 @@ class STSRequest:
     metadata: Dict[str, Any] = None
 
 
-@dataclass
+@dataclass(kw_only=True)
 class STSResponse:
     type: str
     session_id: str = None

--- a/aiavatar/sts/performance_recorder/__init__.py
+++ b/aiavatar/sts/performance_recorder/__init__.py
@@ -1,1 +1,6 @@
-from .base import PerformanceRecorder, PerformanceRecord
+from .base import (
+    PerformanceRecorder,
+    PerformanceRecord,
+    TIME_ORIGIN_PIPELINE_START,
+    TIME_ORIGIN_USER_SPEECH_END,
+)

--- a/aiavatar/sts/performance_recorder/base.py
+++ b/aiavatar/sts/performance_recorder/base.py
@@ -1,5 +1,15 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Optional
+
+
+TIME_ORIGIN_USER_SPEECH_END = "user_speech_end"
+TIME_ORIGIN_PIPELINE_START = "pipeline_start"
+VALID_TIME_ORIGINS = {
+    TIME_ORIGIN_USER_SPEECH_END,
+    TIME_ORIGIN_PIPELINE_START,
+}
 
 
 @dataclass
@@ -27,9 +37,69 @@ class PerformanceRecord:
     quick_response_text: str = None
     error_info: str = None
     tool_calls: str = None
+    speech_end_at: Optional[datetime] = None
+    silence_threshold_time: Optional[float] = None
+    stt_after_threshold_time: Optional[float] = None
+    turn_end_gate_time: Optional[float] = None
+    turn_end_gate_held: Optional[bool] = None
 
 
 class PerformanceRecorder(ABC):
+    _PRE_PIPELINE_TIME_FIELDS = (
+        "silence_threshold_time",
+        "stt_after_threshold_time",
+        "turn_end_gate_time",
+    )
+    _PIPELINE_LAP_TIME_FIELDS = (
+        "stt_time",
+        "stop_response_time",
+        "before_llm_time",
+        "llm_first_chunk_time",
+        "llm_first_voice_chunk_time",
+        "llm_time",
+        "tts_first_chunk_time",
+        "tts_time",
+        "total_time",
+    )
+
+    def __init__(self, time_origin: str = TIME_ORIGIN_USER_SPEECH_END):
+        if time_origin not in VALID_TIME_ORIGINS:
+            raise ValueError(
+                f"Invalid time_origin: {time_origin}. "
+                f"Must be one of {sorted(VALID_TIME_ORIGINS)}"
+            )
+        self.time_origin = time_origin
+
+    def _prepare_record_for_storage(
+        self,
+        record: PerformanceRecord,
+    ) -> PerformanceRecord:
+        """Convert timing values to laps from the configured origin."""
+        if self.time_origin == TIME_ORIGIN_PIPELINE_START:
+            return record
+
+        pre_pipeline_time = 0.0
+        prepared_record = replace(record)
+        for field_name in self._PRE_PIPELINE_TIME_FIELDS:
+            value = getattr(record, field_name)
+            if value is None:
+                continue
+            pre_pipeline_time += value
+            setattr(prepared_record, field_name, pre_pipeline_time)
+
+        if pre_pipeline_time <= 0:
+            return record
+
+        for field_name in self._PIPELINE_LAP_TIME_FIELDS:
+            value = getattr(prepared_record, field_name)
+            if value is not None and value > 0:
+                setattr(
+                    prepared_record,
+                    field_name,
+                    pre_pipeline_time + value,
+                )
+        return prepared_record
+
     @abstractmethod
     def record(self, record: PerformanceRecord):
         pass

--- a/aiavatar/sts/performance_recorder/postgres.py
+++ b/aiavatar/sts/performance_recorder/postgres.py
@@ -5,7 +5,11 @@ import queue
 import threading
 import asyncio
 import asyncpg
-from . import PerformanceRecorder, PerformanceRecord
+from . import (
+    PerformanceRecorder,
+    PerformanceRecord,
+    TIME_ORIGIN_USER_SPEECH_END,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +24,10 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
         user: str = "postgres",
         password: str = None,
         connection_str: str = None,
-        db_pool_size: int = 2  # Single worker only needs 1, but 2 provides failover when a connection becomes stale
+        db_pool_size: int = 2,  # Single worker only needs 1, but 2 provides failover when a connection becomes stale
+        time_origin: str = TIME_ORIGIN_USER_SPEECH_END,
     ):
+        super().__init__(time_origin=time_origin)
         self.host = host
         self.port = port
         self.dbname = dbname
@@ -95,6 +101,11 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
                         user_id TEXT,
                         context_id TEXT,
                         voice_length REAL,
+                        speech_end_at TIMESTAMPTZ,
+                        silence_threshold_time REAL,
+                        stt_after_threshold_time REAL,
+                        turn_end_gate_time REAL,
+                        turn_end_gate_held BOOLEAN,
                         stt_time REAL,
                         stop_response_time REAL,
                         before_llm_time REAL,
@@ -145,6 +156,22 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
 
                 # Add tool_calls column if not exist
                 await self.add_column_if_not_exist(conn, "tool_calls")
+
+                await conn.execute(
+                    "ALTER TABLE performance_records ADD COLUMN IF NOT EXISTS speech_end_at TIMESTAMPTZ"
+                )
+                await conn.execute(
+                    "ALTER TABLE performance_records ADD COLUMN IF NOT EXISTS silence_threshold_time REAL"
+                )
+                await conn.execute(
+                    "ALTER TABLE performance_records ADD COLUMN IF NOT EXISTS stt_after_threshold_time REAL"
+                )
+                await conn.execute(
+                    "ALTER TABLE performance_records ADD COLUMN IF NOT EXISTS turn_end_gate_time REAL"
+                )
+                await conn.execute(
+                    "ALTER TABLE performance_records ADD COLUMN IF NOT EXISTS turn_end_gate_held BOOLEAN"
+                )
 
                 # Create index
                 await conn.execute("CREATE INDEX IF NOT EXISTS idx_created_at ON performance_records (created_at)")
@@ -208,7 +235,7 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
             await conn.execute(sql, *values)
 
     def record(self, record: PerformanceRecord):
-        self.record_queue.put(record)
+        self.record_queue.put(self._prepare_record_for_storage(record))
 
     def close(self):
         self.stop_event.set()

--- a/aiavatar/sts/performance_recorder/sqlite.py
+++ b/aiavatar/sts/performance_recorder/sqlite.py
@@ -3,11 +3,20 @@ from datetime import datetime, timezone
 import queue
 import sqlite3
 import threading
-from . import PerformanceRecorder, PerformanceRecord
+from . import (
+    PerformanceRecorder,
+    PerformanceRecord,
+    TIME_ORIGIN_USER_SPEECH_END,
+)
 
 
 class SQLitePerformanceRecorder(PerformanceRecorder):
-    def __init__(self, db_path="aiavatar.db"):
+    def __init__(
+        self,
+        db_path="aiavatar.db",
+        time_origin=TIME_ORIGIN_USER_SPEECH_END,
+    ):
+        super().__init__(time_origin=time_origin)
         self.db_path = db_path
         self.record_queue = queue.Queue()
         self.stop_event = threading.Event()
@@ -30,6 +39,11 @@ class SQLitePerformanceRecorder(PerformanceRecorder):
                         user_id TEXT,
                         context_id TEXT,
                         voice_length REAL,
+                        speech_end_at TIMESTAMP,
+                        silence_threshold_time REAL,
+                        stt_after_threshold_time REAL,
+                        turn_end_gate_time REAL,
+                        turn_end_gate_held INTEGER,
                         stt_time REAL,
                         stop_response_time REAL,
                         before_llm_time REAL,
@@ -85,6 +99,21 @@ class SQLitePerformanceRecorder(PerformanceRecorder):
                 if "tool_calls" not in columns:
                     conn.execute("ALTER TABLE performance_records ADD COLUMN tool_calls TEXT")
 
+                if "speech_end_at" not in columns:
+                    conn.execute("ALTER TABLE performance_records ADD COLUMN speech_end_at TIMESTAMP")
+
+                if "silence_threshold_time" not in columns:
+                    conn.execute("ALTER TABLE performance_records ADD COLUMN silence_threshold_time REAL")
+
+                if "stt_after_threshold_time" not in columns:
+                    conn.execute("ALTER TABLE performance_records ADD COLUMN stt_after_threshold_time REAL")
+
+                if "turn_end_gate_time" not in columns:
+                    conn.execute("ALTER TABLE performance_records ADD COLUMN turn_end_gate_time REAL")
+
+                if "turn_end_gate_held" not in columns:
+                    conn.execute("ALTER TABLE performance_records ADD COLUMN turn_end_gate_held INTEGER")
+
                 # Create index
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_created_at ON performance_records (created_at)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_transaction_id ON performance_records (transaction_id)")
@@ -117,7 +146,7 @@ class SQLitePerformanceRecorder(PerformanceRecorder):
         conn.commit()
 
     def record(self, record: PerformanceRecord):
-        self.record_queue.put(record)
+        self.record_queue.put(self._prepare_record_for_storage(record))
 
     def close(self):
         self.stop_event.set()

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -119,7 +119,8 @@ class STSPipeline:
                 text=text,
                 audio_data=data,
                 audio_duration=recorded_duration,
-                system_prompt_params=self.vad.get_session_data(session_id, "system_prompt_params")
+                system_prompt_params=self.vad.get_session_data(session_id, "system_prompt_params"),
+                metadata=metadata,
             )):
                 if response.type == "start":
                     self.vad.set_session_data(session_id, "context_id", response.context_id)
@@ -337,29 +338,35 @@ class STSPipeline:
                 raise ValueError("session_id is required but not provided")
 
             start_time = time()
-            transaction_id = str(uuid4())
-
             # Notify client that request is accepted (fire and forget to avoid blocking pipeline latency)
             asyncio.create_task(self.handle_response(STSResponse(
                 type="accepted",
                 session_id=request.session_id,
-                transaction_id=transaction_id,
+                transaction_id=request.transaction_id,
                 metadata={"block_barge_in": request.block_barge_in}
             )))
             for handler in self._on_accepted_handlers:
                 await handler(request)
 
             performance = PerformanceRecord(
-                transaction_id=transaction_id,
+                transaction_id=request.transaction_id,
                 user_id=request.user_id,
                 stt_name=self.stt.__class__.__name__,
                 llm_name=self.llm.__class__.__name__,
                 tts_name=self.tts.__class__.__name__
             )
+            vad_performance = (
+                (request.metadata or {}).get("vad_performance") or {}
+            )
+            performance.speech_end_at = vad_performance.get("speech_end_at")
+            performance.silence_threshold_time = vad_performance.get("silence_threshold_time")
+            performance.stt_after_threshold_time = vad_performance.get("stt_after_threshold_time")
+            performance.turn_end_gate_time = vad_performance.get("turn_end_gate_time")
+            performance.turn_end_gate_held = vad_performance.get("turn_end_gate_held")
 
             # Record request voice
             if self.voice_recorder_enabled and request.audio_data:
-                await self.voice_recorder.record(RequestVoice(transaction_id, request.audio_data))
+                await self.voice_recorder.record(RequestVoice(request.transaction_id, request.audio_data))
 
             if request.text:
                 # Use text if exist
@@ -386,7 +393,7 @@ class STSPipeline:
                         session_id=request.session_id,
                         user_id=request.user_id,
                         context_id=request.context_id,
-                        transaction_id=transaction_id,
+                        transaction_id=request.transaction_id,
                         metadata={"reason": "No speech recognized."}
                     )
                     return
@@ -411,7 +418,7 @@ class STSPipeline:
                         session_id=request.session_id,
                         user_id=request.user_id,
                         context_id=request.context_id,
-                        transaction_id=transaction_id,
+                        transaction_id=request.transaction_id,
                         metadata={"reason": reason}
                     )
                     return
@@ -461,8 +468,8 @@ class STSPipeline:
 
                 # Overwrite active transaction
                 if self.debug:
-                    logger.info(f"Start transaction: {transaction_id} {request.text} (previous: {state.active_transaction_id})")
-                await self.session_state_manager.update_transaction(request.session_id, transaction_id, timestamp_inserted_at)
+                    logger.info(f"Start transaction: {request.transaction_id} {request.text} (previous: {state.active_transaction_id})")
+                await self.session_state_manager.update_transaction(request.session_id, request.transaction_id, timestamp_inserted_at)
             else:
                 # Clear request content to avoid LLM and TTS processing
                 request.text = None
@@ -480,7 +487,7 @@ class STSPipeline:
                 session_id=request.session_id,
                 user_id=request.user_id,
                 context_id=request.context_id,
-                transaction_id=transaction_id,
+                transaction_id=request.transaction_id,
                 metadata={"request_text": request.text, "recognized_text": recognized_text}
             )
 
@@ -497,7 +504,7 @@ class STSPipeline:
                     session_id=request.session_id,
                     user_id=request.user_id,
                     context_id=request.context_id,
-                    transaction_id=transaction_id,
+                    transaction_id=request.transaction_id,
                     text=request.quick_response_text,
                     voice_text=request.quick_response_voice_text,
                     audio_data=request.quick_response_audio,
@@ -519,11 +526,11 @@ class STSPipeline:
                 voice_text = ""
                 language = None
                 async for llm_stream_chunk in llm_stream:
-                    is_txn_active, active_txn = await self.is_transaction_active(request.session_id, transaction_id)
+                    is_txn_active, active_txn = await self.is_transaction_active(request.session_id, request.transaction_id)
                     if not is_txn_active:
                         # Break when new transaction started in this session
                         if self.debug:
-                            logger.info(f"Break llm_stream for new transaction: {active_txn} {request.text} (current: {transaction_id})")
+                            logger.info(f"Break llm_stream for new transaction: {active_txn} {request.text} (current: {request.transaction_id})")
                         break
 
                     # LLM error
@@ -582,11 +589,11 @@ class STSPipeline:
             is_first_chunk = not request.quick_response_text
             tool_call_records = {}  # {tool_call_id: {name, arguments, result}}
             async for audio_chunk, llm_stream_chunk, language, guradrail_name in synthesize_stream():
-                is_txn_active, active_txn = await self.is_transaction_active(request.session_id, transaction_id)
+                is_txn_active, active_txn = await self.is_transaction_active(request.session_id, request.transaction_id)
                 if not is_txn_active:
                     # Break when new transaction started in this session
                     if self.debug:
-                        logger.info(f"Break synthesize_stream for new transaction: {active_txn} {request.text} (current: {transaction_id})")
+                        logger.info(f"Break synthesize_stream for new transaction: {active_txn} {request.text} (current: {request.transaction_id})")
                     break
 
                 if llm_stream_chunk.tool_call:
@@ -605,7 +612,7 @@ class STSPipeline:
                         session_id=request.session_id,
                         user_id=request.user_id,
                         context_id=llm_stream_chunk.context_id,
-                        transaction_id=transaction_id,
+                        transaction_id=request.transaction_id,
                         tool_call=llm_stream_chunk.tool_call,
                         structured_content=llm_stream_chunk.structured_content
                     )
@@ -621,7 +628,7 @@ class STSPipeline:
                     session_id=request.session_id,
                     user_id=request.user_id,
                     context_id=llm_stream_chunk.context_id,
-                    transaction_id=transaction_id,
+                    transaction_id=request.transaction_id,
                     text=llm_stream_chunk.text,
                     voice_text=llm_stream_chunk.voice_text,
                     language=language,
@@ -641,7 +648,7 @@ class STSPipeline:
                 session_id=request.session_id,
                 user_id=request.user_id,
                 context_id=request.context_id,
-                transaction_id=transaction_id,
+                transaction_id=request.transaction_id,
                 text=(request.quick_response_text or "") + response_text,
                 voice_text=(request.quick_response_voice_text or "") + (performance.response_voice_text or "")
             )
@@ -649,10 +656,10 @@ class STSPipeline:
             if self.voice_recorder_enabled:
                 if request.quick_response_audio:
                     await self.voice_recorder.record(ResponseVoices(
-                        transaction_id + "_qr", [request.quick_response_audio], self.voice_recorder_response_audio_format
+                        request.transaction_id + "_qr", [request.quick_response_audio], self.voice_recorder_response_audio_format
                     ))
                 await self.voice_recorder.record(ResponseVoices(
-                    transaction_id, response_audios, self.voice_recorder_response_audio_format
+                    request.transaction_id, response_audios, self.voice_recorder_response_audio_format
                 ))
             for handler in self._on_finish_handlers:
                 await handler(request, final_response)
@@ -674,7 +681,7 @@ class STSPipeline:
                 session_id=request.session_id,
                 user_id=request.user_id,
                 context_id=request.context_id,
-                transaction_id=transaction_id,
+                transaction_id=request.transaction_id,
                 metadata={"error": "Error in processing Speech-to-Speech pipeline"}
             )
 
@@ -693,7 +700,8 @@ class STSPipeline:
                     await response_queue.put(STSResponse(
                         type="cancelled",
                         session_id=session_id,
-                        context_id=request.context_id
+                        context_id=request.context_id,
+                        transaction_id=request.transaction_id,
                     ))
                     await response_queue.put(None)
             except asyncio.QueueEmpty:
@@ -731,6 +739,7 @@ class STSPipeline:
                             type="error",
                             session_id=session_id,
                             context_id=request.context_id,
+                            transaction_id=request.transaction_id,
                             metadata={"error": "invoke timed out"}
                         ))
                 except Exception as ex:
@@ -740,6 +749,7 @@ class STSPipeline:
                             type="error",
                             session_id=session_id,
                             context_id=request.context_id,
+                            transaction_id=request.transaction_id,
                             metadata={"error": "invoke error in queue worker"}
                         ))
                 finally:

--- a/aiavatar/sts/vad/silero.py
+++ b/aiavatar/sts/vad/silero.py
@@ -1,11 +1,13 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
 import logging
 import numpy as np
 import os
 import struct
 import threading
+import time
 import torch
-from typing import AsyncGenerator, Callable, List, Optional, Dict, Awaitable
+from typing import Any, AsyncGenerator, Callable, List, Optional, Dict, Awaitable
 from . import SpeechDetector
 from .base import RecordingSessionBase
 from .filters.base import AudioFilter
@@ -25,6 +27,26 @@ class RecordingSession(RecordingSessionBase):
         self.turn_end_gate_hold_active: bool = False
         self.turn_end_gate_hold_timeout: Optional[float] = None
         self.turn_end_gate_hold_reasons: List[str] = []
+        self.reset_turn_end_timing()
+
+    def reset_turn_end_timing(self):
+        self.speech_end_at: Optional[datetime] = None
+        self.silence_threshold_reached_at: Optional[float] = None
+        self.silence_threshold_time: Optional[float] = None
+        self.stt_after_threshold_time: Optional[float] = None
+        self.turn_end_gate_time: Optional[float] = None
+        self.turn_end_gate_held: Optional[bool] = None
+
+    def snapshot_turn_end_timing(self) -> Optional[Dict[str, Any]]:
+        if self.speech_end_at is None:
+            return None
+        return {
+            "speech_end_at": self.speech_end_at,
+            "silence_threshold_time": self.silence_threshold_time,
+            "stt_after_threshold_time": self.stt_after_threshold_time,
+            "turn_end_gate_time": self.turn_end_gate_time,
+            "turn_end_gate_held": self.turn_end_gate_held,
+        }
 
     def reset(self):
         super().reset()
@@ -33,6 +55,7 @@ class RecordingSession(RecordingSessionBase):
         self.turn_end_gate_hold_timeout = None
         self.turn_end_gate_hold_reasons = []
         self.amplitude_threshold = None
+        self.reset_turn_end_timing()
         # Reset VAD iterator state for next utterance
         if self.vad_iterator:
             self.vad_iterator.reset_states()
@@ -267,7 +290,7 @@ class SileroSpeechDetector(SpeechDetector):
         text: Optional[str] = None,
     ) -> bool:
         """Confirm a VAD turn-end candidate with optional gates."""
-        return await self.turn_end_gate_manager.should_end_turn(
+        should_end = await self.turn_end_gate_manager.should_end_turn(
             session=session,
             audio_factory=lambda: bytes(session.buffer),
             sample_rate=self.sample_rate,
@@ -277,9 +300,53 @@ class SileroSpeechDetector(SpeechDetector):
             silence_duration_threshold=self.silence_duration_threshold,
             text=text,
         )
+        if self.turn_end_gates:
+            if not should_end and session.turn_end_gate_hold_active:
+                session.turn_end_gate_held = True
+            elif should_end:
+                self._finalize_turn_end_gate_timing(session)
+        return should_end
 
-    async def execute_on_speech_detected(self, recorded_data: bytes, recorded_duration: float, session_id: str):
-        await self._execute_on_speech_detected(recorded_data, None, None, recorded_duration, session_id)
+    def _mark_silence_threshold_reached(self, session: RecordingSession):
+        if session.silence_threshold_reached_at is not None:
+            return
+        now_monotonic = time.perf_counter()
+        session.silence_threshold_reached_at = now_monotonic
+        session.speech_end_at = datetime.now(timezone.utc) - timedelta(
+            seconds=session.silence_duration
+        )
+        session.silence_threshold_time = session.silence_duration
+        if self.turn_end_gates:
+            session.turn_end_gate_held = False
+
+    def _finalize_turn_end_gate_timing(self, session: RecordingSession):
+        if (
+            not self.turn_end_gates
+            or session.silence_threshold_reached_at is None
+            or session.turn_end_gate_time is not None
+        ):
+            return
+        stt_time = session.stt_after_threshold_time or 0.0
+        session.turn_end_gate_time = max(
+            0.0,
+            time.perf_counter() - session.silence_threshold_reached_at - stt_time,
+        )
+
+    def _build_vad_performance_metadata(self, session: RecordingSession) -> Optional[dict]:
+        self._finalize_turn_end_gate_timing(session)
+        timing = session.snapshot_turn_end_timing()
+        return {"vad_performance": timing} if timing is not None else None
+
+    async def execute_on_speech_detected(
+        self,
+        recorded_data: bytes,
+        recorded_duration: float,
+        session_id: str,
+        metadata: Optional[dict] = None,
+    ):
+        await self._execute_on_speech_detected(
+            recorded_data, None, metadata, recorded_duration, session_id
+        )
 
     async def process_samples(self, samples: bytes, session_id: str) -> bool:
         if self.to_linear16:
@@ -349,6 +416,7 @@ class SileroSpeechDetector(SpeechDetector):
             session.record_duration += sample_duration
 
             if speech_detected:
+                session.reset_turn_end_timing()
                 session.silence_duration = 0
                 self.turn_end_gate_manager.reset_session(session.session_id, session=session)
             else:
@@ -362,11 +430,18 @@ class SileroSpeechDetector(SpeechDetector):
                 if self.debug:
                     logger.info(f"Recording max duration reached: {session.record_duration} sec")
                 recorded_data = bytes(session.buffer)
-                asyncio.create_task(self.execute_on_speech_detected(recorded_data, session.record_duration, session.session_id))
+                metadata = self._build_vad_performance_metadata(session)
+                asyncio.create_task(self.execute_on_speech_detected(
+                    recorded_data,
+                    session.record_duration,
+                    session.session_id,
+                    metadata,
+                ))
                 self.turn_end_gate_manager.reset_session(session.session_id, session=session)
                 session.reset()
 
             elif session.silence_duration >= self.silence_duration_threshold:
+                self._mark_silence_threshold_reached(session)
                 recorded_duration = session.record_duration - session.silence_duration
                 if recorded_duration < self.min_duration:
                     if self.debug:
@@ -378,7 +453,13 @@ class SileroSpeechDetector(SpeechDetector):
                     if self.debug:
                         logger.info(f"Recording finished: {recorded_duration} sec")
                     recorded_data = bytes(session.buffer)
-                    asyncio.create_task(self.execute_on_speech_detected(recorded_data, recorded_duration, session.session_id))
+                    metadata = self._build_vad_performance_metadata(session)
+                    asyncio.create_task(self.execute_on_speech_detected(
+                        recorded_data,
+                        recorded_duration,
+                        session.session_id,
+                        metadata,
+                    ))
                 session.reset()
 
         return session.is_recording

--- a/aiavatar/sts/vad/stream.py
+++ b/aiavatar/sts/vad/stream.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import struct
+import time
 from typing import Callable, Optional, Dict, List, Awaitable
 from .silero import SileroSpeechDetector, RecordingSession as SileroRecordingSession
 from .filters.base import AudioFilter
@@ -182,6 +183,11 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
         if task is None:
             return
 
+        started_at = (
+            time.perf_counter()
+            if session.silence_threshold_reached_at is not None
+            else None
+        )
         try:
             await task
         except asyncio.CancelledError:
@@ -200,6 +206,17 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
                 context,
                 exc_info=True
             )
+        finally:
+            if started_at is not None:
+                elapsed = time.perf_counter() - started_at
+                session.stt_after_threshold_time = (
+                    session.stt_after_threshold_time or 0.0
+                ) + elapsed
+
+    def _mark_silence_threshold_reached(self, session: RecordingSession):
+        super()._mark_silence_threshold_reached(session)
+        if session.stt_after_threshold_time is None:
+            session.stt_after_threshold_time = 0.0
 
     async def _should_end_turn_with_gate(self, session: RecordingSession, recorded_duration: float) -> bool:
         if self.turn_end_gates and session.pending_recognition_task is not None:
@@ -282,6 +299,7 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
             session.segment_duration += sample_duration
 
             if speech_detected:
+                session.reset_turn_end_timing()
                 session.silence_duration = 0
                 self.turn_end_gate_manager.reset_session(session.session_id, session=session)
                 session.segment_silence_duration = 0
@@ -340,7 +358,14 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
                             return session.is_recording
 
                     recorded_data = bytes(session.buffer)
-                    asyncio.create_task(self.execute_on_speech_detected(recorded_data, final_text, None, session.record_duration, session.session_id))
+                    metadata = self._build_vad_performance_metadata(session)
+                    asyncio.create_task(self.execute_on_speech_detected(
+                        recorded_data,
+                        final_text,
+                        metadata,
+                        session.record_duration,
+                        session.session_id,
+                    ))
                 else:
                     if self.debug:
                         logger.info("No text recognized at max duration, skipping")
@@ -348,6 +373,7 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
                 session.reset()
 
             elif session.silence_duration >= self.silence_duration_threshold:
+                self._mark_silence_threshold_reached(session)
                 recorded_duration = session.record_duration - session.silence_duration
                 if recorded_duration < self.min_duration:
                     if self.debug:
@@ -366,12 +392,17 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
                     final_text = session.last_recognized_text
                     if final_text is None:
                         # No segment was recognized, run recognition on full buffer
+                        started_at = time.perf_counter()
                         try:
                             result = await self._recognize_audio(session, bytes(session.buffer))
                             final_text = result.text
                         except Exception as ex:
                             logger.error("Error in final recognition", exc_info=True)
                             await self._execute_on_speech_recognition_error(ex, session.session_id)
+                        finally:
+                            session.stt_after_threshold_time = (
+                                session.stt_after_threshold_time or 0.0
+                            ) + (time.perf_counter() - started_at)
 
                     if final_text:
                         if self._validate_recognized_text:
@@ -382,7 +413,14 @@ class SileroStreamSpeechDetector(SileroSpeechDetector):
                                 return session.is_recording
 
                         recorded_data = bytes(session.buffer)
-                        asyncio.create_task(self.execute_on_speech_detected(recorded_data, final_text, None, recorded_duration, session.session_id))
+                        metadata = self._build_vad_performance_metadata(session)
+                        asyncio.create_task(self.execute_on_speech_detected(
+                            recorded_data,
+                            final_text,
+                            metadata,
+                            recorded_duration,
+                            session.session_id,
+                        ))
                     else:
                         if self.debug:
                             logger.info("No text recognized, skipping")

--- a/tests/sts/performance_recorder/test_pipeline_vad_performance.py
+++ b/tests/sts/performance_recorder/test_pipeline_vad_performance.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from aiavatar.sts.llm.base import LLMServiceDummy
+from aiavatar.sts.models import STSRequest
+from aiavatar.sts.performance_recorder import PerformanceRecord, PerformanceRecorder
+from aiavatar.sts.pipeline import STSPipeline
+from aiavatar.sts.stt.base import SpeechRecognizerDummy
+from aiavatar.sts.tts.base import SpeechSynthesizerDummy
+from aiavatar.sts.vad.base import SpeechDetectorDummy
+
+
+class CapturePerformanceRecorder(PerformanceRecorder):
+    def __init__(self):
+        self.records = []
+
+    def record(self, record: PerformanceRecord):
+        self.records.append(record)
+
+    def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("metadata", "expected_threshold"),
+    [
+        (
+            {
+                "vad_performance": {
+                    "speech_end_at": datetime(2026, 1, 2, tzinfo=timezone.utc),
+                    "silence_threshold_time": 0.5,
+                    "stt_after_threshold_time": 0.1,
+                    "turn_end_gate_time": 0.3,
+                    "turn_end_gate_held": True,
+                }
+            },
+            0.5,
+        ),
+        (None, None),
+    ],
+)
+async def test_pipeline_copies_optional_vad_performance(
+    tmp_path,
+    metadata,
+    expected_threshold,
+):
+    recorder = CapturePerformanceRecorder()
+    pipeline = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=LLMServiceDummy(response_text="ok", db_connection_str=str(tmp_path / "llm.db")),
+        tts=SpeechSynthesizerDummy(synthesized_bytes=b"audio"),
+        performance_recorder=recorder,
+        voice_recorder_enabled=False,
+        db_connection_str=str(tmp_path / "pipeline.db"),
+    )
+
+    responses = [
+        response
+        async for response in pipeline.invoke(STSRequest(
+            session_id="session",
+            text="hello",
+            metadata=metadata,
+        ))
+    ]
+
+    assert responses[-1].type == "final"
+    record = recorder.records[0]
+    assert record.silence_threshold_time == expected_threshold
+    if metadata is None:
+        assert record.speech_end_at is None
+        assert record.stt_after_threshold_time is None
+        assert record.turn_end_gate_time is None
+        assert record.turn_end_gate_held is None
+    else:
+        assert record.speech_end_at == datetime(2026, 1, 2, tzinfo=timezone.utc)
+        assert record.stt_after_threshold_time == 0.1
+        assert record.turn_end_gate_time == 0.3
+        assert record.turn_end_gate_held is True

--- a/tests/sts/performance_recorder/test_vad_performance_fields.py
+++ b/tests/sts/performance_recorder/test_vad_performance_fields.py
@@ -1,0 +1,260 @@
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+
+from aiavatar.sts.performance_recorder import PerformanceRecord
+from aiavatar.sts.performance_recorder.sqlite import SQLitePerformanceRecorder
+
+
+def test_sqlite_fresh_schema_orders_timing_columns_from_speech_end(tmp_path):
+    db_path = tmp_path / "fresh-performance.db"
+    recorder = SQLitePerformanceRecorder(db_path=str(db_path))
+    recorder.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        columns = [
+            row[1]
+            for row in conn.execute("PRAGMA table_info(performance_records)")
+        ]
+    finally:
+        conn.close()
+
+    assert columns == [
+        "id",
+        "created_at",
+        "transaction_id",
+        "user_id",
+        "context_id",
+        "voice_length",
+        "speech_end_at",
+        "silence_threshold_time",
+        "stt_after_threshold_time",
+        "turn_end_gate_time",
+        "turn_end_gate_held",
+        "stt_time",
+        "stop_response_time",
+        "before_llm_time",
+        "llm_first_chunk_time",
+        "llm_first_voice_chunk_time",
+        "llm_time",
+        "tts_first_chunk_time",
+        "tts_time",
+        "total_time",
+        "stt_name",
+        "llm_name",
+        "tts_name",
+        "request_text",
+        "request_files",
+        "response_text",
+        "response_voice_text",
+        "quick_response_text",
+        "error_info",
+        "tool_calls",
+    ]
+
+
+def test_sqlite_records_vad_performance_fields_and_nulls(tmp_path):
+    db_path = tmp_path / "performance.db"
+    recorder = SQLitePerformanceRecorder(db_path=str(db_path))
+    speech_end_at = datetime.now(timezone.utc)
+    try:
+        recorder.record(PerformanceRecord(
+            transaction_id="silero",
+            speech_end_at=speech_end_at,
+            silence_threshold_time=0.5,
+            stt_after_threshold_time=0.12,
+            turn_end_gate_time=0.3,
+            turn_end_gate_held=True,
+        ))
+        recorder.record(PerformanceRecord(
+            transaction_id="unsupported-vad",
+            stt_time=0.25,
+        ))
+        recorder.record_queue.join()
+    finally:
+        recorder.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        silero = conn.execute(
+            """
+            SELECT speech_end_at, silence_threshold_time,
+                   stt_after_threshold_time, turn_end_gate_time,
+                   turn_end_gate_held, stt_time
+            FROM performance_records
+            WHERE transaction_id = ?
+            """,
+            ("silero",),
+        ).fetchone()
+        unsupported = conn.execute(
+            """
+            SELECT speech_end_at, silence_threshold_time,
+                   stt_after_threshold_time, turn_end_gate_time,
+                   turn_end_gate_held, stt_time
+            FROM performance_records
+            WHERE transaction_id = ?
+            """,
+            ("unsupported-vad",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert silero[0] == str(speech_end_at)
+    assert silero[1:] == pytest.approx((0.5, 0.62, 0.92, 1, 0.0))
+    assert unsupported == (None, None, None, None, None, 0.25)
+
+
+@pytest.mark.parametrize(
+    ("time_origin", "expected_offset"),
+    [
+        (None, 0.92),
+        ("pipeline_start", 0.0),
+    ],
+)
+def test_sqlite_time_origin_rebases_vad_and_pipeline_lap_times(
+    tmp_path,
+    time_origin,
+    expected_offset,
+):
+    db_path = tmp_path / f"performance-{time_origin or 'default'}.db"
+    recorder_kwargs = {"db_path": str(db_path)}
+    if time_origin is not None:
+        recorder_kwargs["time_origin"] = time_origin
+    recorder = SQLitePerformanceRecorder(**recorder_kwargs)
+
+    raw_lap_times = (0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
+    record = PerformanceRecord(
+        transaction_id="time-origin",
+        silence_threshold_time=0.5,
+        stt_after_threshold_time=0.12,
+        turn_end_gate_time=0.3,
+        stt_time=raw_lap_times[0],
+        stop_response_time=raw_lap_times[1],
+        before_llm_time=raw_lap_times[2],
+        llm_first_chunk_time=raw_lap_times[3],
+        llm_first_voice_chunk_time=raw_lap_times[4],
+        llm_time=raw_lap_times[5],
+        tts_first_chunk_time=raw_lap_times[6],
+        tts_time=raw_lap_times[7],
+        total_time=raw_lap_times[8],
+    )
+    try:
+        recorder.record(record)
+        recorder.record_queue.join()
+    finally:
+        recorder.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            """
+            SELECT silence_threshold_time, stt_after_threshold_time,
+                   turn_end_gate_time, stt_time, stop_response_time,
+                   before_llm_time, llm_first_chunk_time,
+                   llm_first_voice_chunk_time, llm_time,
+                   tts_first_chunk_time, tts_time, total_time
+            FROM performance_records
+            WHERE transaction_id = ?
+            """,
+            ("time-origin",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    expected_vad_laps = (
+        (0.5, 0.62, 0.92)
+        if time_origin is None
+        else (0.5, 0.12, 0.3)
+    )
+    assert row[:3] == pytest.approx(expected_vad_laps)
+    assert row[3:] == pytest.approx(tuple(
+        value + expected_offset
+        for value in raw_lap_times
+    ))
+    assert record.stt_time == 0.1
+    assert record.stt_after_threshold_time == 0.12
+    assert record.turn_end_gate_time == 0.3
+
+
+def test_sqlite_user_speech_end_origin_keeps_unreached_laps_at_zero(tmp_path):
+    db_path = tmp_path / "performance-zero-laps.db"
+    recorder = SQLitePerformanceRecorder(db_path=str(db_path))
+    try:
+        recorder.record(PerformanceRecord(
+            transaction_id="partial-record",
+            silence_threshold_time=0.5,
+            stt_after_threshold_time=0.1,
+            turn_end_gate_time=0.2,
+            stt_time=0.01,
+        ))
+        recorder.record_queue.join()
+    finally:
+        recorder.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            """
+            SELECT stt_time, stop_response_time, before_llm_time, total_time
+            FROM performance_records
+            WHERE transaction_id = ?
+            """,
+            ("partial-record",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row == pytest.approx((0.81, 0.0, 0.0, 0.0))
+
+
+def test_sqlite_rejects_invalid_time_origin(tmp_path):
+    with pytest.raises(ValueError, match="Invalid time_origin"):
+        SQLitePerformanceRecorder(
+            db_path=str(tmp_path / "invalid-origin.db"),
+            time_origin="invalid",
+        )
+
+
+def test_sqlite_migrates_vad_performance_columns(tmp_path):
+    db_path = tmp_path / "existing-performance.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE performance_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TIMESTAMP,
+                transaction_id TEXT,
+                user_id TEXT,
+                context_id TEXT,
+                request_files TEXT,
+                before_llm_time REAL,
+                quick_response_text TEXT,
+                error_info TEXT,
+                tool_calls TEXT
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    recorder = SQLitePerformanceRecorder(db_path=str(db_path))
+    recorder.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        columns = {
+            row[1]: row[2]
+            for row in conn.execute("PRAGMA table_info(performance_records)")
+        }
+    finally:
+        conn.close()
+
+    assert columns["speech_end_at"] == "TIMESTAMP"
+    assert columns["silence_threshold_time"] == "REAL"
+    assert columns["stt_after_threshold_time"] == "REAL"
+    assert columns["turn_end_gate_time"] == "REAL"
+    assert columns["turn_end_gate_held"] == "INTEGER"

--- a/tests/sts/vad/test_speech_recognizer_override.py
+++ b/tests/sts/vad/test_speech_recognizer_override.py
@@ -2,12 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from aiavatar.sts.playback import PlaybackTimeline
 from aiavatar.sts.pipeline import STSPipeline
-from aiavatar.sts.vad.echo_cancelling.stream import (
-    EchoCancellingSileroStreamSpeechDetector,
-    RecordingSession as EchoStreamRecordingSession,
-)
 from aiavatar.sts.vad.stream import (
     RecordingSession as StreamRecordingSession,
     SileroStreamSpeechDetector,
@@ -48,7 +43,6 @@ class CaptureAwareSpeechRecognizer(TrackingSpeechRecognizer):
     "session_class",
     [
         StreamRecordingSession,
-        EchoStreamRecordingSession,
     ],
 )
 def test_stream_session_speech_recognizer_override_survives_reset(session_class):
@@ -157,64 +151,3 @@ async def test_pipeline_finalize_keeps_batch_override_until_user_clears_it():
 
     pipeline.clear_speech_recognizer("session")
     assert pipeline.get_speech_recognizer("session") is default
-
-
-@pytest.mark.asyncio
-async def test_echo_stream_uses_capture_aware_session_override():
-    timeline = PlaybackTimeline()
-    default = TrackingSpeechRecognizer("default")
-    override = CaptureAwareSpeechRecognizer("override", timeline)
-    detector = object.__new__(EchoCancellingSileroStreamSpeechDetector)
-    detector.speech_recognizer = default
-    detector.playback_timeline = timeline
-    session = EchoStreamRecordingSession("session")
-    session.set_speech_recognizer(override)
-
-    result = await detector._recognize_audio(
-        session,
-        b"audio",
-        capture_ended_at=123.0,
-    )
-
-    assert result.text == "override"
-    assert override.capture_calls == [("session", b"audio", 123.0)]
-    assert default.calls == []
-
-
-@pytest.mark.asyncio
-async def test_echo_stream_uses_plain_session_override():
-    default = TrackingSpeechRecognizer("default")
-    override = TrackingSpeechRecognizer("override")
-    detector = object.__new__(EchoCancellingSileroStreamSpeechDetector)
-    detector.speech_recognizer = default
-    detector.playback_timeline = PlaybackTimeline()
-    session = EchoStreamRecordingSession("session")
-    session.set_speech_recognizer(override)
-
-    result = await detector._recognize_audio(
-        session,
-        b"audio",
-        capture_ended_at=123.0,
-    )
-
-    assert result.text == "override"
-    assert override.calls == [("session", b"audio")]
-    assert default.calls == []
-
-
-@pytest.mark.asyncio
-async def test_echo_stream_rejects_override_using_another_timeline():
-    detector = object.__new__(EchoCancellingSileroStreamSpeechDetector)
-    detector.speech_recognizer = TrackingSpeechRecognizer("default")
-    detector.playback_timeline = PlaybackTimeline()
-    session = EchoStreamRecordingSession("session")
-    session.set_speech_recognizer(
-        CaptureAwareSpeechRecognizer("override", PlaybackTimeline())
-    )
-
-    with pytest.raises(ValueError, match="must share the same playback_timeline"):
-        await detector._recognize_audio(
-            session,
-            b"audio",
-            capture_ended_at=123.0,
-        )

--- a/tests/sts/vad/test_vad_performance.py
+++ b/tests/sts/vad/test_vad_performance.py
@@ -1,0 +1,205 @@
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from aiavatar.sts.vad.silero import SileroSpeechDetector
+from aiavatar.sts.vad.stream import SileroStreamSpeechDetector
+
+from _turn_end_gate_helpers import (
+    AlwaysHoldForeverGate,
+    AlwaysHoldGate,
+    DummySpeechRecognizer,
+    detect_non_silent,
+    fake_init_silero_model,
+)
+
+
+SPEECH_CHUNK = b"\x01\x00" * 1600
+SILENCE_CHUNK = b"\x00\x00" * 1600
+
+
+@pytest.mark.asyncio
+async def test_silero_records_speech_end_threshold_and_gate_hold(monkeypatch):
+    monkeypatch.setattr(
+        SileroSpeechDetector,
+        "_init_silero_model",
+        fake_init_silero_model,
+    )
+    detector = SileroSpeechDetector(
+        silence_duration_threshold=0.2,
+        turn_end_gates=[AlwaysHoldGate(timeout=0.3)],
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+
+    detected = []
+
+    @detector.on_speech_detected
+    async def on_speech_detected(data, text, metadata, duration, session_id):
+        detected.append(metadata)
+
+    await detector.process_samples(SPEECH_CHUNK, "silero-performance")
+    await detector.process_samples(SPEECH_CHUNK, "silero-performance")
+    for _ in range(6):
+        await detector.process_samples(SILENCE_CHUNK, "silero-performance")
+    await asyncio.sleep(0)
+
+    timing = detected[0]["vad_performance"]
+    assert isinstance(timing["speech_end_at"], datetime)
+    assert timing["speech_end_at"].tzinfo is not None
+    assert timing["silence_threshold_time"] == pytest.approx(0.2)
+    assert timing["stt_after_threshold_time"] is None
+    assert timing["turn_end_gate_time"] is not None
+    assert timing["turn_end_gate_time"] >= 0
+    assert timing["turn_end_gate_held"] is True
+
+
+@pytest.mark.asyncio
+async def test_silero_resets_candidate_timing_when_speech_resumes(monkeypatch):
+    monkeypatch.setattr(
+        SileroSpeechDetector,
+        "_init_silero_model",
+        fake_init_silero_model,
+    )
+    detector = SileroSpeechDetector(
+        silence_duration_threshold=0.2,
+        turn_end_gates=[AlwaysHoldForeverGate()],
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+
+    session_id = "silero-performance-reset"
+    await detector.process_samples(SPEECH_CHUNK, session_id)
+    await detector.process_samples(SPEECH_CHUNK, session_id)
+    await detector.process_samples(SILENCE_CHUNK, session_id)
+    await detector.process_samples(SILENCE_CHUNK, session_id)
+
+    session = detector.get_session(session_id)
+    assert session.silence_threshold_reached_at is not None
+    assert session.turn_end_gate_held is True
+
+    await detector.process_samples(SPEECH_CHUNK, session_id)
+
+    assert session.silence_threshold_reached_at is None
+    assert session.speech_end_at is None
+    assert session.turn_end_gate_time is None
+    assert session.turn_end_gate_held is None
+
+
+@pytest.mark.asyncio
+async def test_silero_finalizes_gate_timing_when_max_duration_ends_hold(monkeypatch):
+    monkeypatch.setattr(
+        SileroSpeechDetector,
+        "_init_silero_model",
+        fake_init_silero_model,
+    )
+    detector = SileroSpeechDetector(
+        silence_duration_threshold=0.2,
+        turn_end_gates=[AlwaysHoldForeverGate()],
+        max_duration=0.5,
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+    detected = []
+
+    @detector.on_speech_detected
+    async def on_speech_detected(data, text, metadata, duration, session_id):
+        detected.append(metadata)
+
+    session_id = "silero-performance-max-duration"
+    await detector.process_samples(SPEECH_CHUNK, session_id)
+    await detector.process_samples(SPEECH_CHUNK, session_id)
+    await detector.process_samples(SILENCE_CHUNK, session_id)
+    await detector.process_samples(SILENCE_CHUNK, session_id)
+    await detector.process_samples(SILENCE_CHUNK, session_id)
+    await asyncio.sleep(0)
+
+    timing = detected[0]["vad_performance"]
+    assert timing["turn_end_gate_held"] is True
+    assert timing["turn_end_gate_time"] is not None
+    assert timing["turn_end_gate_time"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_silero_stream_records_only_stt_wait_after_threshold(monkeypatch):
+    monkeypatch.setattr(
+        SileroSpeechDetector,
+        "_init_silero_model",
+        fake_init_silero_model,
+    )
+    detector = SileroStreamSpeechDetector(
+        speech_recognizer=DummySpeechRecognizer(),
+        silence_duration_threshold=0.2,
+        segment_silence_threshold=10.0,
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+
+    async def delayed_recognition(session, data):
+        await asyncio.sleep(0.02)
+        return SimpleNamespace(text="こんにちは")
+
+    monkeypatch.setattr(detector, "_recognize_audio", delayed_recognition)
+    detected = []
+
+    @detector.on_speech_detected
+    async def on_speech_detected(data, text, metadata, duration, session_id):
+        detected.append(metadata)
+
+    await detector.process_samples(SPEECH_CHUNK, "stream-performance")
+    await detector.process_samples(SPEECH_CHUNK, "stream-performance")
+    await detector.process_samples(SILENCE_CHUNK, "stream-performance")
+    await detector.process_samples(SILENCE_CHUNK, "stream-performance")
+    await asyncio.sleep(0)
+
+    timing = detected[0]["vad_performance"]
+    assert timing["silence_threshold_time"] == pytest.approx(0.2)
+    assert timing["stt_after_threshold_time"] >= 0.015
+    assert timing["turn_end_gate_time"] is None
+    assert timing["turn_end_gate_held"] is None
+
+
+@pytest.mark.asyncio
+async def test_silero_stream_does_not_emit_performance_without_recognized_text(monkeypatch):
+    monkeypatch.setattr(
+        SileroSpeechDetector,
+        "_init_silero_model",
+        fake_init_silero_model,
+    )
+    detector = SileroStreamSpeechDetector(
+        speech_recognizer=DummySpeechRecognizer(),
+        silence_duration_threshold=0.2,
+        segment_silence_threshold=10.0,
+        min_duration=0.1,
+        sample_rate=16000,
+        chunk_size=1,
+    )
+    monkeypatch.setattr(detector, "_detect_speech_silero", detect_non_silent)
+
+    async def empty_recognition(session, data):
+        return SimpleNamespace(text="")
+
+    monkeypatch.setattr(detector, "_recognize_audio", empty_recognition)
+    detected = []
+
+    @detector.on_speech_detected
+    async def on_speech_detected(data, text, metadata, duration, session_id):
+        detected.append(metadata)
+
+    await detector.process_samples(SPEECH_CHUNK, "stream-empty-recognition")
+    await detector.process_samples(SPEECH_CHUNK, "stream-empty-recognition")
+    await detector.process_samples(SILENCE_CHUNK, "stream-empty-recognition")
+    await detector.process_samples(SILENCE_CHUNK, "stream-empty-recognition")
+    await asyncio.sleep(0)
+
+    assert detected == []


### PR DESCRIPTION
Add VAD, streaming STT, and turn-end gate timing to performance records. Support cumulative lap times from user speech end or pipeline start.