### PR TITLE
Close only pipeline-owned recorders on shutdown

### DIFF
--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import AsyncExitStack
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 import json
@@ -73,6 +74,7 @@ class STSPipeline:
         skip_tts_channels: List[str] = None,
         debug: bool = False
     ):
+        self._lifecycle = AsyncExitStack()
         self.debug = debug
         self.use_invoke_queue = use_invoke_queue
 
@@ -185,7 +187,7 @@ class STSPipeline:
         self._process_llm_chunk = self.process_llm_chunk_default
 
         # Performance recorder
-        if performance_recorder:
+        if performance_recorder is not None:
             self.performance_recorder = performance_recorder
         else:
             if self.db_pool_provider:
@@ -193,12 +195,20 @@ class STSPipeline:
                 self.performance_recorder = PostgreSQLPerformanceRecorder(connection_str=self.db_pool_provider.connection_str)
             else:
                 self.performance_recorder = SQLitePerformanceRecorder(db_path=db_connection_str)
+            self._lifecycle.push_async_callback(
+                asyncio.to_thread,
+                self.performance_recorder.close,
+            )
 
         # Voice recorder
-        self.voice_recorder = voice_recorder or FileVoiceRecorder(
-            record_dir=voice_recorder_dir,
-            sample_rate=stt_sample_rate
-        )
+        if voice_recorder is not None:
+            self.voice_recorder = voice_recorder
+        else:
+            self.voice_recorder = FileVoiceRecorder(
+                record_dir=voice_recorder_dir,
+                sample_rate=stt_sample_rate,
+            )
+            self._lifecycle.push_async_callback(self.voice_recorder.stop)
         self.voice_recorder_enabled = voice_recorder_enabled
         self.voice_recorder_response_audio_format = "wav"
 
@@ -800,5 +810,5 @@ class STSPipeline:
         await self.vad.finalize_session(context_id)
 
     async def shutdown(self):
-        self.performance_recorder.close()
-        await self.voice_recorder.stop()
+        """Close resources constructed and owned by this pipeline."""
+        await self._lifecycle.aclose()

--- a/tests/sts/test_pipeline_lifecycle.py
+++ b/tests/sts/test_pipeline_lifecycle.py
@@ -1,0 +1,70 @@
+import pytest
+
+from aiavatar.sts.llm.base import LLMServiceDummy
+from aiavatar.sts.pipeline import STSPipeline
+from aiavatar.sts.stt.base import SpeechRecognizerDummy
+from aiavatar.sts.tts.base import SpeechSynthesizerDummy
+from aiavatar.sts.vad.base import SpeechDetectorDummy
+
+
+class FakePerformanceRecorder:
+    def __init__(self, events, **kwargs):
+        self.events = events
+
+    def close(self):
+        self.events.append("performance:close")
+
+
+class FakeVoiceRecorder:
+    def __init__(self, events, **kwargs):
+        self.events = events
+
+    async def stop(self):
+        self.events.append("voice:stop")
+
+
+def create_pipeline(*, performance_recorder=None, voice_recorder=None):
+    return STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=LLMServiceDummy(),
+        tts=SpeechSynthesizerDummy(),
+        performance_recorder=performance_recorder,
+        voice_recorder=voice_recorder,
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_closes_only_internally_created_resources(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(
+        "aiavatar.sts.pipeline.SQLitePerformanceRecorder",
+        lambda **kwargs: FakePerformanceRecorder(events, **kwargs),
+    )
+    monkeypatch.setattr(
+        "aiavatar.sts.pipeline.FileVoiceRecorder",
+        lambda **kwargs: FakeVoiceRecorder(events, **kwargs),
+    )
+
+    pipeline = create_pipeline()
+
+    await pipeline.shutdown()
+    await pipeline.shutdown()
+
+    assert events == ["voice:stop", "performance:close"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_leaves_injected_resources_open():
+    events = []
+    performance_recorder = FakePerformanceRecorder(events)
+    voice_recorder = FakeVoiceRecorder(events)
+    pipeline = create_pipeline(
+        performance_recorder=performance_recorder,
+        voice_recorder=voice_recorder,
+    )
+
+    await pipeline.shutdown()
+
+    assert events == []


### PR DESCRIPTION
- Track internally created recorders in the pipeline lifecycle
- Keep externally injected recorders open
- This allows a PerformanceRecorder to be shared across pipelines with different lifecycles