### PR TITLE
Add channel filtering to admin logs

### DIFF
--- a/aiavatar/admin/README.md
+++ b/aiavatar/admin/README.md
@@ -87,6 +87,7 @@ The following filters are available. All specified conditions are combined with 
 - User ID: exact match
 - Session ID: exact match
 - Context ID: exact match
+- Channel: exact transaction match; returns contexts containing at least one matching transaction
 - Keyword: searches request, response, voice response, quick response, error, and tool-call data
 - Error presence
 - Limit: 1–10,000; default 200
@@ -95,7 +96,7 @@ The limit applies to the number of messages retrieved. The messages are then gro
 
 The drawer displays:
 
-- Timestamp, Session ID, User ID, Context ID, and Transaction ID
+- Timestamp, Channel, Session ID, User ID, Context ID, and Transaction ID
 - Request, Response, Error, and Tool calls
 - First-response time and the detailed nine-phase breakdown for each turn
 - Request and Response audio playback

--- a/aiavatar/admin/logs.py
+++ b/aiavatar/admin/logs.py
@@ -34,6 +34,7 @@ class ConversationLogResponse(BaseModel):
     user_id: Optional[str] = None
     session_id: Optional[str] = None
     context_id: Optional[str] = None
+    channel: Optional[str] = None
     tts_first_chunk_time: Optional[float] = None
     before_llm_time: Optional[float] = None
     quick_response_text: Optional[str] = None
@@ -72,6 +73,7 @@ class LogsAPI:
             user_id: Optional[str] = Query(None),
             session_id: Optional[str] = Query(None),
             context_id: Optional[str] = Query(None),
+            channel: Optional[str] = Query(None),
             has_error: Optional[bool] = Query(None),
             keyword: Optional[str] = Query(None, max_length=500),
         ) -> LogsResponse:
@@ -81,6 +83,7 @@ class LogsAPI:
                     user_id=user_id,
                     session_id=session_id,
                     context_id=context_id,
+                    channel=channel,
                     has_error=has_error,
                     keyword=keyword,
                 )

