### PR TITLE
Add asynchronous dialog state observer

### DIFF
--- a/aiavatar/sts/dialog_observer.py
+++ b/aiavatar/sts/dialog_observer.py
@@ -1,0 +1,401 @@
+import asyncio
+import copy
+from dataclasses import dataclass, field
+import inspect
+import logging
+from types import MappingProxyType
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Tuple
+
+from .models import STSRequest, STSResponse
+
+
+logger = logging.getLogger(__name__)
+
+_UNSET = object()
+
+
+def _freeze(value: Any) -> Any:
+    """Create a recursively read-only snapshot without copying immutable bytes."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze(item) for key, item in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze(item) for item in value)
+    if isinstance(value, bytes):
+        return value
+    return copy.deepcopy(value)
+
+
+@dataclass(frozen=True)
+class DialogRequest:
+    """Read-only request data exposed to dialog observer functions."""
+
+    text: Optional[str] = None
+    audio_data: Optional[bytes] = None
+    audio_duration: float = 0
+    files: Any = None
+    metadata: Mapping[str, Any] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    channel: Optional[str] = None
+
+    @classmethod
+    def from_sts_request(
+        cls,
+        request: STSRequest,
+        *,
+        text: Any = _UNSET,
+    ) -> "DialogRequest":
+        return cls(
+            text=request.text if text is _UNSET else text,
+            audio_data=request.audio_data,
+            audio_duration=request.audio_duration,
+            files=_freeze(request.files),
+            metadata=_freeze(request.metadata or {}),
+            channel=request.channel,
+        )
+
+
+@dataclass(frozen=True)
+class DialogResponse:
+    """Read-only final response data exposed to dialog observer functions."""
+
+    text: Optional[str] = None
+    voice_text: Optional[str] = None
+    metadata: Mapping[str, Any] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    structured_content: Any = None
+
+    @classmethod
+    def from_sts_response(cls, response: STSResponse) -> "DialogResponse":
+        return cls(
+            text=response.text,
+            voice_text=response.voice_text,
+            metadata=_freeze(response.metadata or {}),
+            structured_content=_freeze(response.structured_content),
+        )
+
+
+@dataclass(frozen=True)
+class DialogObservation:
+    """A request or response observation with stable pipeline identifiers."""
+
+    session_id: str
+    transaction_id: str
+    context_id: Optional[str]
+    user_id: Optional[str]
+    request: DialogRequest
+    response: Optional[DialogResponse] = None
+
+
+DialogObserverFunction = Callable[
+    [DialogObservation, dict[Any, Any]],
+    Awaitable[Optional[dict[Any, Any]]],
+]
+
+
+@dataclass
+class _ObserverSlot:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    sequence: int = 0
+    task: Optional[asyncio.Task] = None
+
+
+class DialogObserver:
+    """Run latest-wins asynchronous observers for requests and responses.
+
+    A running observer is isolated by session, phase, and registered function.
+    A newer observation cancels and replaces the older invocation in the same
+    slot. State patches are committed only when the invocation still has the
+    latest sequence, so a slow or cancellation-resistant observer cannot
+    overwrite newer state.
+    """
+
+    REQUEST_PHASE = "request"
+    RESPONSE_PHASE = "response"
+
+    def __init__(self, *, handler_timeout: Optional[float] = None):
+        if handler_timeout is not None and handler_timeout <= 0:
+            raise ValueError("handler_timeout must be greater than zero")
+
+        self.handler_timeout = handler_timeout
+        self._request_handlers: list[DialogObserverFunction] = []
+        self._response_handlers: list[DialogObserverFunction] = []
+
+        self._states: Dict[str, dict[Any, Any]] = {}
+        self._state_locks: Dict[str, asyncio.Lock] = {}
+        self._slots: Dict[Tuple[str, str, int], _ObserverSlot] = {}
+
+        self._replacement_task_sessions: Dict[asyncio.Task, str] = {}
+        self._closed = False
+
+    def on_request(self, function: DialogObserverFunction) -> DialogObserverFunction:
+        """Register an async function invoked for request observations."""
+        self._register(self._request_handlers, function)
+        return function
+
+    def on_response(self, function: DialogObserverFunction) -> DialogObserverFunction:
+        """Register an async function invoked for final response observations."""
+        self._register(self._response_handlers, function)
+        return function
+
+    def _register(
+        self,
+        handlers: list[DialogObserverFunction],
+        function: DialogObserverFunction,
+    ) -> None:
+        if not inspect.iscoroutinefunction(function):
+            raise TypeError("Dialog observer functions must be async")
+        if function not in handlers:
+            handlers.append(function)
+
+    def observe_request(self, observation: DialogObservation) -> None:
+        """Schedule request observers without waiting in the pipeline."""
+        if observation.response is not None:
+            raise ValueError("Request observation must not contain a response")
+        self._observe(self.REQUEST_PHASE, self._request_handlers, observation)
+
+    def observe_response(self, observation: DialogObservation) -> None:
+        """Schedule response observers without waiting in the pipeline."""
+        if observation.response is None:
+            raise ValueError("Response observation requires a response")
+        self._observe(self.RESPONSE_PHASE, self._response_handlers, observation)
+
+    def _observe(
+        self,
+        phase: str,
+        handlers: list[DialogObserverFunction],
+        observation: DialogObservation,
+    ) -> None:
+        if self._closed or not handlers:
+            return
+
+        for function in handlers:
+            slot_key = (
+                observation.session_id,
+                phase,
+                id(function),
+            )
+            slot = self._slots.get(slot_key)
+            if slot is None:
+                slot = _ObserverSlot()
+                self._slots[slot_key] = slot
+            slot.sequence += 1
+
+            # Request cancellation immediately. _replace_observer waits for the
+            # observer to stop before it starts the replacement.
+            if slot.task is not None and not slot.task.done():
+                slot.task.cancel()
+
+            replacement_task = asyncio.create_task(
+                self._replace_observer(
+                    slot=slot,
+                    function=function,
+                    observation=observation,
+                    sequence=slot.sequence,
+                )
+            )
+            self._track_replacement_task(
+                replacement_task,
+                observation.session_id,
+            )
+
+    async def _replace_observer(
+        self,
+        *,
+        slot: _ObserverSlot,
+        function: DialogObserverFunction,
+        observation: DialogObservation,
+        sequence: int,
+    ) -> None:
+        try:
+            async with slot.lock:
+                if sequence != slot.sequence:
+                    return
+
+                previous_task = slot.task
+                if previous_task is not None and not previous_task.done():
+                    previous_task.cancel()
+                    await asyncio.gather(previous_task, return_exceptions=True)
+
+                if sequence != slot.sequence or self._closed:
+                    return
+
+                slot.task = asyncio.create_task(
+                    self._run_observer(
+                        slot=slot,
+                        function=function,
+                        observation=observation,
+                        sequence=sequence,
+                    )
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Failed to replace dialog observer task")
+
+    async def _run_observer(
+        self,
+        *,
+        slot: _ObserverSlot,
+        function: DialogObserverFunction,
+        observation: DialogObservation,
+        sequence: int,
+    ) -> None:
+        current_task = asyncio.current_task()
+        try:
+            state = self.get_state(observation.session_id)
+            awaitable = function(observation, state)
+            if self.handler_timeout is None:
+                states = await awaitable
+            else:
+                states = await asyncio.wait_for(
+                    awaitable,
+                    timeout=self.handler_timeout,
+                )
+
+            if states is None:
+                return
+            if not isinstance(states, dict):
+                raise TypeError(
+                    "Dialog observer functions must return a dict or None"
+                )
+
+            # Check both before and after taking the state lock. A replacement
+            # may advance the sequence while this observer is completing.
+            if sequence != slot.sequence:
+                return
+            state_lock = self._state_locks.setdefault(
+                observation.session_id,
+                asyncio.Lock(),
+            )
+            async with state_lock:
+                if sequence != slot.sequence:
+                    return
+                self._states.setdefault(observation.session_id, {}).update(
+                    copy.deepcopy(states)
+                )
+        except asyncio.CancelledError:
+            raise
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Dialog observer timed out: session=%s function=%s",
+                observation.session_id,
+                getattr(
+                    function,
+                    "__name__",
+                    repr(function),
+                ),
+            )
+        except Exception:
+            logger.exception(
+                "Dialog observer failed: session=%s function=%s",
+                observation.session_id,
+                getattr(
+                    function,
+                    "__name__",
+                    repr(function),
+                ),
+            )
+        finally:
+            if slot.task is current_task:
+                slot.task = None
+
+    def get_state(self, session_id: str) -> dict[Any, Any]:
+        """Return a detached copy of the latest committed state."""
+        return copy.deepcopy(self._states.get(session_id, {}))
+
+    async def update_state(
+        self,
+        session_id: str,
+        states: dict[Any, Any],
+    ) -> None:
+        """Atomically update state outside an observer function."""
+        state_lock = self._state_locks.setdefault(session_id, asyncio.Lock())
+        async with state_lock:
+            self._states.setdefault(session_id, {}).update(
+                copy.deepcopy(states)
+            )
+
+    async def wait_for_idle(self, session_id: Optional[str] = None) -> None:
+        """Wait until current replacement and observer tasks have completed."""
+        while True:
+            tasks = {
+                task
+                for task, task_session_id in self._replacement_task_sessions.items()
+                if not task.done()
+                and (session_id is None or task_session_id == session_id)
+            }
+            tasks.update(
+                slot.task
+                for (slot_session_id, _, _), slot in self._slots.items()
+                if slot.task is not None
+                and not slot.task.done()
+                and (session_id is None or slot_session_id == session_id)
+            )
+            if not tasks:
+                return
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await asyncio.sleep(0)
+
+    async def clear_session(self, session_id: str) -> None:
+        """Cancel observer tasks and delete state for one session."""
+        slot_items = [
+            (key, slot)
+            for key, slot in self._slots.items()
+            if key[0] == session_id
+        ]
+        tasks = []
+        for _, slot in slot_items:
+            slot.sequence += 1
+            if slot.task is not None and not slot.task.done():
+                slot.task.cancel()
+                tasks.append(slot.task)
+
+        replacement_tasks = [
+            task
+            for task, task_session_id in self._replacement_task_sessions.items()
+            if task_session_id == session_id and not task.done()
+        ]
+        for task in replacement_tasks:
+            task.cancel()
+        tasks.extend(replacement_tasks)
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        for key, _ in slot_items:
+            self._slots.pop(key, None)
+        self._states.pop(session_id, None)
+        self._state_locks.pop(session_id, None)
+
+    async def shutdown(self) -> None:
+        """Cancel all observers and release all in-memory state."""
+        self._closed = True
+        session_ids = {
+            *self._states.keys(),
+            *(key[0] for key in self._slots),
+            *self._replacement_task_sessions.values(),
+        }
+        for session_id in session_ids:
+            await self.clear_session(session_id)
+
+    def _track_replacement_task(
+        self,
+        task: asyncio.Task,
+        session_id: str,
+    ) -> None:
+        self._replacement_task_sessions[task] = session_id
+
+        def on_done(completed_task: asyncio.Task) -> None:
+            self._replacement_task_sessions.pop(completed_task, None)
+            if completed_task.cancelled():
+                return
+            try:
+                completed_task.result()
+            except Exception:
+                logger.exception("Dialog observer replacement task failed")
+
+        task.add_done_callback(on_done)

--- a/tests/sts/test_dialog_observer.py
+++ b/tests/sts/test_dialog_observer.py
@@ -1,0 +1,284 @@
+import asyncio
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from aiavatar.sts import STSPipeline
+from aiavatar.sts.dialog_observer import (
+    DialogObservation,
+    DialogObserver,
+    DialogRequest,
+    DialogResponse,
+)
+from aiavatar.sts.llm import LLMServiceDummy
+from aiavatar.sts.models import STSRequest
+from aiavatar.sts.stt import SpeechRecognizerDummy
+from aiavatar.sts.tts import SpeechSynthesizerDummy
+from aiavatar.sts.vad import SpeechDetectorDummy
+
+
+def make_observation(
+    transaction_id: str,
+    text: str,
+    *,
+    session_id: str = "session",
+    response_text: str = None,
+) -> DialogObservation:
+    return DialogObservation(
+        session_id=session_id,
+        transaction_id=transaction_id,
+        context_id="context",
+        user_id="user",
+        request=DialogRequest(text=text),
+        response=(
+            DialogResponse(text=response_text)
+            if response_text is not None
+            else None
+        ),
+    )
+
+
+def test_dialog_snapshots_are_immutable_and_detached():
+    files = [{"url": "data:image/png;base64,abc", "tags": ["one"]}]
+    metadata = {"nested": {"value": 1}}
+    audio_data = b"audio"
+    request = STSRequest(
+        text="original",
+        audio_data=audio_data,
+        audio_duration=1.25,
+        files=files,
+        metadata=metadata,
+        channel="websocket",
+    )
+    snapshot = DialogRequest.from_sts_request(request, text="recognized")
+
+    files[0]["url"] = "changed"
+    metadata["nested"]["value"] = 2
+
+    assert snapshot.text == "recognized"
+    assert snapshot.audio_data is audio_data
+    assert snapshot.files[0]["url"] == "data:image/png;base64,abc"
+    assert snapshot.metadata["nested"]["value"] == 1
+    with pytest.raises(TypeError):
+        snapshot.files[0]["url"] = "cannot-mutate"
+    with pytest.raises(TypeError):
+        snapshot.metadata["new"] = "cannot-mutate"
+    with pytest.raises(FrozenInstanceError):
+        snapshot.text = "cannot-mutate"
+
+
+def test_dialog_observer_rejects_sync_functions():
+    observer = DialogObserver()
+
+    with pytest.raises(TypeError, match="must be async"):
+        observer.on_request(lambda observation, state: None)
+
+
+@pytest.mark.asyncio
+async def test_state_is_a_detached_dict_and_supports_non_string_keys():
+    observer = DialogObserver()
+    await observer.update_state("session", {1: {"value": "original"}})
+
+    state = observer.get_state("session")
+    state[1]["value"] = "changed"
+    state[2] = "local-only"
+
+    assert isinstance(state, dict)
+    assert observer.get_state("session") == {1: {"value": "original"}}
+    await observer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_request_observer_is_latest_wins_and_discards_canceled_patch():
+    observer = DialogObserver()
+    first_started = asyncio.Event()
+    first_canceled = asyncio.Event()
+
+    @observer.on_request
+    async def observe_request(observation, state):
+        if observation.request.text == "first":
+            first_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                first_canceled.set()
+                # Even a cancellation-resistant observer cannot commit this.
+                return {"value": "stale"}
+        return {"value": observation.request.text}
+
+    observer.observe_request(make_observation("transaction-1", "first"))
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+
+    observer.observe_request(make_observation("transaction-2", "second"))
+    await asyncio.wait_for(observer.wait_for_idle("session"), timeout=1)
+
+    assert first_canceled.is_set()
+    assert observer.get_state("session") == {"value": "second"}
+    await observer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_request_and_response_slots_are_independent():
+    observer = DialogObserver()
+    response_started = asyncio.Event()
+    release_response = asyncio.Event()
+    response_canceled = False
+
+    async def observe(observation, state):
+        nonlocal response_canceled
+        if observation.response is not None:
+            response_started.set()
+            try:
+                await release_response.wait()
+            except asyncio.CancelledError:
+                response_canceled = True
+                raise
+            return {"response": observation.response.text}
+        return {"request": observation.request.text}
+
+    observer.on_request(observe)
+    observer.on_response(observe)
+    observer.observe_response(
+        make_observation(
+            "transaction-1",
+            "first",
+            response_text="first-response",
+        )
+    )
+    await asyncio.wait_for(response_started.wait(), timeout=1)
+
+    observer.observe_request(make_observation("transaction-2", "second"))
+    await asyncio.sleep(0)
+    assert not response_canceled
+
+    release_response.set()
+    await asyncio.wait_for(observer.wait_for_idle("session"), timeout=1)
+    assert observer.get_state("session") == {
+        "request": "second",
+        "response": "first-response",
+    }
+    await observer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_clear_session_cancels_tasks_and_deletes_state():
+    observer = DialogObserver()
+    started = asyncio.Event()
+    canceled = asyncio.Event()
+
+    await observer.update_state("session", {"existing": True})
+
+    @observer.on_request
+    async def observe_request(observation, state):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            canceled.set()
+            raise
+
+    observer.observe_request(make_observation("transaction", "request"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    await asyncio.wait_for(observer.clear_session("session"), timeout=1)
+
+    assert canceled.is_set()
+    assert observer.get_state("session") == {}
+    await observer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_observes_processed_request_and_final_response(tmp_path):
+    observer = DialogObserver()
+    request_observations = []
+    response_observations = []
+
+    @observer.on_request
+    async def record_request_observation(observation, state):
+        request_observations.append(observation)
+        return {"request_seen": observation.request.text}
+
+    @observer.on_response
+    async def record_response_observation(observation, state):
+        response_observations.append(observation)
+        return {"response_seen": observation.response.text}
+
+    db_path = str(tmp_path / "dialog-observer.db")
+    pipeline = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=LLMServiceDummy(
+            response_text="Final answer.",
+            db_connection_str=db_path,
+        ),
+        tts=SpeechSynthesizerDummy(),
+        db_connection_str=db_path,
+        voice_recorder_enabled=False,
+        insert_channel_tag=True,
+    )
+
+    @pipeline.on_before_llm
+    async def observe_dialog_request(request):
+        observer.observe_request(DialogObservation(
+            session_id=request.session_id,
+            transaction_id=request.transaction_id,
+            context_id=request.context_id,
+            user_id=request.user_id,
+            request=DialogRequest.from_sts_request(request),
+        ))
+
+    @pipeline.on_finish
+    async def observe_dialog_response(request, response):
+        observer.observe_response(DialogObservation(
+            session_id=request.session_id,
+            transaction_id=request.transaction_id,
+            context_id=response.context_id,
+            user_id=response.user_id,
+            request=DialogRequest.from_sts_request(request),
+            response=DialogResponse.from_sts_response(response),
+        ))
+
+    request = STSRequest(
+        session_id="session",
+        context_id=None,
+        user_id="user",
+        text="Original request",
+        audio_data=b"immutable-audio",
+        audio_duration=2.5,
+        files=[{"url": "data:image/png;base64,abc"}],
+        metadata={"source": "test"},
+        channel="websocket",
+    )
+
+    responses = [response async for response in pipeline.invoke(request)]
+    final_response = next(response for response in responses if response.type == "final")
+    await asyncio.wait_for(observer.wait_for_idle("session"), timeout=1)
+
+    assert len(request_observations) == 1
+    request_observation = request_observations[0]
+    assert request_observation.session_id == "session"
+    assert request_observation.transaction_id == request.transaction_id
+    assert request_observation.context_id == final_response.context_id
+    assert request_observation.user_id == "user"
+    assert request_observation.request.text.startswith(
+        "<channel name='websocket' />Original request"
+    )
+    assert request_observation.request.audio_data == b"immutable-audio"
+    assert request_observation.request.audio_duration == 2.5
+    assert request_observation.request.files[0]["url"].startswith("data:image")
+    assert request_observation.request.metadata == {"source": "test"}
+
+    assert len(response_observations) == 1
+    response_observation = response_observations[0]
+    assert response_observation.transaction_id == request_observation.transaction_id
+    assert response_observation.request.text == request_observation.request.text
+    assert response_observation.response.text == "Final answer."
+    assert observer.get_state("session") == {
+        "request_seen": "<channel name='websocket' />Original request",
+        "response_seen": "Final answer.",
+    }
+
+    await pipeline.shutdown()
+    await observer.shutdown()
+    await pipeline.stt.close()
+    await pipeline.tts.close()

--- a/tests/sts/test_pipeline.py
+++ b/tests/sts/test_pipeline.py
@@ -1233,6 +1233,45 @@ async def test_insert_channel_tag_disabled():
     await sts.shutdown()
 
 
+def test_sts_request_has_a_unique_transaction_id_by_default():
+    first = STSRequest()
+    second = STSRequest()
+    specified = STSRequest(transaction_id="specified-transaction")
+
+    assert first.transaction_id
+    assert second.transaction_id
+    assert first.transaction_id != second.transaction_id
+    assert specified.transaction_id == "specified-transaction"
+
+
+def test_sts_request_is_keyword_only():
+    with pytest.raises(TypeError):
+        STSRequest("start")
+
+
+@pytest.mark.asyncio
+async def test_queued_cancellation_keeps_request_transaction_id():
+    sts = object.__new__(STSPipeline)
+    request_queue = asyncio.Queue()
+    response_queue = asyncio.Queue()
+    request = STSRequest(
+        session_id="session",
+        transaction_id="queued-transaction",
+    )
+    await request_queue.put(("queue-request", request))
+    sts._request_queues = {"session": request_queue}
+    sts._response_queues = {
+        "session": {"queue-request": response_queue},
+    }
+
+    await sts._clear_queue("session")
+
+    response = await response_queue.get()
+    assert response.type == "cancelled"
+    assert response.transaction_id == "queued-transaction"
+    assert await response_queue.get() is None
+
+
 @pytest.mark.asyncio
 async def test_transaction_id_in_responses():
     """Test that all responses from a single invoke have a consistent non-None transaction_id"""


### PR DESCRIPTION
Introduce DialogObserver to asynchronously evaluate requests and responses and maintain custom per-session state.

For example, applications can detect user emotion from request text and audio, or track the current conversation topic from AI responses.