### PR TITLE
Support OpenAI-compatible speech recognition endpoints

### DIFF
--- a/aiavatar/sts/stt/openai.py
+++ b/aiavatar/sts/stt/openai.py
@@ -17,6 +17,7 @@ class OpenAISpeechRecognizer(SpeechRecognizer):
         language: str = "ja",
         alternative_languages: List[str] = None,
         *,
+        base_url: str = "https://api.openai.com/v1",
         max_connections: int = 100,
         max_keepalive_connections: int = 20,
         timeout: float = 10.0,
@@ -31,6 +32,7 @@ class OpenAISpeechRecognizer(SpeechRecognizer):
             debug=debug
         )
         self.openai_api_key = openai_api_key
+        self.base_url = (base_url or "https://api.openai.com/v1").rstrip("/")
         self.model = model
         self.min_data_length = min_data_length
         self.sample_rate = sample_rate
@@ -73,7 +75,7 @@ class OpenAISpeechRecognizer(SpeechRecognizer):
 
         resp = await self.http_request_with_retry(
             method="POST",
-            url="https://api.openai.com/v1/audio/transcriptions",
+            url=f"{self.base_url}/audio/transcriptions",
             headers=headers,
             data=form_data,
             files=files

--- a/tests/sts/stt/test_openai_unit.py
+++ b/tests/sts/stt/test_openai_unit.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+import pytest
+
+from aiavatar.sts.stt.openai import OpenAISpeechRecognizer
+
+
+@pytest.mark.asyncio
+async def test_openai_stt_uses_configured_base_url():
+    recognizer = OpenAISpeechRecognizer(
+        openai_api_key="test-key",
+        base_url="https://stt.example/v1/",
+        min_data_length=1,
+    )
+    observed = {}
+
+    async def fake_request(**kwargs):
+        observed.update(kwargs)
+        return SimpleNamespace(json=lambda: {"text": "hello"})
+
+    recognizer.http_request_with_retry = fake_request
+    try:
+        assert await recognizer.transcribe(b"\0\0") == "hello"
+    finally:
+        await recognizer.close()
+
+    assert observed["url"] == "https://stt.example/v1/audio/transcriptions"
+    assert observed["headers"] == {"Authorization": "Bearer test-key"}


### PR DESCRIPTION
Allow OpenAI speech recognition to use a configurable base URL, enabling compatible transcription services without requiring a custom recognizer.