--- a/aiavatar/admin/static/logs-view.js
+++ b/aiavatar/admin/static/logs-view.js
@@ -68,6 +68,7 @@ function renderLog(log, { voiceRecorderEnabled, playVoice }) {
   meta.className = "meta";
   const values = [
     `time: ${log.created_at || "—"}`,
+    `channel: ${log.channel || "Unclassified"}`,
     `session: ${log.session_id || "—"}`,
     `user: ${log.user_id || "—"}`,
     `context: ${log.context_id || "—"}`,
@@ -157,6 +158,7 @@ export function renderLogs(root, { api, setStatus }) {
       <div class="field grow"><label for="logs-user">User ID</label><input id="logs-user" name="user_id" autocomplete="off"></div>
       <div class="field grow"><label for="logs-session">Session ID</label><input id="logs-session" name="session_id" autocomplete="off"></div>
       <div class="field grow"><label for="logs-context">Context ID</label><input id="logs-context" name="context_id" autocomplete="off"></div>
+      <div class="field grow"><label for="logs-channel">Channel</label><input id="logs-channel" name="channel" autocomplete="off"></div>
       <div class="field grow"><label for="logs-keyword">Keyword</label><input id="logs-keyword" name="keyword" autocomplete="off" placeholder="request, response, error, tool call"></div>
       <div class="field"><label for="logs-error">Error</label><select id="logs-error" name="has_error"><option value="">All</option><option value="true">With error</option><option value="false">Without error</option></select></div>
       <div class="field"><label for="logs-limit">Limit</label><input id="logs-limit" name="limit" type="number" min="1" max="10000" value="200"></div>
@@ -299,7 +301,7 @@ export function renderLogs(root, { api, setStatus }) {
   async function load(event) {
     event?.preventDefault();
     const params = new URLSearchParams();
-    for (const name of ["user_id", "session_id", "context_id", "keyword", "has_error", "limit"]) {
+    for (const name of ["user_id", "session_id", "context_id", "channel", "keyword", "has_error", "limit"]) {
       const value = form.elements[name].value.trim();
       if (value) params.set(name, value);
     }

--- a/aiavatar/sts/performance_recorder/postgres.py
+++ b/aiavatar/sts/performance_recorder/postgres.py
@@ -188,6 +188,10 @@ class PostgreSQLPerformanceRecorder(PerformanceRecorder):
                 await conn.execute("CREATE INDEX IF NOT EXISTS idx_user_id ON performance_records (user_id)")
                 await conn.execute("CREATE INDEX IF NOT EXISTS idx_session_id ON performance_records (session_id)")
                 await conn.execute("CREATE INDEX IF NOT EXISTS idx_context_id ON performance_records (context_id)")
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_channel_context_id "
+                    "ON performance_records (channel, context_id)"
+                )
 
                 self._db_initialized = True
 

--- a/aiavatar/sts/performance_recorder/query.py
+++ b/aiavatar/sts/performance_recorder/query.py
@@ -500,6 +500,7 @@ class ConversationLog:
     error_info: Optional[str] = None
     tool_calls: Optional[str] = None
     timing_breakdown: Optional["TurnTimingBreakdown"] = None
+    channel: Optional[str] = None
 
 
 @dataclass
@@ -546,8 +547,8 @@ SELECT COALESCE(speech_end_at, created_at) AS event_at,
        transaction_id, user_id, session_id, context_id, tts_first_chunk_time, before_llm_time, quick_response_text,
        request_text, request_files, response_text, response_voice_text, error_info, tool_calls,
        speech_end_at, silence_threshold_time, stt_after_threshold_time, turn_end_gate_time,
-       stt_time, stop_response_time, llm_first_chunk_time, llm_first_voice_chunk_time
-FROM performance_records
+       stt_time, stop_response_time, llm_first_chunk_time, llm_first_voice_chunk_time, channel
+FROM performance_records AS records
 """
 
 
@@ -580,6 +581,7 @@ class MetricsQuery(ABC):
         user_id: str = None,
         session_id: str = None,
         context_id: str = None,
+        channel: str = None,
         has_error: bool = None,
         keyword: str = None,
     ) -> List[ConversationGroup]:
@@ -617,6 +619,7 @@ def _group_logs(rows, time_origin: str) -> List[ConversationGroup]:
             user_id=row[2],
             session_id=row[3],
             context_id=row[4],
+            channel=row[22],
             tts_first_chunk_time=row[5],
             before_llm_time=row[6],
             quick_response_text=row[7],
@@ -702,15 +705,29 @@ class SQLiteMetricsQuery(MetricsQuery):
         user_id: str = None,
         session_id: str = None,
         context_id: str = None,
+        channel: str = None,
         has_error: bool = None,
         keyword: str = None,
     ):
         clauses = []
         params = []
-        for column, value in (("user_id", user_id), ("session_id", session_id), ("context_id", context_id)):
+        for column, value in (
+            ("user_id", user_id),
+            ("session_id", session_id),
+            ("context_id", context_id),
+        ):
             if value:
                 clauses.append(f"{column} = ?")
                 params.append(value)
+        if channel:
+            clauses.append(
+                "COALESCE(records.context_id, '') IN ("
+                "SELECT COALESCE(channel_records.context_id, '') "
+                "FROM performance_records AS channel_records "
+                "WHERE channel_records.channel = ?"
+                ")"
+            )
+            params.append(channel)
         if has_error is True:
             clauses.append("error_info IS NOT NULL AND error_info <> ''")
         elif has_error is False:
@@ -771,11 +788,19 @@ class SQLiteMetricsQuery(MetricsQuery):
         user_id: str = None,
         session_id: str = None,
         context_id: str = None,
+        channel: str = None,
         has_error: bool = None,
         keyword: str = None,
     ) -> List[ConversationGroup]:
         rows = await asyncio.to_thread(
-            self._fetch_logs, limit, user_id, session_id, context_id, has_error, keyword
+            self._fetch_logs,
+            limit,
+            user_id,
+            session_id,
+            context_id,
+            channel,
+            has_error,
+            keyword,
         )
         return _group_logs(rows, self.time_origin)
 
@@ -857,6 +882,7 @@ class PostgreSQLMetricsQuery(MetricsQuery):
         user_id: str = None,
         session_id: str = None,
         context_id: str = None,
+        channel: str = None,
         has_error: bool = None,
         keyword: str = None,
     ):
@@ -867,9 +893,22 @@ class PostgreSQLMetricsQuery(MetricsQuery):
             params.append(value)
             return f"${len(params)}"
 
-        for column, value in (("user_id", user_id), ("session_id", session_id), ("context_id", context_id)):
+        for column, value in (
+            ("user_id", user_id),
+            ("session_id", session_id),
+            ("context_id", context_id),
+        ):
             if value:
                 clauses.append(f"{column} = {bind(value)}")
+        if channel:
+            channel_marker = bind(channel)
+            clauses.append(
+                "COALESCE(records.context_id, '') IN ("
+                "SELECT COALESCE(channel_records.context_id, '') "
+                "FROM performance_records AS channel_records "
+                f"WHERE channel_records.channel = {channel_marker}"
+                ")"
+            )
         if has_error is True:
             clauses.append("error_info IS NOT NULL AND error_info <> ''")
         elif has_error is False:
@@ -895,6 +934,7 @@ class PostgreSQLMetricsQuery(MetricsQuery):
             "request_files", "response_text", "response_voice_text", "error_info", "tool_calls",
             "speech_end_at", "silence_threshold_time", "stt_after_threshold_time", "turn_end_gate_time",
             "stt_time", "stop_response_time", "llm_first_chunk_time", "llm_first_voice_chunk_time",
+            "channel",
         )
         return [tuple(record[column] for column in columns) for record in records]
 
@@ -938,11 +978,12 @@ class PostgreSQLMetricsQuery(MetricsQuery):
         user_id: str = None,
         session_id: str = None,
         context_id: str = None,
+        channel: str = None,
         has_error: bool = None,
         keyword: str = None,
     ) -> List[ConversationGroup]:
         rows = await self._fetch_filtered_logs(
-            limit, user_id, session_id, context_id, has_error, keyword
+            limit, user_id, session_id, context_id, channel, has_error, keyword
         )
         return _group_logs(rows, self.time_origin)
 

--- a/aiavatar/sts/performance_recorder/sqlite.py
+++ b/aiavatar/sts/performance_recorder/sqlite.py
@@ -132,6 +132,10 @@ class SQLitePerformanceRecorder(PerformanceRecorder):
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_user_id ON performance_records (user_id)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_session_id ON performance_records (session_id)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_context_id ON performance_records (context_id)")
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_channel_context_id "
+                    "ON performance_records (channel, context_id)"
+                )
 
         finally:
             conn.close()

--- a/tests/admin/test_admin.py
+++ b/tests/admin/test_admin.py
@@ -97,7 +97,7 @@ def test_new_admin_uses_one_replaceable_authenticator_and_new_routes(tmp_path):
         recorder.record(PerformanceRecord(
             transaction_id="cccccccc-cccc-cccc-cccc-cccccccccccc",
             session_id="session-text",
-            context_id="context-text",
+            context_id="context",
             channel="linebot",
             request_text="hello text",
             before_llm_time=0.1,
@@ -138,6 +138,12 @@ def test_new_admin_uses_one_replaceable_authenticator_and_new_routes(tmp_path):
         assert logs.status_code == 200
         log = logs.json()["groups"][0]["logs"][0]
         assert log["session_id"] == "session-new"
+        assert log["channel"] == "websocket"
+        linebot_logs = client.get("/admin/api/logs?channel=linebot", auth=auth)
+        assert linebot_logs.status_code == 200
+        context_logs = linebot_logs.json()["groups"][0]["logs"]
+        assert {item["session_id"] for item in context_logs} == {"session-new", "session-text"}
+        assert {item["channel"] for item in context_logs} == {"websocket", "linebot"}
         timing = log["timing_breakdown"]
         assert timing["total_first_response"] == pytest.approx(0.9)
         assert [

--- a/tests/sts/performance_recorder/test_postgres_performance_recorder.py
+++ b/tests/sts/performance_recorder/test_postgres_performance_recorder.py
@@ -239,6 +239,7 @@ async def test_init_db_creates_indexes(recorder):
         assert "idx_transaction_id" in index_names
         assert "idx_user_id" in index_names
         assert "idx_context_id" in index_names
+        assert "idx_channel_context_id" in index_names
     finally:
         await conn.close()
 

--- a/tests/sts/performance_recorder/test_query.py
+++ b/tests/sts/performance_recorder/test_query.py
@@ -683,18 +683,28 @@ async def test_metrics_by_channel_separates_pipeline_and_speech_latency(recorder
 @pytest.mark.asyncio
 async def test_query_logs_filters_and_includes_session_id(recorder, query):
     records = [
-        PerformanceRecord(transaction_id="a", user_id="u1", session_id="s1", context_id="c1", request_text="hello tokyo"),
-        PerformanceRecord(transaction_id="b", user_id="u1", session_id="s2", context_id="c1", response_text="hello osaka", error_info="boom"),
-        PerformanceRecord(transaction_id="c", user_id="u2", session_id="s1", context_id="c2", tool_calls='[{"name":"weather"}]'),
+        PerformanceRecord(transaction_id="a", user_id="u1", session_id="s1", context_id="c1", channel="linebot", request_text="hello tokyo"),
+        PerformanceRecord(transaction_id="b", user_id="u1", session_id="s2", context_id="c1", channel="websocket", response_text="hello osaka", error_info="boom"),
+        PerformanceRecord(transaction_id="c", user_id="u2", session_id="s1", context_id="c2", channel="phone", tool_calls='[{"name":"weather"}]'),
     ]
     for record in records:
         recorder.record(record)
     recorder.record_queue.join()
 
-    result = await query.query_logs(10, user_id="u1", session_id="s1", keyword="tokyo", has_error=False)
+    result = await query.query_logs(
+        10,
+        user_id="u1",
+        session_id="s1",
+        channel="linebot",
+        keyword="tokyo",
+        has_error=False,
+    )
     assert len(result) == 1
     assert len(result[0].logs) == 1
     assert result[0].logs[0].session_id == "s1"
+    assert result[0].logs[0].channel == "linebot"
+    channel_result = await query.query_logs(10, channel="linebot")
+    assert {log.transaction_id for log in channel_result[0].logs} == {"a", "b"}
     assert (await query.query_logs(10, has_error=True))[0].logs[0].transaction_id == "b"
     assert (await query.query_logs(10, keyword="weather"))[0].logs[0].transaction_id == "c"
 

--- a/tests/sts/performance_recorder/test_query_postgres.py
+++ b/tests/sts/performance_recorder/test_query_postgres.py
@@ -298,6 +298,13 @@ async def test_query_summary_with_data(recorder, query, test_marker):
             stt_time=0.1 * (i + 1),
             tts_first_chunk_time=0.5 * (i + 1),
         ))
+    recorder.record(PerformanceRecord(
+        transaction_id=f"sibling-{uuid4()}",
+        user_id=test_marker,
+        context_id=context_id,
+        channel="another-channel",
+        request_text="Sibling request",
+    ))
 
     recorder.record_queue.join()
 
@@ -402,18 +409,20 @@ async def test_metrics_by_channel_includes_text_and_speech_rows(recorder, query,
 async def test_query_logs_with_data(recorder, query, test_marker):
     """Test logs query with actual data"""
     context_id = f"ctx_{uuid4()}"
+    channel = f"channel_{uuid4()}"
     for i in range(3):
         recorder.record(PerformanceRecord(
             transaction_id=f"test_txn_{uuid4()}",
             user_id=test_marker,
             context_id=context_id,
+            channel=channel,
             request_text=f"Request {i}",
             response_text=f"Response {i}",
         ))
 
     recorder.record_queue.join()
 
-    result = await query.query_logs(100)
+    result = await query.query_logs(100, channel=channel)
 
     # Find our group by context_id
     our_group = None
@@ -423,7 +432,8 @@ async def test_query_logs_with_data(recorder, query, test_marker):
             break
 
     assert our_group is not None
-    assert len(our_group.logs) == 3
+    assert len(our_group.logs) == 4
+    assert {log.channel for log in our_group.logs} == {channel, "another-channel"}
 
 
 @pytest.mark.asyncio

--- a/tests/sts/performance_recorder/test_sqlite_performance_recorder.py
+++ b/tests/sts/performance_recorder/test_sqlite_performance_recorder.py
@@ -206,6 +206,7 @@ def test_init_db_creates_indexes(recorder, db_path):
         assert "idx_user_id" in index_names
         assert "idx_session_id" in index_names
         assert "idx_context_id" in index_names
+        assert "idx_channel_context_id" in index_names
     finally:
         conn.close()
 
@@ -270,3 +271,4 @@ def test_migrates_session_id_and_channel_without_backfill(tmp_path):
     assert legacy_session is None
     assert legacy_channel is None
     assert "idx_session_id" in indexes
+    assert "idx_channel_context_id" in indexes


### PR DESCRIPTION
Show channels in transaction details and filter contexts by contained channels. Add a channel-context index for efficient log searches.