### PR TITLE
Support multiple adapters on a shared STS pipeline

### DIFF
--- a/aiavatar/adapter/base.py
+++ b/aiavatar/adapter/base.py
@@ -1,16 +1,22 @@
 import re
 from abc import ABC, abstractmethod
+import logging
 from typing import Any, Callable, Awaitable, List, Optional
 from ..sts.models import STSResponse
-from ..sts.pipeline import STSPipeline
+from ..sts.pipeline import STSPipeline, ResponseHandler
 from .models import AIAvatarRequest, AIAvatarResponse, AvatarControlRequest
+
+logger = logging.getLogger(__name__)
 
 
 class Adapter(ABC):
     def __init__(self, sts: STSPipeline):
         self.sts = sts
-        self.sts.handle_response = self.handle_response
-        self.sts.stop_response = self.stop_response
+        self.sts.add_response_handler(ResponseHandler(
+            can_handle=self.can_handle,
+            handle_response=self.handle_response,
+            stop_response=self.stop_response
+        ))
 
         # Control tag pattern: receives (tag, attr) and returns a regex with two capture groups
         self.control_tag_pattern = r'\[{tag}:(\w+)\]|<{tag}\s[^>]*{attr}=["\'](\w+)["\']'
@@ -37,6 +43,10 @@ class Adapter(ABC):
             except Exception:
                 pass
         return updated
+
+    def can_handle(self, session_id) -> bool:
+        logger.warning(f"Adapter {self.__class__.__name__} doesn't handle any responses. Implement `can_handle` and return `True` when the session_id is owned by this adapter.")
+        return False
 
     @abstractmethod
     async def handle_response(self, response: STSResponse):

--- a/aiavatar/adapter/chatcompletions/server.py
+++ b/aiavatar/adapter/chatcompletions/server.py
@@ -11,6 +11,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from ...database import PoolProvider
 from ...sts import STSPipeline
+from ...sts.pipeline import InsertChannelTagConfig
 from ...sts.models import STSRequest, STSResponse
 from ...sts.vad import SpeechDetectorDummy
 from ...sts.stt import SpeechRecognizerDummy
@@ -117,7 +118,7 @@ class AIAvatarChatCompletionsServer(Adapter):
         channel_context_bridge: ChannelContextBridge = None,
         channel_id: str = "chatcompletions",
         session_timeout: float = 3600,
-        insert_channel_tag: bool = False,
+        insert_channel_tag: InsertChannelTagConfig = False,
         response_content_field: str = "voice_text",
 
         # Debug
@@ -159,6 +160,9 @@ class AIAvatarChatCompletionsServer(Adapter):
 
         self.debug = debug
         self.channel_id = channel_id
+        self.sessions: Dict[str, STSRequest] = {}
+        if self.channel_id not in self.sts.skip_tts_channels:
+            self.sts.skip_tts_channels.append(self.channel_id)
         self.session_timeout = session_timeout
         self.response_content_field = response_content_field
         self.channel_context_bridge = channel_context_bridge or SQLiteChannelContextBridge(
@@ -242,7 +246,7 @@ class AIAvatarChatCompletionsServer(Adapter):
 
         return STSRequest(
             type="start",
-            session_id=str(uuid4()),
+            session_id=f"{self.channel_id}_{uuid4()}",
             user_id=channel_user.user_id,
             context_id=user_context.context_id if user_context else None,
             text=text,
@@ -297,6 +301,18 @@ class AIAvatarChatCompletionsServer(Adapter):
             ],
         )
 
+    def _register_session(self, request: STSRequest):
+        self.sessions[request.session_id] = request
+
+    async def _finalize_session(self, session_id: str):
+        try:
+            await self.sts.finalize(session_id)
+        finally:
+            try:
+                await self.sts.session_state_manager.clear_session(session_id)
+            finally:
+                self.sessions.pop(session_id, None)
+
     def get_api_router(self, path: str = "/v1/chat/completions"):
         router = APIRouter()
 
@@ -315,60 +331,71 @@ class AIAvatarChatCompletionsServer(Adapter):
             created = int(time.time())
 
             if not chat_request.stream:
-                return await self._invoke_non_streaming(
-                    sts_request,
-                    completion_id=completion_id,
-                    created=created,
-                    model=chat_request.model,
-                )
+                self._register_session(sts_request)
+                try:
+                    return await self._invoke_non_streaming(
+                        sts_request,
+                        completion_id=completion_id,
+                        created=created,
+                        model=chat_request.model,
+                    )
+                finally:
+                    await self._finalize_session(sts_request.session_id)
 
             async def stream_response():
-                yield self._make_chunk(
-                    completion_id=completion_id,
-                    created=created,
-                    model=chat_request.model,
-                    delta=ChatCompletionDelta(role="assistant"),
-                ).model_dump_json(exclude_none=True)
+                self._register_session(sts_request)
+                try:
+                    yield self._make_chunk(
+                        completion_id=completion_id,
+                        created=created,
+                        model=chat_request.model,
+                        delta=ChatCompletionDelta(role="assistant"),
+                    ).model_dump_json(exclude_none=True)
 
-                final_context_id = sts_request.context_id
-                async for response in self.sts.invoke(sts_request):
-                    for on_resp in self._on_response_handlers:
-                        await on_resp(None, response)
+                    final_context_id = sts_request.context_id
+                    async for response in self.sts.invoke(sts_request):
+                        for on_resp in self._on_response_handlers:
+                            await on_resp(None, response)
 
-                    if response.type == "chunk":
-                        yield self._make_chunk(
-                            completion_id=completion_id,
-                            created=created,
-                            model=chat_request.model,
-                            delta=ChatCompletionDelta(content=self._get_response_content(response)),
-                        ).model_dump_json(exclude_none=True)
-                    elif response.type == "final":
-                        final_context_id = response.context_id
-                    elif response.type == "error":
-                        yield json.dumps({
-                            "error": response.metadata or {"message": "Error in STS pipeline"}
-                        }, ensure_ascii=False)
-                    elif response.type == "stop":
-                        await self.stop_response(response.session_id, response.context_id)
+                        if response.type == "chunk":
+                            yield self._make_chunk(
+                                completion_id=completion_id,
+                                created=created,
+                                model=chat_request.model,
+                                delta=ChatCompletionDelta(content=self._get_response_content(response)),
+                            ).model_dump_json(exclude_none=True)
+                        elif response.type == "final":
+                            final_context_id = response.context_id
+                        elif response.type == "error":
+                            yield json.dumps({
+                                "error": response.metadata or {"message": "Error in STS pipeline"}
+                            }, ensure_ascii=False)
+                        elif response.type == "stop":
+                            await self.stop_response(response.session_id, response.context_id)
 
-                if final_context_id:
-                    await self.channel_context_bridge.upsert_context(UserContext(
-                        user_id=sts_request.user_id,
-                        context_id=final_context_id,
-                    ))
+                    if final_context_id:
+                        await self.channel_context_bridge.upsert_context(UserContext(
+                            user_id=sts_request.user_id,
+                            context_id=final_context_id,
+                        ))
 
-                yield self._make_chunk(
-                    completion_id=completion_id,
-                    created=created,
-                    model=chat_request.model,
-                    delta=ChatCompletionDelta(),
-                    finish_reason="stop",
-                ).model_dump_json(exclude_none=True)
-                yield "[DONE]"
+                    yield self._make_chunk(
+                        completion_id=completion_id,
+                        created=created,
+                        model=chat_request.model,
+                        delta=ChatCompletionDelta(),
+                        finish_reason="stop",
+                    ).model_dump_json(exclude_none=True)
+                    yield "[DONE]"
+                finally:
+                    await self._finalize_session(sts_request.session_id)
 
             return EventSourceResponse(stream_response())
 
         return router
+
+    def can_handle(self, session_id: str) -> bool:
+        return session_id in self.sessions
 
     async def handle_response(self, response: STSResponse):
         pass

--- a/aiavatar/adapter/http/server.py
+++ b/aiavatar/adapter/http/server.py
@@ -149,6 +149,8 @@ class AIAvatarHttpServer(Adapter):
 
         # API server auth
         api_key: str = None,
+        # Channel
+        channel: str = "http",
         # Debug
         debug: bool = False            
     ):
@@ -195,6 +197,7 @@ class AIAvatarHttpServer(Adapter):
 
         # Call base after self.sts is set
         super().__init__(self.sts)
+        self.sessions: Dict[str, int] = {}
 
         # Optional components
         self.speaker_registry = speaker_registry
@@ -205,6 +208,9 @@ class AIAvatarHttpServer(Adapter):
         # API Key
         self.api_key = api_key
         self._bearer_scheme = HTTPBearer(auto_error=False)
+
+        # Channel
+        self.channel = channel
 
     def get_config(self) -> dict:
         return {
@@ -218,6 +224,25 @@ class AIAvatarHttpServer(Adapter):
                 detail="Invalid or missing API Key",
             )
         return credentials.credentials
+
+    def _register_session(self, session_id: str):
+        self.sessions[session_id] = self.sessions.get(session_id, 0) + 1
+
+    def _unregister_session(self, session_id: str):
+        remaining = self.sessions.get(session_id, 0) - 1
+        if remaining > 0:
+            self.sessions[session_id] = remaining
+        else:
+            self.sessions.pop(session_id, None)
+
+    async def invoke(self, request: STSRequest):
+        request.channel = self.channel
+        self._register_session(request.session_id)
+        try:
+            async for response in self.sts.invoke(request):
+                yield response
+        finally:
+            self._unregister_session(request.session_id)
 
     def get_api_router(self, path: str = "/chat", stt: SpeechRecognizer = None, tts: SpeechSynthesizer = None):
         router = APIRouter()
@@ -270,63 +295,67 @@ class AIAvatarHttpServer(Adapter):
                 await on_req(request)
 
             async def stream_response():
-                if request.audio_data:
-                    request.audio_data = base64.b64decode(request.audio_data)
+                self._register_session(request.session_id)
+                try:
+                    if request.audio_data:
+                        request.audio_data = base64.b64decode(request.audio_data)
 
-                async for response in self.sts.invoke(STSRequest(
-                    type=request.type,
-                    session_id=request.session_id,
-                    user_id=request.user_id,
-                    context_id=request.context_id,
-                    text=request.text,
-                    audio_data=request.audio_data,
-                    files=request.files,
-                    system_prompt_params=request.system_prompt_params,
-                    wait_in_queue=request.wait_in_queue,
-                    channel=request.channel,
-                    metadata=request.metadata
-                )):
-                    aiavatar_response = AIAvatarResponse(
-                        type=response.type,
-                        session_id=response.session_id,
-                        user_id=response.user_id,
-                        context_id=response.context_id,
-                        text=response.text,
-                        voice_text=response.voice_text,
-                        audio_data=response.audio_data,
-                        metadata=response.metadata or {},
-                        structured_content=response.structured_content
-                    )
+                    async for response in self.sts.invoke(STSRequest(
+                        type=request.type,
+                        session_id=request.session_id,
+                        user_id=request.user_id,
+                        context_id=request.context_id,
+                        text=request.text,
+                        audio_data=request.audio_data,
+                        files=request.files,
+                        system_prompt_params=request.system_prompt_params,
+                        wait_in_queue=request.wait_in_queue,
+                        channel=self.channel,
+                        metadata=request.metadata
+                    )):
+                        aiavatar_response = AIAvatarResponse(
+                            type=response.type,
+                            session_id=response.session_id,
+                            user_id=response.user_id,
+                            context_id=response.context_id,
+                            text=response.text,
+                            voice_text=response.voice_text,
+                            audio_data=response.audio_data,
+                            metadata=response.metadata or {},
+                            structured_content=response.structured_content
+                        )
 
-                    # Callback for each response chunk
-                    for on_resp in self._on_response_handlers:
-                        await on_resp(aiavatar_response, response)
+                        # Callback for each response chunk
+                        for on_resp in self._on_response_handlers:
+                            await on_resp(aiavatar_response, response)
 
-                    if response.type == "chunk":
-                        # Language
-                        aiavatar_response.language = response.language
+                        if response.type == "chunk":
+                            # Language
+                            aiavatar_response.language = response.language
 
-                        # Face and Animation
-                        aiavatar_response.avatar_control_request = self.parse_avatar_control_request(response.text)
+                            # Face and Animation
+                            aiavatar_response.avatar_control_request = self.parse_avatar_control_request(response.text)
 
-                        # Voice
-                        if response.audio_data:
-                            b64_chunk = base64.b64encode(response.audio_data).decode("utf-8")
-                            aiavatar_response.audio_data = b64_chunk
+                            # Voice
+                            if response.audio_data:
+                                b64_chunk = base64.b64encode(response.audio_data).decode("utf-8")
+                                aiavatar_response.audio_data = b64_chunk
 
-                    if response.type == "tool_call":
-                        aiavatar_response.metadata["tool_call"] = response.tool_call.to_dict()
+                        if response.type == "tool_call":
+                            aiavatar_response.metadata["tool_call"] = response.tool_call.to_dict()
 
-                    elif response.type == "final":
-                        vision_source = self.parse_vision_source(response.text)
-                        if vision_source:
-                            aiavatar_response.type = "vision"
-                            aiavatar_response.metadata = {"source": vision_source}
+                        elif response.type == "final":
+                            vision_source = self.parse_vision_source(response.text)
+                            if vision_source:
+                                aiavatar_response.type = "vision"
+                                aiavatar_response.metadata = {"source": vision_source}
 
