### PR TITLE
Add session data support to the dummy VAD

### DIFF
--- a/aiavatar/sts/vad/base.py
+++ b/aiavatar/sts/vad/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import asyncio
 from collections import deque
 import logging
-from typing import AsyncGenerator, List, Callable, Awaitable, Optional, Any
+from typing import AsyncGenerator, Dict, List, Callable, Awaitable, Optional, Any
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,7 @@ class SpeechDetector(ABC):
         self._on_recording_started: List[Callable[[str], Awaitable[None]]] = []
         self._on_voiced: List[Callable[[str], Awaitable[None]]] = []
         self._should_trigger_recording_started: Optional[Callable[[Optional[str], Any], bool]] = None
+        self._session_data: Dict[str, Dict[str, Any]] = {}
         # Parameters for on_recording_started trigger
         self.on_recording_started_min_duration = on_recording_started_min_duration
         self.on_recording_started_min_text_length = on_recording_started_min_text_length
@@ -150,6 +151,28 @@ class SpeechDetector(ABC):
                 pass
         return updated
 
+    def get_session_data(self, session_id: str, key: str) -> Any:
+        """Return a value stored for a detector session."""
+        session_data = self._session_data.get(session_id)
+        if session_data is not None:
+            return session_data.get(key)
+
+    def set_session_data(
+        self,
+        session_id: str,
+        key: str,
+        value: Any,
+        create_session: bool = False,
+    ) -> None:
+        """Store a value for a detector session, optionally creating it."""
+        if create_session:
+            session_data = self._session_data.setdefault(session_id, {})
+        else:
+            session_data = self._session_data.get(session_id)
+
+        if session_data is not None:
+            session_data[key] = value
+
     @abstractmethod
     async def process_samples(self, samples: bytes, session_id: str = None):
         pass
@@ -171,4 +194,4 @@ class SpeechDetectorDummy(SpeechDetector):
         pass
 
     async def finalize_session(self, session_id):
-        pass
+        self._session_data.pop(session_id, None)

--- a/tests/adapter/websocket/test_channel.py
+++ b/tests/adapter/websocket/test_channel.py
@@ -5,6 +5,7 @@ import pytest
 from aiavatar.adapter.models import AIAvatarRequest
 from aiavatar.adapter.websocket.server import AIAvatarWebSocketServer, WebSocketSessionData
 from aiavatar.sts.models import STSResponse
+from aiavatar.sts.vad import SpeechDetectorDummy
 
 
 class FakeVAD:
@@ -24,8 +25,8 @@ class FakeVAD:
 
 
 class FakePipeline:
-    def __init__(self):
-        self.vad = FakeVAD()
+    def __init__(self, vad=None):
+        self.vad = vad or FakeVAD()
         self.response_handlers = []
         self.accepted_hook_channels = []
         self.invoked_requests = []
@@ -123,3 +124,33 @@ async def test_adapter_channel_ignores_client_value_and_sets_pipeline_channel():
     assert all("channel" not in payload for payload in session_start_payloads)
     assert pipeline.vad.get_session_data("session-1", "channel") == "m5stack"
     assert pipeline.invoked_requests[0].channel == "m5stack"
+
+
+@pytest.mark.asyncio
+async def test_dummy_vad_supports_invoke_only_websocket_sessions():
+    pipeline = FakePipeline(vad=SpeechDetectorDummy())
+    server = AIAvatarWebSocketServer(sts=pipeline, channel="websocket_ss")
+    session_data = WebSocketSessionData()
+    websocket = FakeWebSocket(
+        {
+            "type": "start",
+            "session_id": "session-1",
+            "user_id": "user-1",
+            "context_id": "context-1",
+        },
+        {
+            "type": "invoke",
+            "session_id": "session-1",
+            "user_id": "user-1",
+            "text": "hello",
+        },
+    )
+
+    await server.process_websocket(websocket, session_data)
+    await server.process_websocket(websocket, session_data)
+
+    assert pipeline.vad.get_session_data("session-1", "user_id") == "user-1"
+    assert pipeline.vad.get_session_data("session-1", "context_id") == "context-1"
+    assert pipeline.vad.get_session_data("session-1", "channel") == "websocket_ss"
+    assert pipeline.invoked_requests[0].context_id == "context-1"
+    assert pipeline.invoked_requests[0].channel == "websocket_ss"

--- a/tests/sts/vad/test_base.py
+++ b/tests/sts/vad/test_base.py
@@ -1,0 +1,32 @@
+import pytest
+
+from aiavatar.sts.vad import SpeechDetectorDummy
+
+
+def test_dummy_session_data_requires_an_existing_session():
+    vad = SpeechDetectorDummy()
+
+    vad.set_session_data("session-1", "user_id", "user-1")
+
+    assert vad.get_session_data("session-1", "user_id") is None
+
+
+@pytest.mark.asyncio
+async def test_dummy_session_data_is_created_and_finalized():
+    vad = SpeechDetectorDummy()
+
+    vad.set_session_data(
+        "session-1",
+        "user_id",
+        "user-1",
+        create_session=True,
+    )
+    vad.set_session_data("session-1", "context_id", "context-1")
+
+    assert vad.get_session_data("session-1", "user_id") == "user-1"
+    assert vad.get_session_data("session-1", "context_id") == "context-1"
+
+    await vad.finalize_session("session-1")
+
+    assert vad.get_session_data("session-1", "user_id") is None
+    assert vad.get_session_data("session-1", "context_id") is None


### PR DESCRIPTION
Allow SpeechDetectorDummy to manage session data for invoke-only WebSocket sessions.