### PR TITLE
Group admin metrics by channel

### DIFF
--- a/aiavatar/admin/README.md
+++ b/aiavatar/admin/README.md
@@ -41,33 +41,42 @@ When `name` is omitted, a short name is derived from the Adapter class name. For
 
 ### Metrics
 
-The Metrics view shows the latency from the end of the user's speech to the first response.
+The Metrics view groups latency by the `channel` recorded on each Pipeline request. It does not combine latency averages across channels, so text-only and voice traffic do not distort each other's statistics.
 
 - Period: `1h`, `6h`, `24h`, `7d`, or `30d`
 - Interval: `1m`, `5m`, `15m`, `1h`, or `1d`
-- Summary: request count, error count, average, median, and P95
-- Chart: stacked average latency by phase for each time bucket
+- Overall summary: request, success, error, and channel counts
+- Per-channel summary: request count, error count, average, median, and P95 displayed latency
+- Per-channel chart: Speech latency when speech timing is available; otherwise Pipeline latency
 
-The detailed breakdown contains nine phases:
+The UI shows one latency chart per channel. A channel with measurable speech timing uses latency from speech end to first content output. A text-only channel instead uses latency from Pipeline invocation to first content output. The API returns both metric sets so other consumers can choose explicitly.
+
+The Pipeline form of the chart contains six phases:
+
+1. Input / STT
+2. Stop current response
+3. Before-LLM handlers
+4. LLM
+5. Processing
+6. TTS
+
+The Speech form prepends three speech phases to the same Pipeline phases:
 
 1. Silence detection
 2. Streaming STT finalization
 3. Turn-end gate
-4. STT
-5. Stop current response
-6. Before-LLM handlers
-7. LLM
-8. Processing
-9. TTS
 
-The endpoint for a normal response is the first TTS audio chunk. The endpoint for a Quick Response is `before_llm_time`. When an intermediate timing point is absent in an older record, its unknown interval is included in the next known phase so that the stack remains equal to the measured first-response time.
+The first content output endpoint is selected from existing timing fields in this order:
 
-The request count includes every record in the selected period. The detailed breakdown uses only records that meet all of the following conditions, and the UI reports this subset as coverage:
+1. Quick Response: `before_llm_time`
+2. Voice response: `tts_first_chunk_time`
+3. Text response fallback: `llm_first_chunk_time`
 
-- `speech_end_at` is present
-- The request has no error
-- A Quick Response or TTS first-chunk endpoint is present
-- The VAD and timing data can be interpreted
+No additional Pipeline start or first-output timestamps are persisted. When an intermediate timing point is absent, its unknown interval is included in the next known phase so that the stack remains equal to the measured latency.
+
+The request count includes every record in the selected period. Pipeline coverage includes successful records with one of the endpoints above, including records without `speech_end_at`. Speech coverage is the subset that also has usable speech-end and VAD timing. Failed requests and records without a usable endpoint remain in request/error counts but not in latency averages.
+
+New requests receive their channel from `STSRequest.channel`. Historical records without a channel are grouped as `Unclassified`.
 
 ### Logs
 
@@ -122,9 +131,9 @@ Metrics period selection and bucketing, as well as Logs display and ordering, us
 event_at = speech_end_at ?? created_at
 ```
 
-`speech_end_at` is the time at which the user's speech ended. `created_at`, which represents record persistence time, is used only as a fallback for older records without `speech_end_at`.
+`speech_end_at` is the time at which the user's speech ended. `created_at`, which represents record persistence time, is used as the event timestamp for text requests and as a fallback for older records without `speech_end_at`.
 
-For compatibility, the Logs API still returns this value in a field named `created_at`, but its value is the `event_at` defined above. Records without `speech_end_at` can appear in the log list, but they cannot be included in a detailed breakdown measured from the end of the user's speech.
+For compatibility, the Logs API still returns this value in a field named `created_at`, but its value is the `event_at` defined above. Records without `speech_end_at` can appear in the channel-specific Pipeline metrics and the log list, but not in the Speech breakdown. The existing aggregate Metrics endpoints and the per-turn Logs breakdown remain speech-based for compatibility.
 
 ## Authentication
 
@@ -179,6 +188,7 @@ All endpoints are under `/admin/api`.
 | Method | Path | Purpose |
 | --- | --- | --- |
 | GET | `/capabilities` | Return available optional features |
+| GET | `/metrics/by-channel?period=24h&interval=1h` | Return Pipeline and Speech metrics grouped by channel |
 | GET | `/metrics/summary?period=24h` | Return the Metrics summary |
 | GET | `/metrics/timeline?period=24h&interval=1h` | Return the detailed phase timeline |
 | GET | `/logs` | Return conversation messages matching the filters |
@@ -219,7 +229,7 @@ Database-specific behavior, timestamp selection, latency calculation, log filter
 | `static/index.html` | Provide the shared layout and load Chart.js and the application entry point |
 | `static/admin-app.js` | Load capabilities and manage navigation, view lifecycles, and global status |
 | `static/admin-api.js` | Provide the same-origin HTTP client for `/admin/api/` |
-| `static/metrics-view.js` | Render Metrics summary cards and the Chart.js chart |
+| `static/metrics-view.js` | Render overall counts and per-channel Pipeline and Speech charts |
 | `static/logs-view.js` | Render filters, the log table, details drawer, audio playback, and per-turn charts |
 | `static/config-view.js` | Load and arrange Config components |
 | `static/config-panel.js` | Generate configuration fields and save their values |

--- a/aiavatar/admin/metrics.py
+++ b/aiavatar/admin/metrics.py
@@ -38,12 +38,32 @@ class TimelineResponse(BaseModel):
     buckets: List[TimelineBucketResponse]
 
 
-class SummaryResponse(DetailedMetrics):
-    period: str
+class SummaryMetricsResponse(DetailedMetrics):
     total_requests: int
     p50_first_response_time: Optional[float] = None
     p95_first_response_time: Optional[float] = None
     p99_first_response_time: Optional[float] = None
+
+
+class SummaryResponse(SummaryMetricsResponse):
+    period: str
+
+
+class ChannelMetricsResponse(BaseModel):
+    channel: Optional[str] = None
+    pipeline_summary: SummaryMetricsResponse
+    speech_summary: SummaryMetricsResponse
+    pipeline_buckets: List[TimelineBucketResponse]
+    speech_buckets: List[TimelineBucketResponse]
+
+
+class MetricsByChannelResponse(BaseModel):
+    period: str
+    interval: str
+    total_requests: int
+    success_count: int
+    error_count: int
+    channels: List[ChannelMetricsResponse]
 
 
 class MetricsAPI:
@@ -80,6 +100,31 @@ class MetricsAPI:
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(ex))
             except Exception:
                 logger.exception("Error querying detailed metrics summary")
+                raise HTTPException(status_code=500, detail="Could not query metrics")
+
+        @router.get(
+            "/metrics/by-channel",
+            response_model=MetricsByChannelResponse,
+            tags=["Admin Metrics"],
+        )
+        async def get_metrics_by_channel(
+            period: str = Query("24h"),
+            interval: str = Query("1h"),
+        ) -> MetricsByChannelResponse:
+            try:
+                channels = await self.query.query_metrics_by_channel(period, interval)
+                return MetricsByChannelResponse(
+                    period=period,
+                    interval=interval,
+                    total_requests=sum(item.pipeline_summary.total_requests for item in channels),
+                    success_count=sum(item.pipeline_summary.success_count for item in channels),
+                    error_count=sum(item.pipeline_summary.error_count for item in channels),
+                    channels=[ChannelMetricsResponse(**asdict(item)) for item in channels],
+                )
+            except ValueError as ex:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(ex))
+            except Exception:
+                logger.exception("Error querying metrics by channel")
                 raise HTTPException(status_code=500, detail="Could not query metrics")
 
         return router

--- a/aiavatar/admin/static/config-view.js
+++ b/aiavatar/admin/static/config-view.js
@@ -10,7 +10,7 @@ const components = [
 
 export function renderConfig(root, { api, setStatus }) {
   root.innerHTML = `