-                    elif response.type == "stop":
-                        await self.stop_response(response)
+                        elif response.type == "stop":
+                            await self.stop_response(response.session_id, response.context_id)
 
-                    yield aiavatar_response.model_dump_json()
+                        yield aiavatar_response.model_dump_json()
+                finally:
+                    self._unregister_session(request.session_id)
 
             return EventSourceResponse(stream_response())
 
@@ -343,44 +372,50 @@ class AIAvatarHttpServer(Adapter):
                 await on_req(request)
 
             message_id = f"message_{uuid4()}"
+            session_id = request.conversation_id or f"sess_temp_{message_id}"
             async def stream_response():
-                created_at_int = None
-                async for response in self.sts.invoke(STSRequest(
-                    type="start",
-                    session_id=request.conversation_id or f"sess_temp_{message_id}",
-                    user_id=request.user,
-                    context_id=request.conversation_id,
-                    text=request.query,
-                    files=request.files,
-                    system_prompt_params=request.inputs
-                )):
-                    if not created_at_int:
-                        created_at_int = int(time.time())
+                self._register_session(session_id)
+                try:
+                    created_at_int = None
+                    async for response in self.sts.invoke(STSRequest(
+                        type="start",
+                        session_id=session_id,
+                        user_id=request.user,
+                        context_id=request.conversation_id,
+                        text=request.query,
+                        files=request.files,
+                        system_prompt_params=request.inputs,
+                        channel=self.channel
+                    )):
+                        if not created_at_int:
+                            created_at_int = int(time.time())
 
-                    # Callback for each response chunk
-                    for on_resp in self._on_response_handlers:
-                        await on_resp(None, response)
+                        # Callback for each response chunk
+                        for on_resp in self._on_response_handlers:
+                            await on_resp(None, response)
 
-                    if response.type == "chunk":
-                        chat_messages_response = PostChatMessagesResponse(
-                            event="message_replace" if response.metadata.get("is_guardrail_triggered") is True else "message",
-                            message_id=message_id,
-                            conversation_id=response.context_id,
-                            answer=response.text,
-                            created_at=created_at_int
-                        )
-                        yield chat_messages_response.model_dump_json()
+                        if response.type == "chunk":
+                            chat_messages_response = PostChatMessagesResponse(
+                                event="message_replace" if response.metadata.get("is_guardrail_triggered") is True else "message",
+                                message_id=message_id,
+                                conversation_id=response.context_id,
+                                answer=response.text,
+                                created_at=created_at_int
+                            )
+                            yield chat_messages_response.model_dump_json()
 
-                    elif response.type == "final":
-                        chat_messages_response = PostChatMessagesResponse(
-                            event="message_end",
-                            message_id=message_id,
-                            conversation_id=response.context_id,
-                        )
-                        yield chat_messages_response.model_dump_json()
+                        elif response.type == "final":
+                            chat_messages_response = PostChatMessagesResponse(
+                                event="message_end",
+                                message_id=message_id,
+                                conversation_id=response.context_id,
+                            )
+                            yield chat_messages_response.model_dump_json()
 
-                    elif response.type == "stop":
-                        await self.stop_response(response)
+                        elif response.type == "stop":
+                            await self.stop_response(response.session_id, response.context_id)
+                finally:
+                    self._unregister_session(session_id)
 
             return EventSourceResponse(stream_response())
 
@@ -460,6 +495,9 @@ class AIAvatarHttpServer(Adapter):
             )
 
         return router
+
+    def can_handle(self, session_id: str) -> bool:
+        return session_id in self.sessions
 
     async def handle_response(self, response: STSResponse):
         # Do nothing here

--- a/aiavatar/adapter/linebot/server.py
+++ b/aiavatar/adapter/linebot/server.py
@@ -30,6 +30,7 @@ from linebot.v3.webhooks import (
 )
 from ...database import PoolProvider
 from ...sts import STSPipeline
+from ...sts.pipeline import InsertChannelTagConfig
 from ...sts.models import STSRequest, STSResponse
 from ...sts.vad import SpeechDetectorDummy
 from ...sts.stt import SpeechRecognizerDummy
@@ -38,7 +39,7 @@ from ...sts.llm.context_manager import ContextManager
 from ...sts.tts import SpeechSynthesizerDummy
 from ...sts.session_state_manager import SessionStateManager
 from ...sts.performance_recorder import PerformanceRecorder
-from ..models import AvatarControlRequest
+from ..models import AIAvatarResponse, AvatarControlRequest
 from .. import Adapter
 from ..channel_context_bridge import UserContext, ChannelContextBridge, SQLiteChannelContextBridge
 
@@ -57,6 +58,12 @@ class GetChannelUserResponse(BaseModel):
 class PushTextRequest(BaseModel):
     text: str
     files: Optional[list] = None
+
+
+class LineBotResponseTarget:
+    def __init__(self, *, reply_token: str = None, push_to: str = None):
+        self.reply_token = reply_token
+        self.push_to = push_to
 
 
 class AIAvatarLineBotServer(Adapter):
@@ -98,7 +105,8 @@ class AIAvatarLineBotServer(Adapter):
         # API server auth
         api_key: str = None,
         # Channel
-        insert_channel_tag: bool = False,
+        channel: str = "linebot",
+        insert_channel_tag: InsertChannelTagConfig = False,
         # Debug
         debug: bool = False
     ):
@@ -131,6 +139,12 @@ class AIAvatarLineBotServer(Adapter):
 
         # Call base after self.sts is set
         super().__init__(self.sts)
+        self.sessions: Dict[str, LineBotResponseTarget] = {}
+
+        # Channel
+        self.channel = channel
+        if self.channel not in self.sts.skip_tts_channels:
+            self.sts.skip_tts_channels.append(self.channel)
 
         # Debug
         self.debug = debug
@@ -255,29 +269,50 @@ class AIAvatarLineBotServer(Adapter):
                 image_url = f"{self.image_download_url_base}/image/{image_id}"
             files = [{"url": image_url}]
 
-        request = STSRequest(
-            session_id=str(uuid4()),
+        await self.handle_reply_request(
+            reply_token=event.reply_token,
             user_id=user_id,
             context_id=context_id,
             text=text,
             files=files,
-            channel="linebot",
-            metadata={}
         )
 
-        if self._preprocess_request:
-            await self._preprocess_request(request)
+    async def handle_reply_request(
+        self,
+        *,
+        reply_token: str,
+        user_id: str,
+        text: str,
+        files: list = None,
+        context_id: Optional[str] = None,
+    ):
+        request = STSRequest(
+            session_id=f"linebot_{uuid4()}",
+            user_id=user_id,
+            context_id=context_id,
+            text=text,
+            files=files,
+            channel=self.channel,
+            metadata={}
+        )
+        self.sessions[request.session_id] = LineBotResponseTarget(reply_token=reply_token)
 
-        async for response in self.sts.invoke(request):
-            if not response.metadata:
-                response.metadata = {}
-            response.metadata["reply_token"] = event.reply_token
-            if response.type == "final" and response.context_id:
-                await self.channel_context_bridge.upsert_context(UserContext(
-                    user_id=user_id,
-                    context_id=response.context_id,
-                ))
-            await self.sts.handle_response(response)
+        try:
+            if self._preprocess_request:
+                await self._preprocess_request(request)
+
+            async for response in self.sts.invoke(request):
+                if not response.metadata:
+                    response.metadata = {}
+                response.metadata["reply_token"] = reply_token
+                if response.type == "final" and response.context_id:
+                    await self.channel_context_bridge.upsert_context(UserContext(
+                        user_id=user_id,
+                        context_id=response.context_id,
+                    ))
+                await self.sts.handle_response(response)
+        finally:
+            await self._finalize_session(request.session_id)
 
     async def handle_push_request(self, user_id: str, text: str, files: list = None, context_id: Optional[str] = None):
         # Resolve current context_id if not provided
@@ -290,7 +325,7 @@ class AIAvatarLineBotServer(Adapter):
         line_user_id = None
         users = await self.channel_context_bridge.find_channel_users(user_id=user_id)
         for u in users:
-            if u.channel_id == "linebot":
+            if u.channel_id == self.channel:
                 line_user_id = u.channel_user_id
                 break
         if not line_user_id:
@@ -299,20 +334,21 @@ class AIAvatarLineBotServer(Adapter):
 
         # Build request for pipeline
         request = STSRequest(
-            session_id=str(uuid4()),
+            session_id=f"linebot_{uuid4()}",
             user_id=user_id,
             context_id=context_id,
             text=text,
             files=files,
-            channel="linebot",
+            channel=self.channel,
             metadata={}
         )
+        self.sessions[request.session_id] = LineBotResponseTarget(push_to=line_user_id)
 
         # Preprocess and invoke
-        if self._preprocess_request:
-            await self._preprocess_request(request)
-
         try:
+            if self._preprocess_request:
+                await self._preprocess_request(request)
+
             async for response in self.sts.invoke(request):
                 if not response.metadata:
                     response.metadata = {}
@@ -327,6 +363,8 @@ class AIAvatarLineBotServer(Adapter):
         except Exception as ex:
             logger.exception(f"Error at handle_push_request: {ex}")
             await self.send_push_message(line_user_id, self.default_error_message)
+        finally:
+            await self._finalize_session(request.session_id)
 
     # Processors
     async def process_webhook(self, request_body: str, signature: str):
@@ -337,7 +375,7 @@ class AIAvatarLineBotServer(Adapter):
     async def process_event(self, event: Event):
         try:
             if event_handler := self._event_handlers.get(event.type) or self._default_event_handler:
-                channel_user = await self.channel_context_bridge.get_channel_user("linebot", event.source.user_id, auto_create=True)
+                channel_user = await self.channel_context_bridge.get_channel_user(self.channel, event.source.user_id, auto_create=True)
                 user_context = await self.channel_context_bridge.get_context(channel_user.user_id)
                 await event_handler(
                     event=event,
@@ -381,37 +419,71 @@ class AIAvatarLineBotServer(Adapter):
         self._process_avatar_control_request = func
         return func
 
+    def can_handle(self, session_id: str) -> bool:
+        return session_id in self.sessions
+
     async def handle_response(self, response: STSResponse):
+        response_target = self.sessions.get(response.session_id)
+        if not response_target:
+            logger.warning(f"Session not found for response (LINE Bot): {response.session_id}")
+            return
+
+        if response.type == "final" and self._preprocess_response:
+            await self._preprocess_response(response)
+
+        aiavatar_response = AIAvatarResponse(
+            type=response.type,
+            session_id=response.session_id,
+            user_id=response.user_id,
+            context_id=response.context_id,
+            text=response.text,
+            voice_text=response.voice_text,
+            language=response.language,
+            audio_data=response.audio_data,
+            metadata=response.metadata or {},
+            structured_content=response.structured_content,
+        )
+
+        for on_response in self._on_response_handlers:
+            await on_response(aiavatar_response, response)
+
         if response.type == "final":
-            # Message
-            if self._preprocess_response:
-                await self._preprocess_response(response)
+            message_text = aiavatar_response.voice_text or aiavatar_response.text
+            if not message_text:
+                return
 
-            push_to = response.metadata.get("push_to") if response.metadata else None
-
-            if push_to:
+            if response_target.push_to:
                 # Build push message
                 message_request = PushMessageRequest(
-                    to=push_to,
-                    messages=[TextMessage(text=response.voice_text)]
+                    to=response_target.push_to,
+                    messages=[TextMessage(text=message_text)]
                 )
             else:
                 # Build reply message
                 message_request = ReplyMessageRequest(
-                    replyToken=response.metadata["reply_token"],
-                    messages=[TextMessage(text=response.voice_text)]
+                    replyToken=response_target.reply_token,
+                    messages=[TextMessage(text=message_text)]
                 )
 
             # Facial expression
-            avatar_control_request = self.parse_avatar_control_request(response.text)
+            avatar_control_request = self.parse_avatar_control_request(aiavatar_response.text)
             if self._process_avatar_control_request:
                 await self._process_avatar_control_request(avatar_control_request, message_request)
 
             # Send message
-            if push_to:
+            if response_target.push_to:
                 await self.line_api.push_message(message_request)
             else:
                 await self.line_api.reply_message(message_request)
+
+    async def _finalize_session(self, session_id: str):
+        try:
+            await self.sts.finalize(session_id)
+        finally:
+            try:
+                await self.sts.session_state_manager.clear_session(session_id)
+            finally:
+                self.sessions.pop(session_id, None)
 
     async def stop_response(self, session_id: str, context_id: str):
         # Do nothing here
@@ -445,7 +517,7 @@ class AIAvatarLineBotServer(Adapter):
             if self.api_key:
                 self.api_key_auth(credentials)
 
-            channel_user = await self.channel_context_bridge.get_channel_user("linebot", line_user_id)
+            channel_user = await self.channel_context_bridge.get_channel_user(self.channel, line_user_id)
             if not channel_user:
                 raise HTTPException(status_code=404, detail="Channel user not found")
 
@@ -467,7 +539,7 @@ class AIAvatarLineBotServer(Adapter):
             if self.api_key:
                 self.api_key_auth(credentials)
 
-            await self.channel_context_bridge.delete_channel_user("linebot", line_user_id)
+            await self.channel_context_bridge.delete_channel_user(self.channel, line_user_id)
 
             return JSONResponse(content={"result": "success"})
 

--- a/aiavatar/adapter/linebot/tools/channel_link.py
+++ b/aiavatar/adapter/linebot/tools/channel_link.py
@@ -33,6 +33,7 @@ class LinebotChannelLinkTool(Tool):
         channel_id: str,
         client_secret: str,
         base_url: str,
+        channel: str = "linebot",
         channel_context_bridge: ChannelContextBridge = None,
         success_html: str = None,
         error_html: str = None,
@@ -48,6 +49,7 @@ class LinebotChannelLinkTool(Tool):
         self.channel_id = channel_id
         self.client_secret = client_secret
         self.base_url = base_url.rstrip("/")
+        self.channel = channel
         self.callback_path = "/login-callback"
         self.channel_context_bridge = channel_context_bridge
         self.success_html = success_html or self.DEFAULT_SUCCESS_HTML
@@ -163,7 +165,7 @@ class LinebotChannelLinkTool(Tool):
 
             user_id, line_user_id = result
             await self.channel_context_bridge.link_channel_user(
-                channel_id="linebot",
+                channel_id=self.channel,
                 channel_user_id=line_user_id,
                 user_id=user_id,
             )

--- a/aiavatar/adapter/local/server.py
+++ b/aiavatar/adapter/local/server.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import warnings
-from typing import List
+from typing import Dict, List
 from ...database import PoolProvider
 from ...sts.models import STSRequest, STSResponse
 from ...sts.pipeline import STSPipeline
@@ -74,6 +74,8 @@ class AIAvatarLocalServer(Adapter):
         invoke_timeout: float = 60.0,
         use_invoke_queue: bool = False,
 
+        # Channel
+        channel: str = "local",
         # Debug
         debug: bool = False,
     ):
@@ -129,14 +131,20 @@ class AIAvatarLocalServer(Adapter):
 
         # Call base after self.sts is set
         super().__init__(self.sts)
+        self.sessions: Dict[str, None] = {}
 
         # Client communication queue
         self.response_queue = response_queue
+
+        # Channel
+        self.channel = channel
 
         # Mute immediately on barge-in
         if mute_on_barge_in:
             @self.sts.vad.on_recording_started
             async def mute_on_barge_in(session_id: str):
+                if not self.can_handle(session_id):
+                    return
                 await self.stop_response(session_id, "")
 
         # Debug
@@ -159,7 +167,8 @@ class AIAvatarLocalServer(Adapter):
         for on_session_start in self._on_session_start_handlers:
             await on_session_start(request, None)
 
-        await self.handle_response(STSResponse(
+        self.sessions[request.session_id] = None
+        await self.sts.handle_response(STSResponse(
             type="connected",
             session_id=request.session_id,
             user_id=request.user_id,
@@ -174,9 +183,12 @@ class AIAvatarLocalServer(Adapter):
         )
 
     def set_session_data(self, session_id: str, key: str, value: any, create_session: bool = False):
+        if create_session:
+            self.sessions[session_id] = None
         self.sts.vad.set_session_data(session_id, key, value, create_session)
 
     async def send_request(self, request: AIAvatarRequest):
+        self.sessions[request.session_id] = None
         async for r in self.sts.invoke(STSRequest(
             type=request.type,
             session_id=request.session_id,
@@ -188,13 +200,16 @@ class AIAvatarLocalServer(Adapter):
             system_prompt_params=request.system_prompt_params,
             allow_merge=request.allow_merge,
             wait_in_queue=request.wait_in_queue,
-            channel=request.channel,
+            channel=self.channel,
             metadata=request.metadata
         )):
-            await self.handle_response(r)
+            await self.sts.handle_response(r)
 
     async def handle_microphone_data(self, audio_bytes, session_id):
         await self.sts.vad.process_samples(samples=audio_bytes, session_id=session_id)
+
+    def can_handle(self, session_id: str) -> bool:
+        return session_id in self.sessions
 
     async def handle_response(self, response: STSResponse):
         aiavatar_response = AIAvatarResponse(

--- a/aiavatar/adapter/models.py
+++ b/aiavatar/adapter/models.py
@@ -20,7 +20,6 @@ class AIAvatarRequest(BaseModel):
     system_prompt_params: Optional[Dict] = None
     allow_merge: bool = True
     wait_in_queue: bool = False
-    channel: Optional[str] = None
     metadata: Optional[Dict] = None
 
 

--- a/aiavatar/adapter/twilio/__init__.py
+++ b/aiavatar/adapter/twilio/__init__.py
@@ -1,0 +1,6 @@
+from .server import (
+    AIAvatarTwilioServer,
+    AIAvatarTwilioSMSServer,
+    TwilioSessionData,
+    TwilioSMSMessage,
+)

--- a/aiavatar/adapter/twilio/server.py
+++ b/aiavatar/adapter/twilio/server.py
@@ -14,13 +14,13 @@ from twilio.rest import Client
 from twilio.twiml.voice_response import VoiceResponse, Connect
 from ...database import PoolProvider
 from ...sts.models import STSRequest, STSResponse
-from ...sts.pipeline import STSPipeline
-from ...sts.vad import SpeechDetector, SpeechDetectorDummy
-from ...sts.stt import SpeechRecognizer, SpeechRecognizerDummy
+from ...sts.pipeline import STSPipeline, InsertChannelTagConfig
+from ...sts.vad import SpeechDetector
+from ...sts.stt import SpeechRecognizer
 from ...sts.stt.openai import OpenAISpeechRecognizer
 from ...sts.llm import LLMService
 from ...sts.llm.context_manager import ContextManager
-from ...sts.tts import SpeechSynthesizer, SpeechSynthesizerDummy
+from ...sts.tts import SpeechSynthesizer
 from ...sts.session_state_manager import SessionStateManager
 from ...sts.performance_recorder import PerformanceRecorder
 from ...sts.voice_recorder import VoiceRecorder
@@ -140,11 +140,8 @@ class AIAvatarTwilioServer(Adapter):
         auth_token: str = None,
         phone_number: str = None,
         webhook_base_url: str = None,
+        twilio_client: Client = None,
         channel: str = "phone",
-
-        # SMS
-        enable_sms: bool = False,
-        sms_sts: STSPipeline = None,
 
         # Timeout operations
         first_utterance_timeout: float = 10.0,
@@ -157,8 +154,8 @@ class AIAvatarTwilioServer(Adapter):
         max_turn_prompt_prefix: str = None,
 
         # Channel
-        insert_channel_tag: bool = False,
-        skip_tts_channels: List[str] = ["sms"],
+        insert_channel_tag: InsertChannelTagConfig = False,
+        skip_tts_channels: List[str] = None,
 
         # Debug
         debug: bool = False,
@@ -217,7 +214,6 @@ class AIAvatarTwilioServer(Adapter):
         self._on_connect: Callable[[AIAvatarRequest, TwilioSessionData], Awaitable[None]] = None
         self._on_disconnect: Callable[[TwilioSessionData], Awaitable[None]] = None
         self._on_dtmf: Callable[[str, str], Awaitable[None]] = None
-        self._on_sms_received: Callable[[TwilioSMSMessage], Awaitable[None]] = None
         self._resolve_phone_number: Callable[[str], Awaitable[Optional[str]]] = None
 
         # Audio
@@ -228,34 +224,9 @@ class AIAvatarTwilioServer(Adapter):
 
         # Twilio
         self.phone_number = phone_number
-        self.twilio_client = Client(account_sid, auth_token) if account_sid and auth_token else None
+        self.twilio_client = twilio_client or (Client(account_sid, auth_token) if account_sid and auth_token else None)
         self.webhook_base_url: str = webhook_base_url
         self._outbound_call_data: Dict[str, dict] = {}
-
-        # SMS pipeline
-        if sms_sts:
-            self.sms_sts = sms_sts
-        elif enable_sms:
-            self.sms_sts = STSPipeline(
-                vad=SpeechDetectorDummy(),
-                stt=SpeechRecognizerDummy(),
-                llm=self.sts.llm,
-                tts=SpeechSynthesizerDummy(),
-                timestamp_interval_seconds=self.sts.timestamp_interval_seconds,
-                timestamp_prefix=self.sts.timestamp_prefix,
-                timestamp_timezone=self.sts.timestamp_timezone,
-                db_pool_provider=self.sts.db_pool_provider,
-                session_state_manager=self.sts.session_state_manager,
-                performance_recorder=self.sts.performance_recorder,
-                voice_recorder_enabled=False,
-                debug=self.sts.debug,
-            )
-        else:
-            self.sms_sts = None
-
-        if self.sms_sts:
-            self.sms_sts.handle_response = self._handle_sms_response
-            self.sms_sts.stop_response = self._stop_sms_response
 
         # Timeout operations
         self.first_utterance_timeout = first_utterance_timeout
@@ -269,8 +240,10 @@ class AIAvatarTwilioServer(Adapter):
         self._turn_counts: Dict[str, int] = {}
 
         if max_turn_count > 0:
-            @self.sts.on_before_llm
+            @self.sts.on_before_llm(channels=self.channel)
             async def count_turns(request: STSRequest):
+                if not self.can_handle(request.session_id):
+                    return
                 context_id = request.context_id
 
                 # Skip increment for merged requests (redo of cancelled turn)
@@ -299,21 +272,23 @@ class AIAvatarTwilioServer(Adapter):
         if mute_on_barge_in:
             @self.sts.vad.on_recording_started
             async def mute_on_barge_in(session_id: str):
+                if not self.can_handle(session_id):
+                    return
                 # Reset marks so idle timer works correctly after barge-in
-                if session_id in self.sessions:
-                    self.sessions[session_id].last_mark = ""
-                    self.sessions[session_id].hang_mark = ""
+                self.sessions[session_id].last_mark = ""
+                self.sessions[session_id].hang_mark = ""
                 await self.stop_response(session_id, "")
 
         # Debug
         self.debug = debug
         self.last_response = None
 
-        @self.sts.on_accepted
+        @self.sts.on_accepted(channels=self.channel)
         async def on_accepted(request: STSRequest):
+            if not self.can_handle(request.session_id):
+                return
             # Disable first utterance timeout once user has spoken
-            if request.session_id in self.sessions:
-                self.sessions[request.session_id].is_first_utterance_timeout_invoked = True
+            self.sessions[request.session_id].is_first_utterance_timeout_invoked = True
 
             barge_in_enabled = self.sts.vad.get_session_data(request.session_id, "barge_in_enabled")
             if barge_in_enabled is not False:
@@ -355,10 +330,6 @@ class AIAvatarTwilioServer(Adapter):
 
     def on_hangup_timeout(self, func: Callable[[str], Awaitable[None]]):
         self._on_hangup_timeout = func
-        return func
-
-    def on_sms_received(self, func: Callable[[TwilioSMSMessage], Awaitable[None]]):
-        self._on_sms_received = func
         return func
 
     def resolve_phone_number(self, func: Callable[[str], Awaitable[Optional[str]]]):
@@ -462,7 +433,15 @@ class AIAvatarTwilioServer(Adapter):
         return session_data
 
     # Response
+    def can_handle(self, session_id: str) -> bool:
+        return self.sessions.get(session_id) is not None
+
     async def handle_response(self, response: STSResponse):
+        session_data = self.sessions.get(response.session_id)
+        if not session_data:
+            logger.warning(f"Session not found for response (Twilio): {response.session_id}")
+            return
+
         aiavatar_response = AIAvatarResponse(
             type=response.type,
             session_id=response.session_id,
@@ -478,11 +457,6 @@ class AIAvatarTwilioServer(Adapter):
         # Callback for each response chunk (base class)
         for on_resp in self._on_response_handlers:
             await on_resp(aiavatar_response, response)
-
-        session_data = self.sessions.get(response.session_id)
-        if not session_data:
-            logger.warning(f"Session not found for response: {response.session_id}")
-            return
 
         # Reset idle timer during response processing to prevent timeout
         # from misfiring while LLM/TTS is working.
@@ -597,6 +571,7 @@ class AIAvatarTwilioServer(Adapter):
     # Invoke pipeline
     async def invoke(self, request: STSRequest):
         try:
+            request.channel = self.channel
             async for response in self.sts.invoke(request):
                 await self.sts.handle_response(response)
                 if response.context_id:
@@ -638,26 +613,9 @@ class AIAvatarTwilioServer(Adapter):
 
         return call.sid
 
-    # Response (SMS)
-    async def _handle_sms_response(self, response: STSResponse):
-        pass
-
-    async def _stop_sms_response(self, session_id: str, context_id: str):
-        pass
-
-    # Outbound SMS
-    async def send_sms(self, to: str, body: str, from_: str = None) -> str:
-        from_number = from_ or self.phone_number
-        if not from_number:
-            raise ValueError("phone_number is required for sending SMS. Set it in the constructor or pass from_ parameter.")
-        if not self.twilio_client:
-            raise ValueError("twilio_client is not configured. Set account_sid and auth_token in the constructor.")
-        message = self.twilio_client.messages.create(body=body, from_=from_number, to=to)
-        return message.sid
-
     # FastAPI Router
     def get_router(self):
-        # Endpoints: /voice, /ws, /call/make, /sms, /sms/send
+        # Endpoints: /voice, /ws, /call/make
         websocket_url = self.webhook_base_url.replace("https://", "wss://").replace("http://", "ws://") + "/ws"
 
         router = APIRouter()
@@ -752,8 +710,208 @@ class AIAvatarTwilioServer(Adapter):
             )
             return MakeCallResponse(call_sid=call_sid)
 
-        # SMS
-        @router.post("/sms")
+        return router
+
+
+class AIAvatarTwilioSMSServer(Adapter):
+    def __init__(
+        self,
+        *,
+        sts: STSPipeline,
+        account_sid: str = None,
+        auth_token: str = None,
+        phone_number: str = None,
+        twilio_client: Client = None,
+        channel: str = "sms",
+        debug: bool = False,
+    ):
+        if sts is None:
+            raise ValueError("sts is required for AIAvatarTwilioSMSServer")
+
+        super().__init__(sts)
+        self.sessions: Dict[str, TwilioSMSMessage] = {}
+        self._on_sms_received: Callable[[TwilioSMSMessage], Awaitable[None]] = None
+
+        self.phone_number = phone_number
+        self.twilio_client = twilio_client or (Client(account_sid, auth_token) if account_sid and auth_token else None)
+        self.channel = channel
+        self.debug = debug
+        self.last_response = None
+
+        # SMS responses do not need synthesized audio.
+        if self.channel not in self.sts.skip_tts_channels:
+            self.sts.skip_tts_channels.append(self.channel)
+
+    def get_config(self) -> dict:
+        return {
+            "debug": self.debug,
+        }
+
+    def on_sms_received(self, func: Callable[[TwilioSMSMessage], Awaitable[None]]):
+        self._on_sms_received = func
+        return func
+
+    def can_handle(self, session_id: str) -> bool:
+        return session_id in self.sessions
+
+    async def _invoke_request(
+        self,
+        request: AIAvatarRequest,
+        message: TwilioSMSMessage,
+        *,
+        notify_received: bool,
+        resolve_session: bool,
+    ):
+        self.sessions[request.session_id] = message
+
+        try:
+            if notify_received and self._on_sms_received:
+                await self._on_sms_received(message)
+
+            if resolve_session:
+                for on_session_start in self._on_session_start_handlers:
+                    await on_session_start(request, message)
+
+            for on_request in self._on_request_handlers:
+                await on_request(request)
+
+            async for response in self.sts.invoke(STSRequest(
+                type=request.type,
+                session_id=request.session_id,
+                user_id=request.user_id,
+                context_id=request.context_id,
+                text=request.text,
+                files=request.files,
+                system_prompt_params=request.system_prompt_params,
+                allow_merge=request.allow_merge,
+                wait_in_queue=request.wait_in_queue,
+                channel=self.channel,
+                metadata=request.metadata,
+                skip_quick_response=True,
+            )):
+                await self.sts.handle_response(response)
+        finally:
+            await self._finalize_session(request.session_id)
+
+    async def process_message(self, message: TwilioSMSMessage, session_id: str = None):
+        request = AIAvatarRequest(
+            type="start",
+            session_id=session_id or f"twilio_sms_{uuid4()}",
+            user_id=message.from_number,
+            text=message.body,
+        )
+        await self._invoke_request(
+            request,
+            message,
+            notify_received=True,
+            resolve_session=True,
+        )
+
+    async def handle_push_request(
+        self,
+        *,
+        user_id: str,
+        text: str,
+        to: str,
+        context_id: str = None,
+        from_: str = None,
+        session_id: str = None,
+    ):
+        if not to:
+            raise ValueError("to is required for sending SMS")
+        from_number = from_ or self.phone_number
+        if not from_number:
+            raise ValueError("phone_number is required for sending SMS. Set it in the constructor or pass from_ parameter.")
+        if not self.twilio_client:
+            raise ValueError("twilio_client is not configured. Set account_sid and auth_token in the constructor.")
+
+        request = AIAvatarRequest(
+            type="start",
+            session_id=session_id or f"twilio_sms_{uuid4()}",
+            user_id=user_id,
+            context_id=context_id,
+            text=text,
+        )
+        target = TwilioSMSMessage(
+            message_sid="",
+            from_number=to,
+            to_number=from_number,
+            body=text,
+        )
+        await self._invoke_request(
+            request,
+            target,
+            notify_received=False,
+            resolve_session=False,
+        )
+
+    async def _finalize_session(self, session_id: str):
+        try:
+            await self.sts.finalize(session_id)
+        finally:
+            try:
+                await self.sts.session_state_manager.clear_session(session_id)
+            finally:
+                self.sessions.pop(session_id, None)
+
+    async def handle_response(self, response: STSResponse):
+        message = self.sessions.get(response.session_id)
+        if not message:
+            logger.warning(f"Session not found for response (Twilio SMS): {response.session_id}")
+            return
+
+        aiavatar_response = AIAvatarResponse(
+            type=response.type,
+            session_id=response.session_id,
+            user_id=response.user_id,
+            context_id=response.context_id,
+            text=response.text,
+            voice_text=response.voice_text,
+            language=response.language,
+            audio_data=response.audio_data,
+            metadata=response.metadata or {},
+            structured_content=response.structured_content,
+        )
+
+        for on_response in self._on_response_handlers:
+            await on_response(aiavatar_response, response)
+
+        if response.type == "final":
+            body = aiavatar_response.voice_text or aiavatar_response.text
+            if body:
+                await self.send_sms(
+                    to=message.from_number,
+                    body=body,
+                    from_=message.to_number,
+                )
+
+        if self.debug:
+            self.last_response = aiavatar_response
+
+    async def stop_response(self, session_id: str, context_id: str):
+        # A pending SMS has not been handed off to Twilio yet, so there is
+        # nothing to stop at the transport layer.
+        pass
+
+    async def send_sms(self, to: str, body: str, from_: str = None) -> str:
+        from_number = from_ or self.phone_number
+        if not from_number:
+            raise ValueError("phone_number is required for sending SMS. Set it in the constructor or pass from_ parameter.")
+        if not self.twilio_client:
+            raise ValueError("twilio_client is not configured. Set account_sid and auth_token in the constructor.")
+
+        message = await asyncio.to_thread(
+            self.twilio_client.messages.create,
+            body=body,
+            from_=from_number,
+            to=to,
+        )
+        return message.sid
+
+    def get_router(self, path: str = "/sms"):
+        router = APIRouter()
+
+        @router.post(path)
         async def incoming_sms(request: Request):
             form_data = await request.form()
             message = TwilioSMSMessage(
@@ -763,11 +921,17 @@ class AIAvatarTwilioServer(Adapter):
                 body=form_data.get("Body", ""),
             )
             logger.info(f"Incoming SMS from: {message.from_number} (MessageSid: {message.message_sid})")
-            if self._on_sms_received:
-                asyncio.create_task(self._on_sms_received(message))
+
+            async def process_in_background():
+                try:
+                    await self.process_message(message)
+                except Exception:
+                    logger.exception(f"Error processing incoming SMS: {message.message_sid}")
+
+            asyncio.create_task(process_in_background())
             return HTMLResponse(content="<Response></Response>", media_type="application/xml")
 
-        @router.post("/sms/send", response_model=SendSMSResponse)
+        @router.post(path + "/send", response_model=SendSMSResponse)
         async def send_sms_endpoint(request_body: SendSMSRequest):
             message_sid = await self.send_sms(to=request_body.to, body=request_body.body)
             return SendSMSResponse(message_sid=message_sid)

--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Callable, Awaitable, Optional
 from fastapi import APIRouter, Header, HTTPException, WebSocket, WebSocketException, status
 from ...database import PoolProvider
 from ...sts.models import STSRequest, STSResponse
-from ...sts.pipeline import STSPipeline
+from ...sts.pipeline import STSPipeline, InsertChannelTagConfig
 from ...sts.vad import SpeechDetector
 from ...sts.stt import SpeechRecognizer
 from ...sts.stt.openai import OpenAISpeechRecognizer
@@ -91,7 +91,8 @@ class AIAvatarWebSocketServer(Adapter):
         # API server auth
         api_key: str = None,
         # Channel
-        insert_channel_tag: bool = False,
+        channel: str = "websocket",
+        insert_channel_tag: InsertChannelTagConfig = False,
         # Debug
         debug: bool = False,
     ):
@@ -155,18 +156,25 @@ class AIAvatarWebSocketServer(Adapter):
         # API Key
         self.api_key = api_key
 
+        # Channel
+        self.channel = channel
+
         # Mute immediately on barge-in
         if mute_on_barge_in:
             @self.sts.vad.on_recording_started
             async def mute_on_barge_in(session_id: str):
+                if not self.can_handle(session_id):
+                    return
                 await self.stop_response(session_id, "")
 
         # Debug
         self.debug = debug
         self.last_response = None
 
-        @self.sts.on_accepted
+        @self.sts.on_accepted(channels=self.channel)
         async def on_accepted(request: STSRequest):
+            if not self.can_handle(request.session_id):
+                return
             barge_in_enabled = self.sts.vad.get_session_data(request.session_id, "barge_in_enabled")
             if barge_in_enabled is not False:
                 return
@@ -237,8 +245,7 @@ class AIAvatarWebSocketServer(Adapter):
                 self.sts.vad.set_session_data(request.session_id, "user_id", request.user_id, True)
             if request.context_id:
                 self.sts.vad.set_session_data(request.session_id, "context_id", request.context_id, True)
-            if request.channel:
-                self.sts.vad.set_session_data(request.session_id, "channel", request.channel, True)
+            self.sts.vad.set_session_data(request.session_id, "channel", self.channel, True)
             if request.metadata:
                 self._apply_session_config(request.session_id, request.metadata, create_session=True)
             session_data.data["metadata"] = request.metadata
@@ -279,7 +286,7 @@ class AIAvatarWebSocketServer(Adapter):
                 system_prompt_params=request.system_prompt_params,
                 allow_merge=request.allow_merge,
                 wait_in_queue=request.wait_in_queue,
-                channel=request.channel,
+                channel=self.channel,
                 metadata=request.metadata
             )):
                 if r.type == "start":
@@ -321,8 +328,14 @@ class AIAvatarWebSocketServer(Adapter):
                     aiavatar_response.model_dump_json()
                 )
 
+    def can_handle(self, session_id: str) -> bool:
+        return self.sessions.get(session_id) is not None
+
     async def handle_response(self, response: STSResponse):
         session_data = self.sessions.get(response.session_id)
+        if not session_data:
+            logger.warning(f"Session not found for response (WebSocket): {response.session_id}")
+            return
 
         # On accepted: finalize old transaction and update active_transaction_id
         if response.type == "accepted" and response.transaction_id and session_data:
@@ -436,7 +449,7 @@ class AIAvatarWebSocketServer(Adapter):
                 aiavatar_response.metadata = {"source": vision_source}
 
         elif response.type == "stop":
-            await self.stop_response(response)
+            await self.stop_response(response.session_id, response.context_id)
 
         await self.send_response(aiavatar_response)
 

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -7,7 +7,7 @@ import logging
 import re
 from time import time
 import traceback
-from typing import AsyncGenerator, Dict, Tuple, List, Optional
+from typing import AsyncGenerator, Collection, Dict, FrozenSet, Tuple, List, Optional, Union
 from uuid import uuid4
 from ..database import PoolProvider
 from .models import STSRequest, STSResponse
@@ -30,8 +30,72 @@ logger = logging.getLogger(__name__)
 
 LANGUAGE_PATTERN = re.compile(r"""\[(?:lang|language):([a-zA-Z-]+)\]|<(?:lang|language)\s[^>]*code=["']([a-zA-Z-]+)["']""")
 
+ChannelTagRule = Union[str, Tuple[str, str]]
+InsertChannelTagConfig = Union[bool, List[ChannelTagRule]]
+
+
+class ResponseHandler:
+    def __init__(self, can_handle: callable, handle_response: callable, stop_response: callable):
+        self.can_handle = can_handle
+        self.handle_response = handle_response
+        self.stop_response = stop_response
+
 
 class STSPipeline:
+    @property
+    def insert_channel_tag(self) -> InsertChannelTagConfig:
+        if isinstance(self._insert_channel_tag, list):
+            return list(self._insert_channel_tag)
+        return self._insert_channel_tag
+
+    @insert_channel_tag.setter
+    def insert_channel_tag(self, config: InsertChannelTagConfig):
+        if isinstance(config, bool):
+            self._insert_channel_tag = config
+            self._channel_tag_names = {}
+            return
+
+        if not isinstance(config, list):
+            raise TypeError("insert_channel_tag must be a bool or a list of channel tag rules")
+
+        normalized_rules: List[ChannelTagRule] = []
+        channel_tag_names: Dict[str, str] = {}
+        for rule in config:
+            if isinstance(rule, str):
+                source_channel = rule
+                tag_name = rule
+                normalized_rule: ChannelTagRule = rule
+            elif isinstance(rule, tuple) and len(rule) == 2:
+                source_channel, tag_name = rule
+                normalized_rule = rule
+            else:
+                raise TypeError(
+                    "insert_channel_tag rules must be channel names or "
+                    "(channel, tag_name) tuples"
+                )
+
+            if not isinstance(source_channel, str) or not source_channel:
+                raise ValueError("insert_channel_tag channel names must be non-empty strings")
+            if not isinstance(tag_name, str) or not tag_name:
+                raise ValueError("insert_channel_tag tag names must be non-empty strings")
+            if source_channel in channel_tag_names:
+                raise ValueError(
+                    f"insert_channel_tag contains duplicate channel: {source_channel}"
+                )
+
+            normalized_rules.append(normalized_rule)
+            channel_tag_names[source_channel] = tag_name
+
+        self._insert_channel_tag = normalized_rules
+        self._channel_tag_names = channel_tag_names
+
+    def _resolve_channel_tag_name(self, channel: Optional[str]) -> Optional[str]:
+        if not channel or self._insert_channel_tag is False:
+            return None
+        if self._insert_channel_tag is True:
+            return channel
+        return self._channel_tag_names.get(channel)
+
     def __init__(
         self,
         *,
@@ -70,7 +134,7 @@ class STSPipeline:
         invoke_queue_idle_timeout: float = 10.0,
         invoke_timeout: float = 60.0,
         use_invoke_queue: bool = False,
-        insert_channel_tag: bool = False,
+        insert_channel_tag: InsertChannelTagConfig = False,
         skip_tts_channels: List[str] = None,
         debug: bool = False
     ):
@@ -110,23 +174,7 @@ class STSPipeline:
             sample_rate=vad_sample_rate,
             debug=debug
         )