-    <section class="page-heading"><h2>Config</h2><p>Runtime settings for the active pipeline and adapters.</p></section>
+    <section class="page-heading"><h2>Config</h2></section>
     <div class="config-grid" data-grid></div>`;
   const grid = root.querySelector("[data-grid]");
   let stopped = false;

--- a/aiavatar/admin/static/evaluation-view.js
+++ b/aiavatar/admin/static/evaluation-view.js
@@ -1,6 +1,6 @@
 export function renderEvaluation(root, { api, setStatus }) {
   root.innerHTML = `
-    <section class="page-heading"><h2>Evaluation</h2><p>Run a scenario set and retrieve its result.</p></section>
+    <section class="page-heading"><h2>Evaluation</h2></section>
     <section class="panel">
       <form><div class="field"><label for="evaluation-scenarios">Scenarios (JSON array)</label><textarea id="evaluation-scenarios" name="scenarios">[]</textarea></div>
       <div class="inline-error" data-error></div><button class="primary" type="submit">Start evaluation</button></form>

--- a/aiavatar/admin/static/logs-view.js
+++ b/aiavatar/admin/static/logs-view.js
@@ -152,7 +152,7 @@ function renderGroupRow(group, openDrawer) {
 
 export function renderLogs(root, { api, setStatus }) {
   root.innerHTML = `
-    <section class="page-heading"><h2>Logs</h2><p>Search conversation messages. All conditions are combined.</p></section>
+    <section class="page-heading"><h2>Logs</h2></section>
     <form class="filter-grid">
       <div class="field grow"><label for="logs-user">User ID</label><input id="logs-user" name="user_id" autocomplete="off"></div>
       <div class="field grow"><label for="logs-session">Session ID</label><input id="logs-session" name="session_id" autocomplete="off"></div>

--- a/aiavatar/admin/static/metrics-view.js
+++ b/aiavatar/admin/static/metrics-view.js
@@ -1,8 +1,8 @@
-const phases = [
+const speechPhases = [
   ["avg_silence_detection_phase", "Silence detection", "#94a3b8"],
   ["avg_streaming_stt_finalization_phase", "Streaming STT finalization", "#60a5fa"],
   ["avg_turn_end_gate_phase", "Turn-end gate", "#22d3ee"],
-  ["avg_stt_phase", "STT", "#2dd4bf"],
+  ["avg_stt_phase", "Input / STT", "#2dd4bf"],
   ["avg_stop_response_phase", "Stop current response", "#4ade80"],
   ["avg_before_llm_phase", "Before-LLM handlers", "#fbbf24"],
   ["avg_llm_phase", "LLM", "#fb923c"],
@@ -10,8 +10,17 @@ const phases = [
   ["avg_tts_phase", "TTS", "#f87171"],
 ];
 
+const pipelinePhases = speechPhases.slice(3);
+
 function seconds(value) {
   return value == null ? "—" : `${value.toFixed(3)} s`;
+}
+
+function coverage(summary) {
+  const ratio = summary.success_count
+    ? Math.round(summary.measured_count / summary.success_count * 100)
+    : 0;
+  return `${summary.measured_count} measured / ${summary.success_count} successful (${ratio}% coverage).`;
 }
 
 function chartTheme() {
@@ -21,48 +30,153 @@ function chartTheme() {
     : { grid: "#e4e4e7", text: "#71717a", title: "#52525b", tooltip: "#18181b", tooltipBorder: "#18181b" };
 }
 
+function card(label, value, sub = "") {
+  const element = document.createElement("div");
+  element.className = "card";
+  element.innerHTML = `<div class="label"></div><div class="value"></div><div class="sub"></div>`;
+  element.querySelector(".label").textContent = label;
+  element.querySelector(".value").textContent = value;
+  element.querySelector(".sub").textContent = sub;
+  return element;
+}
+
+function createChart(canvas, buckets, phases) {
+  const theme = chartTheme();
+  return new Chart(canvas, {
+    type: "bar",
+    data: {
+      labels: buckets.map(bucket => new Date(`${bucket.timestamp}Z`).toLocaleString()),
+      datasets: phases.map(([key, label, color]) => ({
+        label,
+        data: buckets.map(bucket => bucket[key] ?? 0),
+        backgroundColor: color,
+        stack: "latency",
+      })),
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: "index", intersect: false },
+      scales: {
+        x: {
+          stacked: true,
+          grid: { color: theme.grid },
+          ticks: { color: theme.text, maxRotation: 45 },
+        },
+        y: {
+          stacked: true,
+          beginAtZero: true,
+          grid: { color: theme.grid },
+          ticks: { color: theme.text },
+          title: { display: true, text: "Seconds", color: theme.title },
+        },
+      },
+      plugins: {
+        legend: {
+          position: "bottom",
+          labels: { color: theme.title, boxWidth: 12, boxHeight: 12, padding: 16 },
+        },
+        tooltip: {
+          backgroundColor: theme.tooltip,
+          borderColor: theme.tooltipBorder,
+          borderWidth: 1,
+          titleColor: "#fafafa",
+          bodyColor: "#e4e4e7",
+          padding: 10,
+        },
+      },
+    },
+  });
+}
+
 export function renderMetrics(root, { api, setStatus }) {
   root.innerHTML = `
-    <section class="page-heading"><h2>Metrics</h2><p>Latency measured from the end of the user's speech.</p></section>
+    <section class="page-heading"><h2>Metrics</h2></section>
     <form class="toolbar">
       <div class="field"><label for="metrics-period">Period</label><select id="metrics-period" name="period"><option>1h</option><option>6h</option><option selected>24h</option><option>7d</option><option>30d</option></select></div>
       <div class="field"><label for="metrics-interval">Interval</label><select id="metrics-interval" name="interval"><option>1m</option><option>5m</option><option>15m</option><option selected>1h</option><option>1d</option></select></div>
       <button class="primary" type="submit">Refresh</button>
     </form>
     <div class="cards" data-summary></div>
-    <section class="panel"><h3>First response breakdown</h3><p class="hint" data-coverage></p><div class="empty" data-empty hidden>No detailed timing data in this period.</div><div class="chart-wrap" data-chart><canvas></canvas></div></section>`;
+    <div class="empty" data-empty hidden>No metrics in this period.</div>
+    <div data-channels></div>`;
   const form = root.querySelector("form");
   const cards = root.querySelector("[data-summary]");
-  const coverage = root.querySelector("[data-coverage]");
   const empty = root.querySelector("[data-empty]");
-  const chartWrap = root.querySelector("[data-chart]");
-  let chart = null;
+  const channelContainer = root.querySelector("[data-channels]");
+  let charts = [];
   let stopped = false;
 
+  function clearCharts() {
+    charts.forEach(chart => chart.destroy());
+    charts = [];
+  }
+
   function syncChartTheme() {
-    if (!chart) return;
     const theme = chartTheme();
-    chart.options.scales.x.grid.color = theme.grid;
-    chart.options.scales.x.ticks.color = theme.text;
-    chart.options.scales.y.grid.color = theme.grid;
-    chart.options.scales.y.ticks.color = theme.text;
-    chart.options.scales.y.title.color = theme.title;
-    chart.options.plugins.legend.labels.color = theme.title;
-    chart.options.plugins.tooltip.backgroundColor = theme.tooltip;
-    chart.options.plugins.tooltip.borderColor = theme.tooltipBorder;
-    chart.update("none");
+    charts.forEach(chart => {
+      chart.options.scales.x.grid.color = theme.grid;
+      chart.options.scales.x.ticks.color = theme.text;
+      chart.options.scales.y.grid.color = theme.grid;
+      chart.options.scales.y.ticks.color = theme.text;
+      chart.options.scales.y.title.color = theme.title;
+      chart.options.plugins.legend.labels.color = theme.title;
+      chart.options.plugins.tooltip.backgroundColor = theme.tooltip;
+      chart.options.plugins.tooltip.borderColor = theme.tooltipBorder;
+      chart.update("none");
+    });
   }
 
   window.addEventListener("admin-theme-change", syncChartTheme);
 
-  function card(label, value, sub = "") {
-    const element = document.createElement("div");
-    element.className = "card";
-    element.innerHTML = `<div class="label"></div><div class="value"></div><div class="sub"></div>`;
-    element.querySelector(".label").textContent = label;
-    element.querySelector(".value").textContent = value;
-    element.querySelector(".sub").textContent = sub;
-    return element;
+  function renderChannel(channelMetrics) {
+    const panel = document.createElement("section");
+    panel.className = "panel";
+    panel.innerHTML = `
+      <h3 data-channel></h3>
+      <div class="cards" data-channel-summary></div>
+      <h3 data-latency-title></h3>
+      <p class="hint" data-coverage></p>
+      <div class="empty" data-latency-empty hidden>No timing data in this period.</div>
+      <div class="chart-wrap" data-latency-chart><canvas></canvas></div>`;
+
+    const channelName = channelMetrics.channel || "Unclassified";
+    panel.querySelector("[data-channel]").textContent = `Channel: ${channelName}`;
+    const pipelineSummary = channelMetrics.pipeline_summary;
+    const useSpeech = channelMetrics.speech_summary.measured_count !== 0;
+    const summary = useSpeech ? channelMetrics.speech_summary : pipelineSummary;
+    const buckets = useSpeech ? channelMetrics.speech_buckets : channelMetrics.pipeline_buckets;
+    const phases = useSpeech ? speechPhases : pipelinePhases;
+    const latencyTitle = useSpeech
+      ? "Speech end to first output"
+      : "Pipeline first output";
+    const coverageDetail = useSpeech
+      ? "Includes speech detection, turn-end, and Pipeline phases."
+      : "Pipeline invocation to first content output.";
+
+    panel.querySelector("[data-channel-summary]").replaceChildren(
+      card("Requests", String(pipelineSummary.total_requests), `${pipelineSummary.error_count} errors`),
+      card("Average first output", seconds(summary.avg_first_response_time)),
+      card("Median first output", seconds(summary.p50_first_response_time)),
+      card("P95 first output", seconds(summary.p95_first_response_time)),
+    );
+    panel.querySelector("[data-latency-title]").textContent = latencyTitle;
+    panel.querySelector("[data-coverage]").textContent = `${coverage(summary)} ${coverageDetail}`;
+
+    const latencyEmpty = panel.querySelector("[data-latency-empty]");
+    const latencyChart = panel.querySelector("[data-latency-chart]");
+    latencyEmpty.hidden = summary.measured_count !== 0;
+    latencyChart.hidden = summary.measured_count === 0;
+
+    channelContainer.append(panel);
+
+    if (summary.measured_count !== 0) {
+      charts.push(createChart(
+        panel.querySelector("[data-latency-chart] canvas"),
+        buckets,
+        phases,
+      ));
+    }
   }
 
   async function load(event) {
@@ -71,85 +185,37 @@ export function renderMetrics(root, { api, setStatus }) {
     const interval = form.interval.value;
     setStatus("Loading metrics…");
     try {
-      const [summary, timeline] = await Promise.all([
-        api.get(`metrics/summary?period=${encodeURIComponent(period)}`),
-        api.get(`metrics/timeline?period=${encodeURIComponent(period)}&interval=${encodeURIComponent(interval)}`),
-      ]);
-      if (stopped) return;
-      cards.replaceChildren(
-        card("Requests", String(summary.total_requests), `${summary.error_count} errors`),
-        card("Average first response", seconds(summary.avg_first_response_time)),
-        card("Median first response", seconds(summary.p50_first_response_time)),
-        card("P95 first response", seconds(summary.p95_first_response_time)),
+      const metrics = await api.get(
+        `metrics/by-channel?period=${encodeURIComponent(period)}&interval=${encodeURIComponent(interval)}`,
       );
-      const ratio = summary.success_count ? Math.round(summary.measured_count / summary.success_count * 100) : 0;
-      coverage.textContent = `${summary.measured_count} measured / ${summary.success_count} successful (${ratio}% coverage). Older, text-only, and unsupported VAD records are excluded.`;
-      empty.hidden = summary.measured_count !== 0;
-      chartWrap.hidden = summary.measured_count === 0;
-      if (summary.measured_count === 0) {
-        if (chart) chart.destroy();
-        chart = null;
-        setStatus();
-        return;
+      if (stopped) return;
+      clearCharts();
+      cards.replaceChildren(
+        card("Requests", String(metrics.total_requests)),
+        card("Successful", String(metrics.success_count)),
+        card("Errors", String(metrics.error_count)),
+        card("Channels", String(metrics.channels.length)),
+      );
+      channelContainer.replaceChildren();
+      empty.hidden = metrics.channels.length !== 0;
+      const hasMeasurements = metrics.channels.some(item =>
+        item.pipeline_summary.measured_count || item.speech_summary.measured_count
+      );
+      if (hasMeasurements && !window.Chart) {
+        throw new Error("Chart library is unavailable");
       }
-      if (!window.Chart) throw new Error("Chart library is unavailable");
-      if (chart) chart.destroy();
-      const theme = chartTheme();
-      chart = new Chart(root.querySelector("canvas"), {
-        type: "bar",
-        data: {
-          labels: timeline.buckets.map(bucket => new Date(`${bucket.timestamp}Z`).toLocaleString()),
-          datasets: phases.map(([key, label, color]) => ({
-            label,
-            data: timeline.buckets.map(bucket => bucket[key] || 0),
-            backgroundColor: color,
-            stack: "latency",
-          })),
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          interaction: { mode: "index", intersect: false },
-          scales: {
-            x: {
-              stacked: true,
-              grid: { color: theme.grid },
-              ticks: { color: theme.text, maxRotation: 45 },
-            },
-            y: {
-              stacked: true,
-              beginAtZero: true,
-              grid: { color: theme.grid },
-              ticks: { color: theme.text },
-              title: { display: true, text: "Seconds", color: theme.title },
-            },
-          },
-          plugins: {
-            legend: {
-              position: "bottom",
-              labels: { color: theme.title, boxWidth: 12, boxHeight: 12, padding: 16 },
-            },
-            tooltip: {
-              backgroundColor: theme.tooltip,
-              borderColor: theme.tooltipBorder,
-              borderWidth: 1,
-              titleColor: "#fafafa",
-              bodyColor: "#e4e4e7",
-              padding: 10,
-            },
-          },
-        },
-      });
+      metrics.channels.forEach(renderChannel);
       setStatus();
     } catch (error) {
       setStatus(error.message, true);
     }
   }
+
   form.addEventListener("submit", load);
   load();
   return () => {
     stopped = true;
     window.removeEventListener("admin-theme-change", syncChartTheme);
-    if (chart) chart.destroy();
+    clearCharts();
   };
 }

--- a/aiavatar/sts/performance_recorder/base.py
+++ b/aiavatar/sts/performance_recorder/base.py
@@ -43,6 +43,7 @@ class PerformanceRecord:
     stt_after_threshold_time: Optional[float] = None
     turn_end_gate_time: Optional[float] = None
     turn_end_gate_held: Optional[bool] = None
+    channel: str = None
 
 
 class PerformanceRecorder(ABC):

--- a/aiavatar/sts/performance_recorder/postgres.py
+++ b/aiavatar/sts/performance_recorder/postgres.py
@@ -101,6 +101,7 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
                         user_id TEXT,
                         session_id TEXT,
                         context_id TEXT,
+                        channel TEXT,
                         voice_length REAL,
                         speech_end_at TIMESTAMPTZ,
                         silence_threshold_time REAL,
@@ -137,6 +138,7 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
                 await self.add_column_if_not_exist(conn, "user_id")
 
                 await self.add_column_if_not_exist(conn, "session_id")
+                await self.add_column_if_not_exist(conn, "channel")
 
                 # Add transaction_id column if not exist (migration v0.3.3 -> 0.3.4)
                 await self.add_column_if_not_exist(conn, "transaction_id")

--- a/aiavatar/sts/performance_recorder/query.py
+++ b/aiavatar/sts/performance_recorder/query.py
@@ -128,6 +128,15 @@ class DetailedMetricsSummary:
     avg_tts_phase: Optional[float] = None
 
 
+@dataclass
+class ChannelMetrics:
+    channel: Optional[str]
+    pipeline_summary: DetailedMetricsSummary
+    speech_summary: DetailedMetricsSummary
+    pipeline_buckets: List[DetailedTimelineBucket]
+    speech_buckets: List[DetailedTimelineBucket]
+
+
 _DETAILED_PHASE_FIELDS = (
     "avg_silence_detection_phase",
     "avg_streaming_stt_finalization_phase",
@@ -253,28 +262,32 @@ def _build_summary(rows) -> MetricsSummary:
     )
 
 
-def _raw_phase_vector(row, time_origin: str):
-    """Return nine contiguous phases from speech end to first response.
+def _normalized_phase_vector(row, time_origin: str):
+    """Return nine phases ending at the first Pipeline content output.
 
-    Detailed rows are ordered as defined by ``_DETAILED_QUERY_SQL``. Records
-    without a speech-end timestamp, errors, or a first-response endpoint are
-    intentionally excluded from the detailed cohort.
+    The first output is a Quick Response when present, otherwise the first TTS
+    audio chunk, falling back to the first LLM chunk for text-only channels.
+    Rows without ``speech_end_at`` start at Pipeline invocation and therefore
+    have zero-valued pre-Pipeline phases.
     """
-    if row[12] or row[1] is None:
+    if row[12]:
         return None
 
     def positive(value):
         return max(float(value or 0), 0.0)
 
-    # Validate the actual stored endpoint before carrying missing intermediate
-    # boundaries forward. Otherwise a silence timing alone can be mistaken for
-    # a completed first-response measurement.
-    endpoint_index = 7 if row[11] else 10
-    if positive(row[endpoint_index]) <= 0:
+    if row[11] and positive(row[7]) > 0:
+        endpoint_index = 6  # before_llm_time
+    elif positive(row[10]) > 0:
+        endpoint_index = 9  # tts_first_chunk_time
+    elif positive(row[8]) > 0:
+        endpoint_index = 7  # llm_first_chunk_time
+    else:
         return None
 
-    stored_origin = time_origin
-    if time_origin == TIME_ORIGIN_USER_SPEECH_END:
+    has_speech_origin = row[1] is not None
+    stored_origin = time_origin if has_speech_origin else TIME_ORIGIN_PIPELINE_START
+    if has_speech_origin and time_origin == TIME_ORIGIN_USER_SPEECH_END:
         # Timing columns added before origin rebasing may coexist with newer
         # rows in the same table. A decreasing, explicitly stored VAD boundary
         # identifies an older pipeline-relative row without guessing from the
@@ -290,9 +303,9 @@ def _raw_phase_vector(row, time_origin: str):
             previous = current
 
     if stored_origin == TIME_ORIGIN_PIPELINE_START:
-        silence = positive(row[2])
-        streaming_stt = positive(row[3])
-        turn_end_gate = positive(row[4])
+        silence = positive(row[2]) if has_speech_origin else 0.0
+        streaming_stt = positive(row[3]) if has_speech_origin else 0.0
+        turn_end_gate = positive(row[4]) if has_speech_origin else 0.0
         pre_pipeline = silence + streaming_stt + turn_end_gate
         points = [
             0.0,
@@ -326,7 +339,6 @@ def _raw_phase_vector(row, time_origin: str):
     for index in range(1, len(points)):
         points[index] = max(points[index], points[index - 1])
 
-    endpoint_index = 6 if row[11] else 9
     if points[endpoint_index] <= 0:
         return None
     points = points[:endpoint_index + 1]
@@ -334,13 +346,33 @@ def _raw_phase_vector(row, time_origin: str):
     return [points[index + 1] - points[index] for index in range(9)]
 
 
+def _raw_phase_vector(row, time_origin: str):
+    """Return speech-end phases for the existing aggregate and Logs APIs."""
+    if row[1] is None:
+        return None
+    return _normalized_phase_vector(row, time_origin)
+
+
 def _phase_vector(row, time_origin: str):
     """Return the nine display phases used by aggregate metrics."""
     return _raw_phase_vector(row, time_origin)
 
 
-def _detailed_values(rows, time_origin: str):
-    vectors = [vector for row in rows if (vector := _phase_vector(row, time_origin)) is not None]
+def _pipeline_phase_vector(row, time_origin: str):
+    vector = _normalized_phase_vector(row, time_origin)
+    if vector is None:
+        return None
+    return [0.0, 0.0, 0.0, *vector[3:]]
+
+
+def _speech_phase_vector(row, time_origin: str):
+    if row[1] is None or row[2] is None:
+        return None
+    return _normalized_phase_vector(row, time_origin)
+
+
+def _detailed_values(rows, time_origin: str, vector_builder=_phase_vector):
+    vectors = [vector for row in rows if (vector := vector_builder(row, time_origin)) is not None]
     if not vectors:
         return 0, None, [None] * len(_DETAILED_PHASE_FIELDS), []
     phase_averages = [
@@ -351,14 +383,22 @@ def _detailed_values(rows, time_origin: str):
     return len(vectors), _safe_avg(first_response_times), phase_averages, first_response_times
 
 
-def _detailed_fields(rows, time_origin: str):
-    measured_count, average, phase_averages, first_response_times = _detailed_values(rows, time_origin)
+def _detailed_fields(rows, time_origin: str, vector_builder=_phase_vector):
+    measured_count, average, phase_averages, first_response_times = _detailed_values(
+        rows, time_origin, vector_builder
+    )
     values = dict(zip(_DETAILED_PHASE_FIELDS, phase_averages))
     values.update(measured_count=measured_count, avg_first_response_time=average)
     return values, first_response_times
 
 
-def _build_detailed_timeline(rows, interval_seconds: int, start_time: datetime, time_origin: str):
+def _build_detailed_timeline(
+    rows,
+    interval_seconds: int,
+    start_time: datetime,
+    time_origin: str,
+    vector_builder=_phase_vector,
+):
     data_buckets = {}
     for row in rows:
         data_buckets.setdefault(_bucket_key(row[0], interval_seconds), []).append(row)
@@ -371,7 +411,7 @@ def _build_detailed_timeline(rows, interval_seconds: int, start_time: datetime, 
         key = datetime.fromtimestamp(current_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
         bucket_rows = data_buckets.get(key, [])
         error_count = sum(1 for row in bucket_rows if row[12])
-        values, _ = _detailed_fields(bucket_rows, time_origin)
+        values, _ = _detailed_fields(bucket_rows, time_origin, vector_builder)
         result.append(DetailedTimelineBucket(
             timestamp=key,
             request_count=len(bucket_rows),
@@ -383,9 +423,9 @@ def _build_detailed_timeline(rows, interval_seconds: int, start_time: datetime, 
     return result
 
 
-def _build_detailed_summary(rows, time_origin: str):
+def _build_detailed_summary(rows, time_origin: str, vector_builder=_phase_vector):
     error_count = sum(1 for row in rows if row[12])
-    values, response_times = _detailed_fields(rows, time_origin)
+    values, response_times = _detailed_fields(rows, time_origin, vector_builder)
     sorted_times = sorted(response_times)
     return DetailedMetricsSummary(
         total_requests=len(rows),
@@ -396,6 +436,51 @@ def _build_detailed_summary(rows, time_origin: str):
         p99_first_response_time=percentile(sorted_times, 99),
         **values,
     )
+
+
+def _build_metrics_by_channel(
+    rows,
+    interval_seconds: int,
+    start_time: datetime,
+    time_origin: str,
+) -> List[ChannelMetrics]:
+    rows_by_channel = {}
+    for row in rows:
+        channel = (row[13] if len(row) > 13 else None) or None
+        rows_by_channel.setdefault(channel, []).append(row)
+
+    result = []
+    for channel, channel_rows in sorted(
+        rows_by_channel.items(),
+        key=lambda item: (item[0] is None, item[0] or ""),
+    ):
+        speech_rows = [row for row in channel_rows if row[1] is not None]
+        pipeline_summary = _build_detailed_summary(
+            channel_rows, time_origin, _pipeline_phase_vector
+        )
+        speech_summary = _build_detailed_summary(
+            speech_rows, time_origin, _speech_phase_vector
+        )
+        result.append(ChannelMetrics(
+            channel=channel,
+            pipeline_summary=pipeline_summary,
+            speech_summary=speech_summary,
+            pipeline_buckets=_build_detailed_timeline(
+                channel_rows,
+                interval_seconds,
+                start_time,
+                time_origin,
+                _pipeline_phase_vector,
+            ) if pipeline_summary.measured_count else [],
+            speech_buckets=_build_detailed_timeline(
+                speech_rows,
+                interval_seconds,
+                start_time,
+                time_origin,
+                _speech_phase_vector,
+            ) if speech_summary.measured_count else [],
+        ))
+    return result
 
 
 @dataclass
@@ -450,7 +535,7 @@ _DETAILED_QUERY_SQL = """
 SELECT COALESCE(speech_end_at, created_at) AS event_at,
        speech_end_at, silence_threshold_time, stt_after_threshold_time, turn_end_gate_time,
        stt_time, stop_response_time, before_llm_time, llm_first_chunk_time, llm_first_voice_chunk_time,
-       tts_first_chunk_time, quick_response_text, error_info
+       tts_first_chunk_time, quick_response_text, error_info, channel
 FROM performance_records
 WHERE COALESCE(speech_end_at, created_at) >= ?
 ORDER BY event_at
@@ -481,6 +566,10 @@ class MetricsQuery(ABC):
 
     @abstractmethod
     async def query_detailed_summary(self, period: str) -> DetailedMetricsSummary:
+        pass
+
+    @abstractmethod
+    async def query_metrics_by_channel(self, period: str, interval: str) -> List[ChannelMetrics]:
         pass
 
     @abstractmethod
@@ -666,6 +755,15 @@ class SQLiteMetricsQuery(MetricsQuery):
         rows = await asyncio.to_thread(self._fetch_detailed_rows, start_time)
         return _build_detailed_summary(rows, self.time_origin)
 
+    async def query_metrics_by_channel(self, period: str, interval: str) -> List[ChannelMetrics]:
+        if interval not in VALID_INTERVALS:
+            raise ValueError(f"Invalid interval: {interval}. Must be one of {VALID_INTERVALS}")
+        start_time = datetime.now(timezone.utc) - parse_period(period)
+        rows = await asyncio.to_thread(self._fetch_detailed_rows, start_time)
+        return _build_metrics_by_channel(
+            rows, INTERVAL_SECONDS[interval], start_time, self.time_origin
+        )
+
     async def query_logs(
         self,
         limit: int,
@@ -738,7 +836,7 @@ class PostgreSQLMetricsQuery(MetricsQuery):
         SELECT COALESCE(speech_end_at, created_at) AS event_at,
                speech_end_at, silence_threshold_time, stt_after_threshold_time, turn_end_gate_time,
                stt_time, stop_response_time, before_llm_time, llm_first_chunk_time, llm_first_voice_chunk_time,
-               tts_first_chunk_time, quick_response_text, error_info
+               tts_first_chunk_time, quick_response_text, error_info, channel
         FROM performance_records
         WHERE COALESCE(speech_end_at, created_at) >= $1
         ORDER BY event_at
@@ -749,7 +847,7 @@ class PostgreSQLMetricsQuery(MetricsQuery):
             "event_at", "speech_end_at", "silence_threshold_time", "stt_after_threshold_time",
             "turn_end_gate_time", "stt_time", "stop_response_time", "before_llm_time",
             "llm_first_chunk_time", "llm_first_voice_chunk_time", "tts_first_chunk_time",
-            "quick_response_text", "error_info",
+            "quick_response_text", "error_info", "channel",
         )
         return [tuple(record[column] for column in columns) for record in records]
 
@@ -823,6 +921,15 @@ class PostgreSQLMetricsQuery(MetricsQuery):
         start_time = datetime.now(timezone.utc) - parse_period(period)
         rows = await self._fetch_detailed_rows(start_time)
         return _build_detailed_summary(rows, self.time_origin)
+
+    async def query_metrics_by_channel(self, period: str, interval: str) -> List[ChannelMetrics]:
+        if interval not in VALID_INTERVALS:
+            raise ValueError(f"Invalid interval: {interval}. Must be one of {VALID_INTERVALS}")
+        start_time = datetime.now(timezone.utc) - parse_period(period)
+        rows = await self._fetch_detailed_rows(start_time)
+        return _build_metrics_by_channel(
+            rows, INTERVAL_SECONDS[interval], start_time, self.time_origin
+        )
 
     async def query_logs(
         self,

--- a/aiavatar/sts/performance_recorder/sqlite.py
+++ b/aiavatar/sts/performance_recorder/sqlite.py
@@ -39,6 +39,7 @@ class SQLitePerformanceRecorder(PerformanceRecorder):
                         user_id TEXT,
                         session_id TEXT,
                         context_id TEXT,
+                        channel TEXT,
                         voice_length REAL,
                         speech_end_at TIMESTAMP,
                         silence_threshold_time REAL,
@@ -81,6 +82,9 @@ class SQLitePerformanceRecorder(PerformanceRecorder):
 
                 if "session_id" not in columns:
                     conn.execute("ALTER TABLE performance_records ADD COLUMN session_id TEXT")
+
+                if "channel" not in columns:
+                    conn.execute("ALTER TABLE performance_records ADD COLUMN channel TEXT")
 
                 # Add transaction_id column if not exist (migration v0.3.3 -> 0.3.4)
                 if "transaction_id" not in columns:

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -473,6 +473,7 @@ class STSPipeline:
                 transaction_id=request.transaction_id,
                 user_id=request.user_id,
                 session_id=request.session_id,
+                channel=hook_channel,
                 stt_name=self.stt.__class__.__name__,
                 llm_name=self.llm.__class__.__name__,
                 tts_name=self.tts.__class__.__name__

--- a/tests/admin/test_admin.py
+++ b/tests/admin/test_admin.py
@@ -81,6 +81,7 @@ def test_new_admin_uses_one_replaceable_authenticator_and_new_routes(tmp_path):
             user_id="user",
             session_id="session-new",
             context_id="context",
+            channel="websocket",
             request_text="hello admin",
             speech_end_at=datetime.now(timezone.utc),
             silence_threshold_time=0.1,
@@ -92,6 +93,15 @@ def test_new_admin_uses_one_replaceable_authenticator_and_new_routes(tmp_path):
             llm_first_chunk_time=0.4,
             llm_first_voice_chunk_time=0.5,
             tts_first_chunk_time=0.6,
+        ))
+        recorder.record(PerformanceRecord(
+            transaction_id="cccccccc-cccc-cccc-cccc-cccccccccccc",
+            session_id="session-text",
+            context_id="context-text",
+            channel="linebot",
+            request_text="hello text",
+            before_llm_time=0.1,
+            llm_first_chunk_time=0.2,
         ))
         recorder.record_queue.join()
 
@@ -108,6 +118,22 @@ def test_new_admin_uses_one_replaceable_authenticator_and_new_routes(tmp_path):
         assert client.get("/admin/assets/admin-app.js", auth=auth).status_code == 200
         assert client.get("/admin/api/capabilities", auth=auth).json() == {"evaluation": False}
         assert client.get("/admin/api/metrics/summary", auth=auth).status_code == 200
+        channel_metrics = client.get(
+            "/admin/api/metrics/by-channel?period=24h&interval=1h",
+            auth=auth,
+        )
+        assert channel_metrics.status_code == 200
+        metrics = channel_metrics.json()
+        assert metrics["total_requests"] == 2
+        by_channel = {item["channel"]: item for item in metrics["channels"]}
+        assert by_channel["linebot"]["pipeline_summary"]["avg_first_response_time"] == pytest.approx(0.2)
+        assert by_channel["linebot"]["speech_summary"]["measured_count"] == 0
+        assert by_channel["websocket"]["pipeline_summary"]["avg_first_response_time"] == pytest.approx(0.6)
+        assert by_channel["websocket"]["speech_summary"]["avg_first_response_time"] == pytest.approx(0.9)
+        assert client.get(
+            "/admin/api/metrics/by-channel?period=24h&interval=invalid",
+            auth=auth,
+        ).status_code == 400
         logs = client.get("/admin/api/logs?session_id=session-new", auth=auth)
         assert logs.status_code == 200
         log = logs.json()["groups"][0]["logs"][0]

--- a/tests/sts/performance_recorder/test_pipeline_vad_performance.py
+++ b/tests/sts/performance_recorder/test_pipeline_vad_performance.py
@@ -61,6 +61,7 @@ async def test_pipeline_copies_optional_vad_performance(
         response
         async for response in pipeline.invoke(STSRequest(
             session_id="session",
+            channel="websocket",
             text="hello",
             metadata=metadata,
         ))
@@ -69,6 +70,7 @@ async def test_pipeline_copies_optional_vad_performance(
     assert responses[-1].type == "final"
     record = recorder.records[0]
     assert record.session_id == "session"
+    assert record.channel == "websocket"
     assert record.silence_threshold_time == expected_threshold
     if metadata is None:
         assert record.speech_end_at is None

--- a/tests/sts/performance_recorder/test_postgres_performance_recorder.py
+++ b/tests/sts/performance_recorder/test_postgres_performance_recorder.py
@@ -56,6 +56,7 @@ async def test_record_single(recorder, unique_transaction_id):
         transaction_id=unique_transaction_id,
         user_id="test_user",
         context_id="test_context",
+        channel="websocket",
         stt_name="test_stt",
         llm_name="test_llm",
         tts_name="test_tts",
@@ -81,6 +82,7 @@ async def test_record_single(recorder, unique_transaction_id):
         assert row is not None
         assert row["user_id"] == "test_user"
         assert row["context_id"] == "test_context"
+        assert row["channel"] == "websocket"
         assert row["request_text"] == "Hello, world!"
         assert row["response_text"] == "Hi there!"
         assert row["stt_name"] == "test_stt"
@@ -152,6 +154,7 @@ async def test_record_with_none_values(recorder, unique_transaction_id):
         assert row is not None
         assert row["user_id"] is None
         assert row["context_id"] is None
+        assert row["channel"] is None
         assert row["request_text"] is None
         assert row["response_text"] is None
     finally:
@@ -205,6 +208,13 @@ async def test_init_db_creates_table(recorder):
             """
         )
         assert row is not None
+        channel = await conn.fetchrow(
+            """
+            SELECT column_name FROM information_schema.columns
+            WHERE table_name = 'performance_records' AND column_name = 'channel'
+            """
+        )
+        assert channel is not None
     finally:
         await conn.close()
 

--- a/tests/sts/performance_recorder/test_query.py
+++ b/tests/sts/performance_recorder/test_query.py
@@ -622,6 +622,65 @@ async def test_detailed_summary_excludes_silence_only_record(recorder, query):
 
 
 @pytest.mark.asyncio
+async def test_metrics_by_channel_separates_pipeline_and_speech_latency(recorder, query):
+    recorder.record(PerformanceRecord(
+        transaction_id="text",
+        channel="linebot",
+        stop_response_time=0.05,
+        before_llm_time=0.1,
+        llm_first_chunk_time=0.25,
+    ))
+    recorder.record(PerformanceRecord(
+        transaction_id="voice",
+        channel="websocket",
+        speech_end_at=datetime.now(timezone.utc),
+        silence_threshold_time=0.1,
+        stt_after_threshold_time=0.1,
+        turn_end_gate_time=0.1,
+        stt_time=0.1,
+        stop_response_time=0.2,
+        before_llm_time=0.3,
+        llm_first_chunk_time=0.4,
+        llm_first_voice_chunk_time=0.5,
+        tts_first_chunk_time=0.6,
+    ))
+    recorder.record(PerformanceRecord(
+        transaction_id="partial-speech",
+        channel="partial",
+        speech_end_at=datetime.now(timezone.utc),
+        llm_first_chunk_time=0.2,
+    ))
+    recorder.record_queue.join()
+
+    result = await query.query_metrics_by_channel("1h", "1m")
+    by_channel = {metrics.channel: metrics for metrics in result}
+
+    text = by_channel["linebot"]
+    assert text.pipeline_summary.total_requests == 1
+    assert text.pipeline_summary.measured_count == 1
+    assert text.pipeline_summary.avg_first_response_time == pytest.approx(0.25)
+    assert text.pipeline_summary.avg_llm_phase == pytest.approx(0.15)
+    assert text.pipeline_summary.avg_tts_phase == 0
+    assert text.speech_summary.total_requests == 0
+    assert text.speech_summary.measured_count == 0
+    assert text.speech_buckets == []
+
+    partial = by_channel["partial"]
+    assert partial.pipeline_summary.measured_count == 1
+    assert partial.speech_summary.total_requests == 1
+    assert partial.speech_summary.measured_count == 0
+
+    voice = by_channel["websocket"]
+    assert voice.pipeline_summary.measured_count == 1
+    assert voice.pipeline_summary.avg_first_response_time == pytest.approx(0.6)
+    assert voice.pipeline_summary.avg_silence_detection_phase == 0
+    assert voice.pipeline_summary.avg_stt_phase == pytest.approx(0.1)
+    assert voice.speech_summary.measured_count == 1
+    assert voice.speech_summary.avg_first_response_time == pytest.approx(0.9)
+    assert voice.speech_summary.avg_silence_detection_phase == pytest.approx(0.1)
+
+
+@pytest.mark.asyncio
 async def test_query_logs_filters_and_includes_session_id(recorder, query):
     records = [
         PerformanceRecord(transaction_id="a", user_id="u1", session_id="s1", context_id="c1", request_text="hello tokyo"),

--- a/tests/sts/performance_recorder/test_query_postgres.py
+++ b/tests/sts/performance_recorder/test_query_postgres.py
@@ -366,6 +366,36 @@ async def test_query_summary_excludes_errors(recorder, query, test_marker):
     assert error == 1
 
 
+# ========== channel metrics tests ==========
+
+@pytest.mark.asyncio
+async def test_metrics_by_channel_includes_text_and_speech_rows(recorder, query, test_marker):
+    recorder.record(PerformanceRecord(
+        transaction_id=f"text-{uuid4()}",
+        user_id=test_marker,
+        channel=test_marker,
+        llm_first_chunk_time=0.2,
+    ))
+    recorder.record(PerformanceRecord(
+        transaction_id=f"voice-{uuid4()}",
+        user_id=test_marker,
+        channel=test_marker,
+        speech_end_at=datetime.now(timezone.utc),
+        silence_threshold_time=0.1,
+        stt_after_threshold_time=0.1,
+        turn_end_gate_time=0.1,
+        tts_first_chunk_time=0.6,
+    ))
+    recorder.record_queue.join()
+
+    result = await query.query_metrics_by_channel("1h", "1m")
+    metrics = next(item for item in result if item.channel == test_marker)
+    assert metrics.pipeline_summary.total_requests == 2
+    assert metrics.pipeline_summary.measured_count == 2
+    assert metrics.speech_summary.total_requests == 1
+    assert metrics.speech_summary.measured_count == 1
+
+
 # ========== query_logs tests ==========
 
 @pytest.mark.asyncio

--- a/tests/sts/performance_recorder/test_sqlite_performance_recorder.py
+++ b/tests/sts/performance_recorder/test_sqlite_performance_recorder.py
@@ -36,6 +36,7 @@ def test_record_single(recorder, db_path, unique_transaction_id):
         transaction_id=unique_transaction_id,
         user_id="test_user",
         context_id="test_context",
+        channel="websocket",
         stt_name="test_stt",
         llm_name="test_llm",
         tts_name="test_tts",
@@ -63,6 +64,7 @@ def test_record_single(recorder, db_path, unique_transaction_id):
         assert row is not None
         assert row["user_id"] == "test_user"
         assert row["context_id"] == "test_context"
+        assert row["channel"] == "websocket"
         assert row["request_text"] == "Hello, world!"
         assert row["response_text"] == "Hi there!"
         assert row["stt_name"] == "test_stt"
@@ -136,6 +138,7 @@ def test_record_with_none_values(recorder, db_path, unique_transaction_id):
         assert row is not None
         assert row["user_id"] is None
         assert row["context_id"] is None
+        assert row["channel"] is None
         assert row["request_text"] is None
         assert row["response_text"] is None
     finally:
@@ -231,7 +234,7 @@ def test_default_db_path():
             os.remove(default_path)
 
 
-def test_migrates_session_id_without_backfill(tmp_path):
+def test_migrates_session_id_and_channel_without_backfill(tmp_path):
     db_path = tmp_path / "legacy.db"
     conn = sqlite3.connect(db_path)
     try:
@@ -256,9 +259,14 @@ def test_migrates_session_id_without_backfill(tmp_path):
         legacy_session = conn.execute(
             "SELECT session_id FROM performance_records WHERE transaction_id = 'legacy'"
         ).fetchone()[0]
+        legacy_channel = conn.execute(
+            "SELECT channel FROM performance_records WHERE transaction_id = 'legacy'"
+        ).fetchone()[0]
         indexes = {row[1] for row in conn.execute("PRAGMA index_list(performance_records)")}
     finally:
         conn.close()
     assert "session_id" in columns
+    assert "channel" in columns
     assert legacy_session is None
+    assert legacy_channel is None
     assert "idx_session_id" in indexes

--- a/tests/sts/performance_recorder/test_vad_performance_fields.py
+++ b/tests/sts/performance_recorder/test_vad_performance_fields.py
@@ -28,6 +28,7 @@ def test_sqlite_fresh_schema_orders_timing_columns_from_speech_end(tmp_path):
         "user_id",
         "session_id",
         "context_id",
+        "channel",
         "voice_length",
         "speech_end_at",
         "silence_threshold_time",


### PR DESCRIPTION
Record request channels in performance data and add automatic schema migration. Include text-only records using pipeline latency and show one latency chart per channel.