-
-        @self.vad.on_speech_detected
-        async def on_speech_detected(data: bytes, text: str, metadata: dict, recorded_duration: float, session_id: str):
-            async for response in self.invoke(STSRequest(
-                session_id=session_id,
-                user_id=self.vad.get_session_data(session_id, "user_id"),
-                context_id=self.vad.get_session_data(session_id, "context_id"),
-                channel=self.vad.get_session_data(session_id, "channel"),
-                text=text,
-                audio_data=data,
-                audio_duration=recorded_duration,
-                system_prompt_params=self.vad.get_session_data(session_id, "system_prompt_params"),
-                metadata=metadata,
-            )):
-                if response.type == "start":
-                    self.vad.set_session_data(session_id, "context_id", response.context_id)
-                await self.handle_response(response)
+        self.vad.on_speech_detected(self.on_speech_detected)
 
         # Speech-to-Text
         self.stt = stt or GoogleSpeechRecognizer(
@@ -182,8 +230,7 @@ class STSPipeline:
         self.timestamp_prefix = timestamp_prefix
 
         # Response handler
-        self.handle_response = self.handle_response_default
-        self.stop_response = self.stop_response_default
+        self.response_handlers: List[ResponseHandler] = []
         self._process_llm_chunk = self.process_llm_chunk_default
 
         # Performance recorder
@@ -260,24 +307,77 @@ class STSPipeline:
         self._validate_request = func
         return func
 
-    def on_before_llm(self, func):
-        self._on_before_llm_handlers.append(func)
-        return func
+    @staticmethod
+    def _normalize_hook_channels(
+        channels: Optional[Union[str, Collection[str]]]
+    ) -> Optional[FrozenSet[str]]:
+        if channels is None:
+            return None
 
-    def on_before_tts(self, func):
-        self._on_before_tts_handlers.append(func)
-        return func
+        normalized = (
+            frozenset([channels])
+            if isinstance(channels, str)
+            else frozenset(channels)
+        )
+        if not normalized:
+            raise ValueError("channels must not be empty")
+        if any(not isinstance(channel, str) or not channel for channel in normalized):
+            raise ValueError("channels must contain non-empty strings")
+        return normalized
 
-    def on_accepted(self, func):
-        self._on_accepted_handlers.append(func)
-        return func
+    def _register_hook(self, handlers: list, func=None, *, channels=None):
+        normalized_channels = self._normalize_hook_channels(channels)
 
-    def on_finish(self, func):
-        self._on_finish_handlers.append(func)
-        return func
+        def register(handler):
+            handlers.append((normalized_channels, handler))
+            return handler
+
+        return register if func is None else register(func)
+
+    async def _execute_hooks(self, handlers: list, channel: Optional[str], *args):
+        for channels, handler in handlers:
+            if channels is None or channel in channels:
+                await handler(*args)
+
+    def on_before_llm(self, func=None, *, channels=None):
+        return self._register_hook(self._on_before_llm_handlers, func, channels=channels)
+
+    def on_before_tts(self, func=None, *, channels=None):
+        return self._register_hook(self._on_before_tts_handlers, func, channels=channels)
+
+    def on_accepted(self, func=None, *, channels=None):
+        return self._register_hook(self._on_accepted_handlers, func, channels=channels)
+
+    def on_finish(self, func=None, *, channels=None):
+        return self._register_hook(self._on_finish_handlers, func, channels=channels)
+
+    def add_response_handler(self, handler: ResponseHandler):
+        self.response_handlers.append(handler)
 
     async def process_audio_samples(self, samples: bytes, context_id: str):
         await self.vad.process_samples(samples, context_id)
+
+    async def on_speech_detected(self, data: bytes, text: str, metadata: dict, recorded_duration: float, session_id: str):
+        # Get response handler before loop
+        response_handler = self._resolve_handler(session_id)
+        if not response_handler:
+            logger.warning(f"No response handler found for invoke: session_id={session_id}")
+            return
+
+        async for response in self.invoke(STSRequest(
+            session_id=session_id,
+            user_id=self.vad.get_session_data(session_id, "user_id"),
+            context_id=self.vad.get_session_data(session_id, "context_id"),
+            channel=self.vad.get_session_data(session_id, "channel"),
+            text=text,
+            audio_data=data,
+            audio_duration=recorded_duration,
+            system_prompt_params=self.vad.get_session_data(session_id, "system_prompt_params"),
+            metadata=metadata,
+        )):
+            if response.type == "start":
+                self.vad.set_session_data(session_id, "context_id", response.context_id)
+            await response_handler.handle_response(response)
 
     def set_speech_recognizer(
         self,
@@ -305,11 +405,22 @@ class STSPipeline:
     async def process_llm_chunk_default(self, llm_stream_chunk: LLMResponse, session_id: str, user_id: str):
         return {}
 
-    async def handle_response_default(self, response: STSResponse):
-        logger.info(f"Handle response: {response}")
+    def _resolve_handler(self, session_id: str) -> ResponseHandler:
+        for h in self.response_handlers:
+            if h.can_handle(session_id):
+                return h
 
-    async def stop_response_default(self, session_id: str, context_id: str):
-        logger.info(f"Stop response: {session_id} / {context_id}")
+    async def handle_response(self, response: STSResponse):
+        if handler := self._resolve_handler(response.session_id):
+            await handler.handle_response(response)
+        else:
+            logger.warning(f"No response handler found: session_id={response.session_id}")
+
+    async def stop_response(self, session_id: str, context_id: str):
+        if handler := self._resolve_handler(session_id):
+            await handler.stop_response(session_id, context_id)
+        else:
+            logger.warning(f"No stop handler found: session_id={session_id}")
 
     def is_awake(self, request: STSRequest, last_request_at: datetime) -> bool:
         now = datetime.now(timezone.utc)
@@ -348,6 +459,7 @@ class STSPipeline:
                 raise ValueError("session_id is required but not provided")
 
             start_time = time()
+            hook_channel = request.channel
             # Notify client that request is accepted (fire and forget to avoid blocking pipeline latency)
             asyncio.create_task(self.handle_response(STSResponse(
                 type="accepted",
@@ -355,8 +467,7 @@ class STSPipeline:
                 transaction_id=request.transaction_id,
                 metadata={"block_barge_in": request.block_barge_in}
             )))
-            for handler in self._on_accepted_handlers:
-                await handler(request)
+            await self._execute_hooks(self._on_accepted_handlers, hook_channel, request)
 
             performance = PerformanceRecord(
                 transaction_id=request.transaction_id,
@@ -414,8 +525,8 @@ class STSPipeline:
                 recognized_text = ""    # Request without both text and audio (e.g. image only)
 
             # Insert channel tag
-            if self.insert_channel_tag and request.channel:
-                channel_tag = f"<channel name='{request.channel}' />"
+            if channel_tag_name := self._resolve_channel_tag_name(request.channel):
+                channel_tag = f"<channel name='{channel_tag_name}' />"
                 request.text = f"{channel_tag}{recognized_text}" if recognized_text else channel_tag
             else:
                 request.text = recognized_text
@@ -503,8 +614,7 @@ class STSPipeline:
             )
 
             # LLM
-            for handler in self._on_before_llm_handlers:
-                await handler(request)
+            await self._execute_hooks(self._on_before_llm_handlers, hook_channel, request)
             performance.before_llm_time = time() - start_time
             performance.quick_response_text = request.quick_response_text
 
@@ -563,8 +673,7 @@ class STSPipeline:
                         performance.response_voice_text = voice_text
                         if performance.llm_first_voice_chunk_time == 0:
                             performance.llm_first_voice_chunk_time = time() - start_time
-                            for handler in self._on_before_tts_handlers:
-                                await handler(request)
+                            await self._execute_hooks(self._on_before_tts_handlers, hook_channel, request)
                     performance.llm_time = time() - start_time
 
                     # Parse language
@@ -672,8 +781,7 @@ class STSPipeline:
                 await self.voice_recorder.record(ResponseVoices(
                     request.transaction_id, response_audios, self.voice_recorder_response_audio_format
                 ))
-            for handler in self._on_finish_handlers:
-                await handler(request, final_response)
+            await self._execute_hooks(self._on_finish_handlers, hook_channel, request, final_response)
             yield final_response
         
         except Exception as iex:

--- a/tests/adapter/chatcompletions/test_server_unit.py
+++ b/tests/adapter/chatcompletions/test_server_unit.py
@@ -1,0 +1,236 @@
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+
+from aiavatar.adapter.chatcompletions.server import (
+    AIAvatarChatCompletionsServer,
+    ChatCompletionsRequest,
+    ChatMessage,
+)
+from aiavatar.sts.models import STSResponse
+
+
+class FakeSessionStateManager:
+    def __init__(self):
+        self.cleared_sessions = []
+
+    async def clear_session(self, session_id):
+        self.cleared_sessions.append(session_id)
+
+
+class FakePipeline:
+    def __init__(self, fail_on_invoke=False):
+        self.response_handlers = []
+        self.skip_tts_channels = ["phone"]
+        self.invoked_requests = []
+        self.finalized_sessions = []
+        self.handler_owned_during_invoke = []
+        self.session_state_manager = FakeSessionStateManager()
+        self.fail_on_invoke = fail_on_invoke
+
+    def add_response_handler(self, handler):
+        self.response_handlers.append(handler)
+
+    async def handle_response(self, response):
+        for handler in self.response_handlers:
+            if handler.can_handle(response.session_id):
+                await handler.handle_response(response)
+                return
+        raise AssertionError(f"No response handler for {response.session_id}")
+
+    async def invoke(self, request):
+        self.invoked_requests.append(request)
+        self.handler_owned_during_invoke.append(any(
+            handler.can_handle(request.session_id)
+            for handler in self.response_handlers
+        ))
+        await self.handle_response(STSResponse(
+            type="accepted",
+            session_id=request.session_id,
+        ))
+        if self.fail_on_invoke:
+            raise RuntimeError("invoke failed")
+        yield STSResponse(
+            type="chunk",
+            session_id=request.session_id,
+            user_id=request.user_id,
+            context_id=request.context_id,
+            text="chunk text",
+            voice_text="chunk voice",
+        )
+        yield STSResponse(
+            type="final",
+            session_id=request.session_id,
+            user_id=request.user_id,
+            context_id="context-updated",
+            text="final text",
+            voice_text="final voice",
+        )
+
+    async def finalize(self, session_id):
+        self.finalized_sessions.append(session_id)
+
+
+class ForeignResponseHandler:
+    def __init__(self):
+        self.responses = []
+
+    def can_handle(self, session_id):
+        return session_id.startswith("foreign_")
+
+    async def handle_response(self, response):
+        self.responses.append(response)
+
+
+class FakeChannelContextBridge:
+    def __init__(self):
+        self.channel_user_requests = []
+        self.contexts = []
+
+    async def get_channel_user(self, channel_id, channel_user_id, auto_create=False):
+        self.channel_user_requests.append((channel_id, channel_user_id, auto_create))
+        return SimpleNamespace(user_id="application-user")
+
+    async def get_context(self, user_id):
+        return SimpleNamespace(context_id="context-current")
+
+    async def upsert_context(self, context):
+        self.contexts.append(context)
+
+
+def get_endpoint(server):
+    router = server.get_api_router()
+    return next(
+        route.endpoint
+        for route in router.routes
+        if route.path == "/v1/chat/completions"
+    )
+
+
+def credentials():
+    return HTTPAuthorizationCredentials(
+        scheme="Bearer",
+        credentials="external-user-token",
+    )
+
+
+def assert_chatcompletions_session_id(session_id):
+    prefix, value = session_id.split("_", 1)
+    assert prefix == "chatcompletions"
+    UUID(value)
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_response_owns_session_on_shared_pipeline():
+    pipeline = FakePipeline()
+    foreign_handler = ForeignResponseHandler()
+    pipeline.response_handlers.append(foreign_handler)
+    bridge = FakeChannelContextBridge()
+    server = AIAvatarChatCompletionsServer(
+        sts=pipeline,
+        channel_context_bridge=bridge,
+    )
+
+    response = await get_endpoint(server)(
+        ChatCompletionsRequest(messages=[ChatMessage(role="user", content="Hello")]),
+        credentials(),
+    )
+
+    request = pipeline.invoked_requests[0]
+    assert_chatcompletions_session_id(request.session_id)
+    assert request.channel == "chatcompletions"
+    assert request.user_id == "application-user"
+    assert request.context_id == "context-current"
+    assert request.metadata["chatcompletions_token"] == "external-user-token"
+    assert pipeline.skip_tts_channels == ["phone", "chatcompletions"]
+    assert pipeline.handler_owned_during_invoke == [True]
+    assert foreign_handler.responses == []
+    assert response.choices[0].message.content == "final voice"
+    assert bridge.contexts[0].context_id == "context-updated"
+    assert pipeline.finalized_sessions == [request.session_id]
+    assert pipeline.session_state_manager.cleared_sessions == [request.session_id]
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_owns_session_until_done():
+    pipeline = FakePipeline()
+    bridge = FakeChannelContextBridge()
+    server = AIAvatarChatCompletionsServer(
+        sts=pipeline,
+        channel_context_bridge=bridge,
+    )
+
+    response = await get_endpoint(server)(
+        ChatCompletionsRequest(
+            messages=[ChatMessage(role="user", content="Hello")],
+            stream=True,
+        ),
+        credentials(),
+    )
+    chunks = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+    request = pipeline.invoked_requests[0]
+    body = "".join(chunks)
+    assert_chatcompletions_session_id(request.session_id)
+    assert pipeline.handler_owned_during_invoke == [True]
+    assert '"role":"assistant"' in body
+    assert '"content":"chunk voice"' in body
+    assert '"finish_reason":"stop"' in body
+    assert "[DONE]" in body
+    assert bridge.contexts[0].context_id == "context-updated"
+    assert pipeline.finalized_sessions == [request.session_id]
+    assert pipeline.session_state_manager.cleared_sessions == [request.session_id]
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_releases_session_when_client_closes():
+    pipeline = FakePipeline()
+    server = AIAvatarChatCompletionsServer(
+        sts=pipeline,
+        channel_context_bridge=FakeChannelContextBridge(),
+    )
+
+    response = await get_endpoint(server)(
+        ChatCompletionsRequest(
+            messages=[ChatMessage(role="user", content="Hello")],
+            stream=True,
+        ),
+        credentials(),
+    )
+    iterator = response.body_iterator
+    await anext(iterator)
+
+    session_id = next(iter(server.sessions))
+    assert server.can_handle(session_id)
+
+    await iterator.aclose()
+
+    assert pipeline.finalized_sessions == [session_id]
+    assert pipeline.session_state_manager.cleared_sessions == [session_id]
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_response_releases_session_when_invoke_fails():
+    pipeline = FakePipeline(fail_on_invoke=True)
+    server = AIAvatarChatCompletionsServer(
+        sts=pipeline,
+        channel_context_bridge=FakeChannelContextBridge(),
+    )
+
+    with pytest.raises(RuntimeError, match="invoke failed"):
+        await get_endpoint(server)(
+            ChatCompletionsRequest(messages=[ChatMessage(role="user", content="Hello")]),
+            credentials(),
+        )
+
+    session_id = pipeline.invoked_requests[0].session_id
+    assert pipeline.finalized_sessions == [session_id]
+    assert pipeline.session_state_manager.cleared_sessions == [session_id]
+    assert server.sessions == {}

--- a/tests/adapter/linebot/test_channel_link.py
+++ b/tests/adapter/linebot/test_channel_link.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aiavatar.adapter.linebot.tools.channel_link import LinebotChannelLinkTool
+
+
+class FakeChannelContextBridge:
+    def __init__(self):
+        self.linked_users = []
+
+    async def link_channel_user(self, channel_id, channel_user_id, user_id):
+        self.linked_users.append((channel_id, channel_user_id, user_id))
+
+
+def test_callback_uses_configured_adapter_channel():
+    bridge = FakeChannelContextBridge()
+    tool = LinebotChannelLinkTool(
+        channel_id="line-login-channel-id",
+        client_secret="secret",
+        base_url="https://example.com",
+        channel="custom-linebot",
+        channel_context_bridge=bridge,
+    )
+
+    async def verify_state(state, code):
+        assert state == "state"
+        assert code == "code"
+        return "application-user", "line-user"
+
+    tool.verify_state = verify_state
+    app = FastAPI()
+    app.include_router(tool.get_callback_router())
+
+    response = TestClient(app).get("/login-callback?state=state&code=code")
+
+    assert response.status_code == 200
+    assert bridge.linked_users == [(
+        "custom-linebot",
+        "line-user",
+        "application-user",
+    )]

--- a/tests/adapter/linebot/test_server.py
+++ b/tests/adapter/linebot/test_server.py
@@ -1,0 +1,282 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+
+try:
+    from linebot.v3 import WebhookParser as _WebhookParser  # noqa: F401
+except ModuleNotFoundError:
+    linebot_module = ModuleType("linebot")
+    linebot_v3_module = ModuleType("linebot.v3")
+    linebot_messaging_module = ModuleType("linebot.v3.messaging")
+    linebot_webhooks_module = ModuleType("linebot.v3.webhooks")
+
+    class StubModel:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            if "replyToken" in kwargs:
+                self.reply_token = kwargs["replyToken"]
+
+    class StubWebhookParser:
+        def __init__(self, channel_secret):
+            self.channel_secret = channel_secret
+
+    class StubConfiguration:
+        def __init__(self, access_token=None):
+            self.access_token = access_token
+
+    class StubAsyncApiClient:
+        def __init__(self, configuration):
+            self.configuration = configuration
+
+    class StubMessagingApi:
+        def __init__(self, api_client):
+            self.api_client = api_client
+
+    linebot_v3_module.WebhookParser = StubWebhookParser
+    for name, value in {
+        "Configuration": StubConfiguration,
+        "AsyncApiClient": StubAsyncApiClient,
+        "AsyncMessagingApi": StubMessagingApi,
+        "AsyncMessagingApiBlob": StubMessagingApi,
+        "TextMessage": StubModel,
+        "ReplyMessageRequest": StubModel,
+        "PushMessageRequest": StubModel,
+    }.items():
+        setattr(linebot_messaging_module, name, value)
+    for name in (
+        "Event",
+        "MessageEvent",
+        "TextMessageContent",
+        "StickerMessageContent",
+        "LocationMessageContent",
+        "ImageMessageContent",
+    ):
+        setattr(linebot_webhooks_module, name, StubModel)
+
+    linebot_module.v3 = linebot_v3_module
+    sys.modules["linebot"] = linebot_module
+    sys.modules["linebot.v3"] = linebot_v3_module
+    sys.modules["linebot.v3.messaging"] = linebot_messaging_module
+    sys.modules["linebot.v3.webhooks"] = linebot_webhooks_module
+
+from aiavatar.adapter.linebot.server import AIAvatarLineBotServer
+from aiavatar.sts.models import STSResponse
+
+
+class FakeSessionStateManager:
+    def __init__(self):
+        self.cleared_sessions = []
+
+    async def clear_session(self, session_id):
+        self.cleared_sessions.append(session_id)
+
+
+class FakePipeline:
+    def __init__(self, fail_on_invoke=False):
+        self.response_handlers = []
+        self.skip_tts_channels = []
+        self.invoked_requests = []
+        self.finalized_sessions = []
+        self.handler_owned_during_invoke = []
+        self.session_state_manager = FakeSessionStateManager()
+        self.fail_on_invoke = fail_on_invoke
+
+    def add_response_handler(self, handler):
+        self.response_handlers.append(handler)
+
+    async def invoke(self, request):
+        self.invoked_requests.append(request)
+        self.handler_owned_during_invoke.append(any(
+            handler.can_handle(request.session_id)
+            for handler in self.response_handlers
+        ))
+        if self.fail_on_invoke:
+            raise RuntimeError("invoke failed")
+        for response_type in ("start", "chunk", "final"):
+            yield STSResponse(
+                type=response_type,
+                session_id=request.session_id,
+                user_id=request.user_id,
+                context_id="context-updated",
+                text="LINE response",
+                voice_text="LINE voice response",
+            )
+
+    async def handle_response(self, response):
+        for handler in self.response_handlers:
+            if handler.can_handle(response.session_id):
+                await handler.handle_response(response)
+                return
+        raise AssertionError(f"No response handler for {response.session_id}")
+
+    async def finalize(self, session_id):
+        self.finalized_sessions.append(session_id)
+
+
+class ForeignResponseHandler:
+    def __init__(self):
+        self.responses = []
+
+    def can_handle(self, session_id):
+        return session_id.startswith("foreign_")
+
+    async def handle_response(self, response):
+        self.responses.append(response)
+
+
+class FakeLineApi:
+    def __init__(self):
+        self.replies = []
+        self.pushes = []
+
+    async def reply_message(self, request):
+        self.replies.append(request)
+
+    async def push_message(self, request):
+        self.pushes.append(request)
+
+
+class FakeChannelContextBridge:
+    def __init__(self):
+        self.contexts = []
+        self.channel_users = []
+
+    async def get_context(self, user_id):
+        return SimpleNamespace(context_id="context-current")
+
+    async def upsert_context(self, context):
+        self.contexts.append(context)
+
+    async def find_channel_users(self, user_id):
+        return self.channel_users
+
+
+def assert_linebot_session_id(session_id):
+    prefix, value = session_id.split("_", 1)
+    assert prefix == "linebot"
+    UUID(value)
+
+
+@pytest.mark.asyncio
+async def test_linebot_reply_routes_shared_pipeline_response():
+    pipeline = FakePipeline()
+    foreign_handler = ForeignResponseHandler()
+    pipeline.response_handlers.append(foreign_handler)
+    bridge = FakeChannelContextBridge()
+    server = AIAvatarLineBotServer(
+        sts=pipeline,
+        channel_access_token="test-channel-access-token",
+        channel_secret="test-channel-secret",
+        channel_context_bridge=bridge,
+    )
+    server.line_api = FakeLineApi()
+    callback_types = []
+
+    @server.on_response
+    async def on_response(aiavatar_response, sts_response):
+        callback_types.append(aiavatar_response.type)
+        assert server.can_handle(sts_response.session_id)
+
+    event = SimpleNamespace(
+        message=SimpleNamespace(type="text", text="Hello"),
+        reply_token="reply-token",
+    )
+    await server.handle_message_event(event, user_id="user-1", context_id="context-1")
+
+    request = pipeline.invoked_requests[0]
+    assert_linebot_session_id(request.session_id)
+    assert request.channel == "linebot"
+    assert pipeline.skip_tts_channels == ["linebot"]
+    assert pipeline.handler_owned_during_invoke == [True]
+    assert foreign_handler.responses == []
+    assert callback_types == ["start", "chunk", "final"]
+    assert len(server.line_api.replies) == 1
+    assert server.line_api.replies[0].reply_token == "reply-token"
+    assert server.line_api.replies[0].messages[0].text == "LINE voice response"
+    assert server.line_api.pushes == []
+    assert bridge.contexts[0].context_id == "context-updated"
+    assert pipeline.finalized_sessions == [request.session_id]
+    assert pipeline.session_state_manager.cleared_sessions == [request.session_id]
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_linebot_direct_reply_routes_shared_pipeline_response():
+    pipeline = FakePipeline()
+    bridge = FakeChannelContextBridge()
+    server = AIAvatarLineBotServer(
+        sts=pipeline,
+        channel_access_token="test-channel-access-token",
+        channel_secret="test-channel-secret",
+        channel_context_bridge=bridge,
+    )
+    server.line_api = FakeLineApi()
+
+    await server.handle_reply_request(
+        reply_token="follow-reply-token",
+        user_id="user-1",
+        context_id="context-1",
+        text="Follow greeting",
+    )
+
+    request = pipeline.invoked_requests[0]
+    assert request.text == "Follow greeting"
+    assert request.channel == "linebot"
+    assert len(server.line_api.replies) == 1
+    assert server.line_api.replies[0].reply_token == "follow-reply-token"
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_linebot_push_routes_response_to_resolved_user():
+    pipeline = FakePipeline()
+    bridge = FakeChannelContextBridge()
+    bridge.channel_users = [SimpleNamespace(
+        channel_id="linebot",
+        channel_user_id="U-line-user",
+    )]
+    server = AIAvatarLineBotServer(
+        sts=pipeline,
+        channel_access_token="test-channel-access-token",
+        channel_secret="test-channel-secret",
+        channel_context_bridge=bridge,
+    )
+    server.line_api = FakeLineApi()
+
+    await server.handle_push_request(user_id="user-1", text="Hello")
+
+    request = pipeline.invoked_requests[0]
+    assert_linebot_session_id(request.session_id)
+    assert request.context_id == "context-current"
+    assert len(server.line_api.pushes) == 1
+    assert server.line_api.pushes[0].to == "U-line-user"
+    assert server.line_api.pushes[0].messages[0].text == "LINE voice response"
+    assert server.line_api.replies == []
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_linebot_releases_session_when_invoke_fails():
+    pipeline = FakePipeline(fail_on_invoke=True)
+    server = AIAvatarLineBotServer(
+        sts=pipeline,
+        channel_access_token="test-channel-access-token",
+        channel_secret="test-channel-secret",
+        channel_context_bridge=FakeChannelContextBridge(),
+    )
+    server.line_api = FakeLineApi()
+    event = SimpleNamespace(
+        message=SimpleNamespace(type="text", text="Hello"),
+        reply_token="reply-token",
+    )
+
+    with pytest.raises(RuntimeError, match="invoke failed"):
+        await server.handle_message_event(event, user_id="user-1", context_id=None)
+
+    session_id = pipeline.invoked_requests[0].session_id
+    assert pipeline.finalized_sessions == [session_id]
+    assert pipeline.session_state_manager.cleared_sessions == [session_id]
+    assert server.sessions == {}

--- a/tests/adapter/test_request_channel.py
+++ b/tests/adapter/test_request_channel.py
@@ -1,0 +1,165 @@
+import asyncio
+
+import pytest
+
+from aiavatar.adapter.http.server import AIAvatarHttpServer, PostChatMessagesRequest
+from aiavatar.adapter.local.server import AIAvatarLocalServer
+from aiavatar.adapter.models import AIAvatarRequest
+from aiavatar.sts.models import STSRequest, STSResponse
+
+
+class FakePipeline:
+    def __init__(self, fail_on_invoke=False):
+        self.response_handlers = []
+        self.invoked_requests = []
+        self.handler_owned_during_invoke = []
+        self.dispatched_responses = []
+        self.fail_on_invoke = fail_on_invoke
+
+    def add_response_handler(self, handler):
+        self.response_handlers.append(handler)
+
+    async def handle_response(self, response):
+        for handler in self.response_handlers:
+            if handler.can_handle(response.session_id):
+                self.dispatched_responses.append(response)
+                await handler.handle_response(response)
+                return
+
+    async def invoke(self, request):
+        self.invoked_requests.append(request)
+        self.handler_owned_during_invoke.append(any(
+            handler.can_handle(request.session_id)
+            for handler in self.response_handlers
+        ))
+        await self.handle_response(STSResponse(
+            type="accepted",
+            session_id=request.session_id,
+        ))
+        if self.fail_on_invoke:
+            raise RuntimeError("invoke failed")
+        yield STSResponse(
+            type="final",
+            session_id=request.session_id,
+            user_id=request.user_id,
+            context_id=request.context_id,
+            text="done",
+        )
+
+
+@pytest.mark.asyncio
+async def test_http_adapter_sets_its_channel_on_pipeline_request():
+    pipeline = FakePipeline()
+    server = AIAvatarHttpServer(sts=pipeline, channel="internal-api")
+    router = server.get_api_router()
+    endpoint = next(route.endpoint for route in router.routes if route.path == "/chat")
+    response = await endpoint(
+        AIAvatarRequest(type="invoke", session_id="session-1", text="hello"),
+        None,
+    )
+
+    async for _ in response.body_iterator:
+        pass
+
+    assert server.channel == "internal-api"
+    assert pipeline.invoked_requests[0].channel == "internal-api"
+    assert pipeline.handler_owned_during_invoke == [True]
+    assert [response.type for response in pipeline.dispatched_responses] == ["accepted"]
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_http_adapter_owns_dify_session_only_while_streaming():
+    pipeline = FakePipeline()
+    server = AIAvatarHttpServer(sts=pipeline)
+    router = server.get_api_router()
+    endpoint = next(route.endpoint for route in router.routes if route.path == "/chat-messages")
+    response = await endpoint(
+        PostChatMessagesRequest(
+            query="hello",
+            user="user-1",
+            conversation_id="conversation-1",
+        ),
+        None,
+    )
+
+    async for _ in response.body_iterator:
+        pass
+
+    assert pipeline.invoked_requests[0].session_id == "conversation-1"
+    assert pipeline.invoked_requests[0].channel == "http"
+    assert pipeline.handler_owned_during_invoke == [True]
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_http_adapter_releases_session_when_stream_fails():
+    pipeline = FakePipeline(fail_on_invoke=True)
+    server = AIAvatarHttpServer(sts=pipeline)
+    router = server.get_api_router()
+    endpoint = next(route.endpoint for route in router.routes if route.path == "/chat")
+    response = await endpoint(
+        AIAvatarRequest(type="invoke", session_id="session-1", text="hello"),
+        None,
+    )
+
+    with pytest.raises(RuntimeError, match="invoke failed"):
+        async for _ in response.body_iterator:
+            pass
+
+    assert pipeline.handler_owned_during_invoke == [True]
+    assert server.sessions == {}
+
+
+def test_http_adapter_reference_counts_overlapping_sessions():
+    server = AIAvatarHttpServer(sts=FakePipeline())
+
+    server._register_session("session-1")
+    server._register_session("session-1")
+    server._unregister_session("session-1")
+
+    assert server.can_handle("session-1")
+    assert server.sessions == {"session-1": 1}
+
+    server._unregister_session("session-1")
+
+    assert not server.can_handle("session-1")
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_http_adapter_server_side_invoke_owns_session_and_sets_channel():
+    pipeline = FakePipeline()
+    server = AIAvatarHttpServer(sts=pipeline, channel="restapi")
+
+    responses = [response async for response in server.invoke(STSRequest(
+        session_id="restapi-session-1",
+        user_id="user-1",
+        text="hello",
+    ))]
+
+    assert responses[-1].type == "final"
+    assert pipeline.invoked_requests[0].channel == "restapi"
+    assert pipeline.handler_owned_during_invoke == [True]
+    assert [response.type for response in pipeline.dispatched_responses] == ["accepted"]
+    assert server.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_local_adapter_sets_its_channel_on_pipeline_request():
+    pipeline = FakePipeline()
+    with pytest.warns(DeprecationWarning):
+        server = AIAvatarLocalServer(
+            asyncio.Queue(),
+            sts=pipeline,
+            channel="legacy-local",
+        )
+
+    await server.send_request(
+        AIAvatarRequest(type="invoke", session_id="session-1", text="hello")
+    )
+
+    assert server.channel == "legacy-local"
+    assert pipeline.invoked_requests[0].channel == "legacy-local"
+    assert pipeline.handler_owned_during_invoke == [True]
+    assert server.can_handle("session-1")

--- a/tests/adapter/twilio/test_sms_server.py
+++ b/tests/adapter/twilio/test_sms_server.py
@@ -1,0 +1,283 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+try:
+    from twilio.rest import Client as _TwilioClient  # noqa: F401
+    from twilio.twiml.voice_response import VoiceResponse as _VoiceResponse  # noqa: F401
+except ModuleNotFoundError:
+    twilio_module = ModuleType("twilio")
+    twilio_rest_module = ModuleType("twilio.rest")
+    twilio_twiml_module = ModuleType("twilio.twiml")
+    twilio_voice_module = ModuleType("twilio.twiml.voice_response")
+
+    class StubClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class StubVoiceResponse:
+        def append(self, value):
+            pass
+
+    class StubConnect:
+        def stream(self, **kwargs):
+            pass
+
+    twilio_rest_module.Client = StubClient
+    twilio_voice_module.VoiceResponse = StubVoiceResponse
+    twilio_voice_module.Connect = StubConnect
+    sys.modules["twilio"] = twilio_module
+    sys.modules["twilio.rest"] = twilio_rest_module
+    sys.modules["twilio.twiml"] = twilio_twiml_module
+    sys.modules["twilio.twiml.voice_response"] = twilio_voice_module
+
+
+from aiavatar.adapter.twilio import (
+    AIAvatarTwilioServer,
+    AIAvatarTwilioSMSServer,
+    TwilioSessionData,
+    TwilioSMSMessage,
+)
+from aiavatar.sts.models import STSRequest, STSResponse
+
+
+class FakePipeline:
+    def __init__(self):
+        self.response_handlers = []
+        self.skip_tts_channels = []
+        self.accepted_hook_channels = []
+        self.invoked_requests = []
+        self.finalized_sessions = []
+        self.session_state_manager = FakeSessionStateManager()
+
+    def add_response_handler(self, handler):
+        self.response_handlers.append(handler)
+
+    def on_accepted(self, func=None, *, channels=None):
+        def register(callback):
+            self.accepted_hook_channels.append(channels)
+            return callback
+
+        if func is not None:
+            return register(func)
+        return register
+
+    async def invoke(self, request):
+        self.invoked_requests.append(request)
+        yield STSResponse(
+            type="start",
+            session_id=request.session_id,
+            user_id=request.user_id,
+            context_id=request.context_id,
+        )
+        yield STSResponse(
+            type="chunk",
+            session_id=request.session_id,
+            user_id=request.user_id,
+            context_id=request.context_id,
+            text="partial",
+            voice_text="partial",
+        )
+        yield STSResponse(
+            type="final",
+            session_id=request.session_id,
+            user_id=request.user_id,
+            context_id=request.context_id,
+            text="response with control tags",
+            voice_text="SMS response",
+        )
+
+    async def handle_response(self, response):
+        for handler in self.response_handlers:
+            if handler.can_handle(response.session_id):
+                await handler.handle_response(response)
+                return
+        raise AssertionError(f"No response handler for {response.session_id}")
+
+    async def finalize(self, session_id):
+        self.finalized_sessions.append(session_id)
+
+
+class FakeSessionStateManager:
+    def __init__(self):
+        self.cleared_sessions = []
+
+    async def clear_session(self, session_id):
+        self.cleared_sessions.append(session_id)
+
+
+class FakeMessages:
+    def __init__(self):
+        self.sent = []
+
+    def create(self, *, body, from_, to):
+        self.sent.append({"body": body, "from": from_, "to": to})
+        return SimpleNamespace(sid="SM-outbound")
+
+
+class FakeTwilioClient:
+    def __init__(self):
+        self.messages = FakeMessages()
+
+
+@pytest.mark.asyncio
+async def test_voice_server_overrides_request_channel_with_adapter_channel():
+    pipeline = FakePipeline()
+    phone = AIAvatarTwilioServer(
+        sts=pipeline,
+        webhook_base_url="https://example.com/twilio",
+        channel="support-phone",
+    )
+    phone.sessions["phone-session-1"] = TwilioSessionData()
+
+    await phone.invoke(STSRequest(
+        session_id="phone-session-1",
+        channel="sms",
+        text="Hello",
+    ))
+
+    assert pipeline.invoked_requests[0].channel == "support-phone"
+
+
+@pytest.mark.asyncio
+async def test_sms_server_routes_shared_pipeline_response_to_sms():
+    pipeline = FakePipeline()
+    client = FakeTwilioClient()
+    phone = AIAvatarTwilioServer(
+        sts=pipeline,
+        twilio_client=client,
+        phone_number="+10000000000",
+        webhook_base_url="https://example.com/twilio",
+    )
+    sms = AIAvatarTwilioSMSServer(
+        sts=pipeline,
+        twilio_client=client,
+        phone_number="+10000000000",
+    )
+    received_messages = []
+    callback_types = []
+    handled_while_registered = []
+
+    @sms.on_sms_received
+    async def on_sms_received(message):
+        received_messages.append(message.message_sid)
+
+    @sms.on_session_start
+    async def on_session_start(request, message):
+        assert message.message_sid == "SM-inbound"
+        request.user_id = "application-user"
+        request.context_id = "context-1"
+
+    @sms.on_response
+    async def on_response(aiavatar_response, sts_response):
+        callback_types.append(aiavatar_response.type)
+        handled_while_registered.append(sms.can_handle(sts_response.session_id))
+
+    await sms.process_message(
+        TwilioSMSMessage(
+            message_sid="SM-inbound",
+            from_number="+12222222222",
+            to_number="+10000000000",
+            body="Hello",
+        ),
+        session_id="sms-session-1",
+    )
+
+    assert len(pipeline.response_handlers) == 2
+    assert pipeline.accepted_hook_channels == ["phone"]
+    assert pipeline.skip_tts_channels == ["sms"]
+    assert received_messages == ["SM-inbound"]
+    assert callback_types == ["start", "chunk", "final"]
+    assert all(handled_while_registered)
+    assert not phone.can_handle("sms-session-1")
+    assert not sms.can_handle("sms-session-1")
+    assert pipeline.finalized_sessions == ["sms-session-1"]
+    assert pipeline.session_state_manager.cleared_sessions == ["sms-session-1"]
+
+    invoked = pipeline.invoked_requests[0]
+    assert invoked.session_id == "sms-session-1"
+    assert invoked.user_id == "application-user"
+    assert invoked.context_id == "context-1"
+    assert invoked.channel == "sms"
+    assert invoked.skip_quick_response is True
+
+    assert client.messages.sent == [{
+        "body": "SMS response",
+        "from": "+10000000000",
+        "to": "+12222222222",
+    }]
+
+    assert "/sms" not in {route.path for route in phone.get_router().routes}
+    assert {route.path for route in sms.get_router().routes} == {"/sms", "/sms/send"}
+
+
+@pytest.mark.asyncio
+async def test_sms_server_push_uses_internal_user_and_sms_response_handler():
+    pipeline = FakePipeline()
+    client = FakeTwilioClient()
+    sms = AIAvatarTwilioSMSServer(
+        sts=pipeline,
+        twilio_client=client,
+        phone_number="+10000000000",
+    )
+    session_start_calls = []
+
+    @sms.on_session_start
+    async def on_session_start(request, message):
+        session_start_calls.append((request.user_id, message.from_number))
+
+    await sms.handle_push_request(
+        user_id="application-user",
+        context_id="context-1",
+        text="Notify the user",
+        to="+12222222222",
+        session_id="sms-push-session-1",
+    )
+
+    assert session_start_calls == []
+    assert not sms.can_handle("sms-push-session-1")
+    assert pipeline.finalized_sessions == ["sms-push-session-1"]
+    assert pipeline.session_state_manager.cleared_sessions == ["sms-push-session-1"]
+
+    invoked = pipeline.invoked_requests[0]
+    assert invoked.user_id == "application-user"
+    assert invoked.context_id == "context-1"
+    assert invoked.channel == "sms"
+    assert client.messages.sent == [{
+        "body": "SMS response",
+        "from": "+10000000000",
+        "to": "+12222222222",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_sms_server_clears_state_when_finalize_fails():
+    pipeline = FakePipeline()
+    client = FakeTwilioClient()
+    sms = AIAvatarTwilioSMSServer(
+        sts=pipeline,
+        twilio_client=client,
+        phone_number="+10000000000",
+    )
+
+    async def fail_finalize(session_id):
+        pipeline.finalized_sessions.append(session_id)
+        raise RuntimeError("finalize failed")
+
+    pipeline.finalize = fail_finalize
+
+    with pytest.raises(RuntimeError, match="finalize failed"):
+        await sms.process_message(
+            TwilioSMSMessage(
+                message_sid="SM-inbound",
+                from_number="+12222222222",
+                to_number="+10000000000",
+                body="Hello",
+            ),
+            session_id="sms-session-finalize-error",
+        )
+
+    assert not sms.can_handle("sms-session-finalize-error")
+    assert pipeline.session_state_manager.cleared_sessions == ["sms-session-finalize-error"]

--- a/tests/adapter/websocket/test_channel.py
+++ b/tests/adapter/websocket/test_channel.py
@@ -1,0 +1,125 @@
+import json
+
+import pytest
+
+from aiavatar.adapter.models import AIAvatarRequest
+from aiavatar.adapter.websocket.server import AIAvatarWebSocketServer, WebSocketSessionData
+from aiavatar.sts.models import STSResponse
+
+
+class FakeVAD:
+    def __init__(self):
+        self.sessions = {}
+        self.voiced_handler = None
+
+    def on_voiced(self, func):
+        self.voiced_handler = func
+        return func
+
+    def set_session_data(self, session_id, key, value, create_session=False):
+        self.sessions.setdefault(session_id, {})[key] = value
+
+    def get_session_data(self, session_id, key):
+        return self.sessions.get(session_id, {}).get(key)
+
+
+class FakePipeline:
+    def __init__(self):
+        self.vad = FakeVAD()
+        self.response_handlers = []
+        self.accepted_hook_channels = []
+        self.invoked_requests = []
+        self.responses = []
+
+    def add_response_handler(self, handler):
+        self.response_handlers.append(handler)
+
+    def on_accepted(self, func=None, *, channels=None):
+        def register(callback):
+            self.accepted_hook_channels.append(channels)
+            return callback
+
+        if func is not None:
+            return register(func)
+        return register
+
+    async def invoke(self, request):
+        self.invoked_requests.append(request)
+        yield STSResponse(type="final", session_id=request.session_id)
+
+    async def handle_response(self, response):
+        self.responses.append(response)
+
+
+class FakeWebSocket:
+    def __init__(self, *requests):
+        self.requests = [json.dumps(request) for request in requests]
+        self.sent_messages = []
+        self.closed = False
+
+    async def receive_text(self):
+        return self.requests.pop(0)
+
+    async def send_text(self, message):
+        self.sent_messages.append(message)
+
+    async def close(self):
+        self.closed = True
+
+
+def test_channel_defaults_to_websocket():
+    pipeline = FakePipeline()
+
+    server = AIAvatarWebSocketServer(sts=pipeline)
+
+    assert server.channel == "websocket"
+    assert pipeline.accepted_hook_channels == ["websocket"]
+
+
+def test_aiavatar_request_does_not_expose_channel_field():
+    request = AIAvatarRequest.model_validate({
+        "type": "invoke",
+        "channel": "client-supplied-channel",
+    })
+
+    assert "channel" not in AIAvatarRequest.model_fields
+    assert "channel" not in request.model_dump()
+
+
+@pytest.mark.asyncio
+async def test_adapter_channel_ignores_client_value_and_sets_pipeline_channel():
+    pipeline = FakePipeline()
+    server = AIAvatarWebSocketServer(sts=pipeline, channel="m5stack")
+    session_data = WebSocketSessionData()
+    websocket = FakeWebSocket(
+        {
+            "type": "start",
+            "session_id": "session-1",
+            "channel": "client-supplied-channel",
+        },
+        {
+            "type": "invoke",
+            "session_id": "session-1",
+            "channel": "another-client-channel",
+            "text": "hello",
+        },
+    )
+    request_payloads = []
+    session_start_payloads = []
+
+    @server.on_request
+    async def on_request(request):
+        request_payloads.append(request.model_dump())
+
+    @server.on_session_start
+    async def on_session_start(request, _session_data):
+        session_start_payloads.append(request.model_dump())
+
+    await server.process_websocket(websocket, session_data)
+    await server.process_websocket(websocket, session_data)
+
+    assert pipeline.accepted_hook_channels == ["m5stack"]
+    assert all("channel" not in payload for payload in request_payloads)
+    assert all("channel" not in payload for payload in session_start_payloads)
+    assert pipeline.vad.get_session_data("session-1", "channel") == "m5stack"
+    assert pipeline.invoked_requests[0].channel == "m5stack"

--- a/tests/admin/test_admin.py
+++ b/tests/admin/test_admin.py
@@ -53,6 +53,9 @@ class AIAvatarTestServer(Adapter):
     def __init__(self, recorder):
         self.sts = Pipeline(recorder)
 
+    def can_handle(self, session_id):
+        return False
+
     async def handle_response(self, response):
         pass
 

--- a/tests/sts/test_pipeline.py
+++ b/tests/sts/test_pipeline.py
@@ -34,6 +34,9 @@ class RecordingAdapter(Adapter):
         async for response in self.sts.invoke(request):
             await self.handle_response(response)
 
+    def can_handle(self, session_id: str) -> bool:
+        return True
+
     async def handle_response(self, response: STSResponse):
         if response.type == "start":
             self.final_user_id = response.user_id

--- a/tests/sts/test_pipeline_hooks.py
+++ b/tests/sts/test_pipeline_hooks.py
@@ -1,0 +1,283 @@
+import asyncio
+
+import pytest
+
+from aiavatar.sts.models import STSRequest, STSResponse
+from aiavatar.sts.pipeline import ResponseHandler, STSPipeline
+from aiavatar.sts.llm import LLMServiceDummy
+from aiavatar.sts.stt import SpeechRecognizerDummy
+from aiavatar.sts.tts import SpeechSynthesizerDummy
+from aiavatar.sts.vad import SpeechDetectorDummy
+
+
+def make_pipeline() -> STSPipeline:
+    pipeline = STSPipeline.__new__(STSPipeline)
+    pipeline._on_before_llm_handlers = []
+    pipeline._on_before_tts_handlers = []
+    pipeline._on_accepted_handlers = []
+    pipeline._on_finish_handlers = []
+    return pipeline
+
+
+@pytest.mark.asyncio
+async def test_hook_channels_support_global_single_and_multiple_channels():
+    pipeline = make_pipeline()
+    calls = []
+
+    @pipeline.on_before_llm
+    async def global_hook(request):
+        calls.append(("global", request.channel))
+
+    @pipeline.on_before_llm(channels="phone")
+    async def phone_hook(request):
+        calls.append(("phone", request.channel))
+
+    @pipeline.on_before_llm(channels=["phone", "sms"])
+    async def telephone_hook(request):
+        calls.append(("telephone", request.channel))
+
+    for channel, expected in (
+        ("phone", ["global", "phone", "telephone"]),
+        ("sms", ["global", "telephone"]),
+        ("web", ["global"]),
+        (None, ["global"]),
+    ):
+        calls.clear()
+        request = STSRequest(session_id="session", channel=channel)
+        await pipeline._execute_hooks(
+            pipeline._on_before_llm_handlers,
+            channel,
+            request,
+        )
+        assert [name for name, _ in calls] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("register_name", "handlers_name", "include_response"),
+    (
+        ("on_accepted", "_on_accepted_handlers", False),
+        ("on_before_llm", "_on_before_llm_handlers", False),
+        ("on_before_tts", "_on_before_tts_handlers", False),
+        ("on_finish", "_on_finish_handlers", True),
+    ),
+)
+async def test_all_pipeline_hooks_accept_channels(
+    register_name,
+    handlers_name,
+    include_response,
+):
+    pipeline = make_pipeline()
+    calls = []
+    request = STSRequest(session_id="session", channel="phone")
+    response = STSResponse(type="final", session_id="session")
+
+    async def hook(*args):
+        calls.append(args)
+
+    returned = getattr(pipeline, register_name)(channels=["phone", "sms"])(hook)
+    assert returned is hook
+
+    args = (request, response) if include_response else (request,)
+    await pipeline._execute_hooks(
+        getattr(pipeline, handlers_name),
+        "web",
+        *args,
+    )
+    assert calls == []
+
+    await pipeline._execute_hooks(
+        getattr(pipeline, handlers_name),
+        "phone",
+        *args,
+    )
+    assert calls == [args]
+
+
+@pytest.mark.asyncio
+async def test_hook_channel_is_stable_during_execution():
+    pipeline = make_pipeline()
+    calls = []
+    request = STSRequest(session_id="session", channel="phone")
+
+    @pipeline.on_accepted
+    async def change_request_channel(request):
+        request.channel = "sms"
+
+    @pipeline.on_accepted(channels="phone")
+    async def phone_hook(request):
+        calls.append(request.channel)
+
+    await pipeline._execute_hooks(
+        pipeline._on_accepted_handlers,
+        "phone",
+        request,
+    )
+
+    assert calls == ["sms"]
+
+
+@pytest.mark.parametrize(
+    "channels",
+    ([], (), [""], ["phone", ""], ["phone", None]),
+)
+def test_hook_channels_reject_invalid_collections(channels):
+    pipeline = make_pipeline()
+
+    with pytest.raises(ValueError):
+        pipeline.on_before_llm(channels=channels)
+
+
+@pytest.mark.parametrize(
+    ("config", "channel", "expected"),
+    (
+        (False, "phone", None),
+        (True, "phone", "phone"),
+        (True, None, None),
+        (["phone", "sms"], "phone", "phone"),
+        (["phone", "sms"], "websocket", None),
+        (["phone", ("websocket_m5", "desktop_robot")], "websocket_m5", "desktop_robot"),
+        ([], "phone", None),
+    ),
+)
+def test_insert_channel_tag_resolves_bool_selected_and_renamed_channels(
+    config,
+    channel,
+    expected,
+):
+    pipeline = make_pipeline()
+    pipeline.insert_channel_tag = config
+
+    assert pipeline._resolve_channel_tag_name(channel) == expected
+
+
+@pytest.mark.parametrize(
+    "config",
+    (
+        None,
+        "phone",
+        ("phone", "voice"),
+        [""],
+        [("phone",)],
+        [("phone", "")],
+        [("phone", "voice"), "phone"],
+        [["phone", "voice"]],
+    ),
+)
+def test_insert_channel_tag_rejects_invalid_rules(config):
+    pipeline = make_pipeline()
+
+    with pytest.raises((TypeError, ValueError)):
+        pipeline.insert_channel_tag = config
+
+
+@pytest.mark.asyncio
+async def test_pipeline_invocation_inserts_only_selected_mapped_channel_tag(tmp_path):
+    pipeline = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=LLMServiceDummy(
+            response_text="response",
+            db_connection_str=str(tmp_path / "context.db"),
+        ),
+        tts=SpeechSynthesizerDummy(synthesized_bytes=b"voice"),
+        db_connection_str=str(tmp_path / "pipeline.db"),
+        voice_recorder_enabled=False,
+        insert_channel_tag=["phone", ("websocket_m5", "desktop_robot")],
+    )
+
+    async def handle_response(response):
+        pass
+
+    async def stop_response(session_id, context_id):
+        pass
+
+    pipeline.add_response_handler(ResponseHandler(
+        can_handle=lambda session_id: session_id in {"m5-session", "websocket-session"},
+        handle_response=handle_response,
+        stop_response=stop_response,
+    ))
+
+    mapped_request = STSRequest(
+        session_id="m5-session",
+        user_id="user",
+        text="Hello",
+        channel="websocket_m5",
+    )
+    unmatched_request = STSRequest(
+        session_id="websocket-session",
+        user_id="user",
+        text="Hello",
+        channel="websocket",
+    )
+
+    try:
+        _ = [response async for response in pipeline.invoke(mapped_request)]
+        _ = [response async for response in pipeline.invoke(unmatched_request)]
+        await asyncio.sleep(0)
+
+        assert mapped_request.text == "<channel name='desktop_robot' />Hello"
+        assert unmatched_request.text == "Hello"
+    finally:
+        await pipeline.shutdown()
+        await pipeline.stt.close()
+        await pipeline.tts.close()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_invocation_filters_all_hooks_by_channel(tmp_path):
+    pipeline = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        llm=LLMServiceDummy(
+            response_text="response",
+            db_connection_str=str(tmp_path / "context.db"),
+        ),
+        tts=SpeechSynthesizerDummy(synthesized_bytes=b"voice"),
+        db_connection_str=str(tmp_path / "pipeline.db"),
+        voice_recorder_enabled=False,
+    )
+    calls = []
+
+    async def handle_response(response):
+        pass
+
+    async def stop_response(session_id, context_id):
+        pass
+
+    pipeline.add_response_handler(ResponseHandler(
+        can_handle=lambda session_id: session_id == "session",
+        handle_response=handle_response,
+        stop_response=stop_response,
+    ))
+
+    def register_hooks(channels, prefix):
+        for name in ("on_accepted", "on_before_llm", "on_before_tts", "on_finish"):
+            async def hook(*args, name=name):
+                calls.append(f"{prefix}:{name}")
+
+            getattr(pipeline, name)(channels=channels)(hook)
+
+    register_hooks("phone", "matched")
+    register_hooks(["sms", "linebot"], "skipped")
+
+    try:
+        responses = [response async for response in pipeline.invoke(STSRequest(
+            session_id="session",
+            user_id="user",
+            text="request",
+            channel="phone",
+        ))]
+        await asyncio.sleep(0)
+
+        assert responses[-1].type == "final"
+        assert calls == [
+            "matched:on_accepted",
+            "matched:on_before_llm",
+            "matched:on_before_tts",
+            "matched:on_finish",
+        ]
+    finally:
+        await pipeline.shutdown()
+        await pipeline.stt.close()
+        await pipeline.tts.close()


### PR DESCRIPTION
Allow adapters to attach to an existing STSPipeline and route responses by session. This enables multiple channels to share the same STT, LLM, and TTS pipeline.