### PR TITLE
Avoid splitting on punctuation inside control tags

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -11,6 +11,14 @@ from .context_manager import ContextManager, SQLiteContextManager
 
 logger = logging.getLogger(__name__)
 
+_XML_TAG_PATTERN = re.compile(
+    r'''(</?[A-Za-z_]\w*(?:"[^"]*"|'[^']*'|[^"'<>])*>)'''
+)
+_INCOMPLETE_CONTROL_TAG_PATTERN = re.compile(
+    r"</?(?:artifact|face|animation|vision|language|tools)\b[^<>]*$",
+    re.IGNORECASE,
+)
+
 
 class ToolCallResult:
     def __init__(self, data: dict = None, is_final: bool = True, text: str = None, task_id: str = None, structured_content: dict = None, deferred_callback: callable = None):
@@ -349,6 +357,23 @@ The list of tools is as follows:
     def replace_last_option_split_char(self, original):
         return re.sub(self.option_split_chars_regex, r"\1|", original)
 
+    def _replace_sentence_splits_outside_markup(self, text: str) -> Tuple[str, bool]:
+        incomplete = _INCOMPLETE_CONTROL_TAG_PATTERN.search(text)
+        suffix = text[incomplete.start():] if incomplete else ""
+        parts = _XML_TAG_PATTERN.split(text[:incomplete.start()] if incomplete else text)
+        for index in range(0, len(parts), 2):
+            parts[index] = re.sub(f"(({self.split_chars_pattern})+)", r"\1|", parts[index])
+        return "".join(parts) + suffix, incomplete is not None
+
+    def _replace_last_option_split_outside_markup(self, text: str) -> str:
+        parts = _XML_TAG_PATTERN.split(text)
+        for index in range(len(parts) - 1, -1, -2):
+            replaced = self.replace_last_option_split_char(parts[index])
+            if replaced != parts[index]:
+                parts[index] = replaced
+                break
+        return "".join(parts)
+
     def get_system_prompt(self, func):
         self._get_system_prompt = func
         return func
@@ -395,6 +420,9 @@ The list of tools is as follows:
         return "NOT_FOUND"
 
     def remove_control_tags(self, text: str) -> str:
+        if incomplete := _INCOMPLETE_CONTROL_TAG_PATTERN.search(text):
+            logger.warning("Incomplete control tag omitted from voice text: %s", incomplete.group(0))
+            text = text[:incomplete.start()]
         clean_text = text
         clean_text = re.sub(r"\[(\w+):([^\]]+)\]", "", clean_text)
         clean_text = re.sub(r"<\w+\s[^>]*>", "", clean_text)
@@ -639,16 +667,17 @@ The list of tools is as follows:
 
             stream_buffer += chunk.text
 
-            # Replace consecutive punctuation with the same punctuation followed by delimiter
-            stream_buffer = re.sub(f"(({self.split_chars_pattern})+)", r"\1|", stream_buffer)
+            # Do not treat punctuation inside control-tag attributes (for
+            # example, the '?' in an artifact URL) as a sentence boundary.
+            stream_buffer, has_incomplete_tag = self._replace_sentence_splits_outside_markup(stream_buffer)
 
             # Split before control tags [xxx:yyy] or <xxx ...> if enabled
             if self.split_on_control_tags:
                 stream_buffer = re.sub(r"(?=\[\w+:[^\]]+\])", "|", stream_buffer)
                 stream_buffer = re.sub(r"(?=<\w+\s[^>]*>)", "|", stream_buffer)
 
-            if len(self.remove_control_tags(stream_buffer)) > self.option_split_threshold:
-                stream_buffer = self.replace_last_option_split_char(stream_buffer)
+            if not has_incomplete_tag and len(self.remove_control_tags(stream_buffer)) > self.option_split_threshold:
+                stream_buffer = self._replace_last_option_split_outside_markup(stream_buffer)
 
             segments = stream_buffer.split("|")
             while len(segments) > 1:

--- a/tests/sts/llm/test_control_tag_streaming.py
+++ b/tests/sts/llm/test_control_tag_streaming.py
@@ -1,0 +1,100 @@
+import pytest
+
+from aiavatar.sts.llm.base import LLMResponse, LLMServiceDummy
+
+
+class ChunkedLLMServiceDummy(LLMServiceDummy):
+    def __init__(self, *, response_chunks, **kwargs):
+        super().__init__(response_text="", **kwargs)
+        self.response_chunks = response_chunks
+
+    async def get_llm_stream_response(
+        self,
+        context_id,
+        user_id,
+        messages,
+        system_prompt_params=None,
+        tools=None,
+        inline_llm_params=None,
+        session_id=None,
+        channel=None,
+    ):
+        for text in self.response_chunks:
+            yield LLMResponse(context_id=context_id, text=text)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response_chunks",
+    [
+        [
+            '<answer><artifact type="presentation" '
+            'src="https://speakerdeck.com/player/b32d37c9c2504d548d792336c291d076?slide=1" />'
+            '最初のスライドです。</answer>'
+        ],
+        [
+            '<answer><artifact type="presentation" '
+            'src="https://speakerdeck.com/player/b32d37c9c2504d548d792336c291d076?',
+            'slide=1" />最初のスライドです。</answer>',
+        ],
+    ],
+)
+async def test_punctuation_inside_streamed_control_tag_is_not_spoken(tmp_path, response_chunks):
+    service = ChunkedLLMServiceDummy(
+        response_chunks=response_chunks,
+        system_prompt="test",
+        model="dummy",
+        voice_text_tag=["ack", "answer"],
+        db_connection_str=str(tmp_path / "context.db"),
+    )
+
+    text_parts = []
+    voice_parts = []
+    async for response in service.chat_stream("context", "user", "show slides"):
+        text_parts.append(response.text or "")
+        voice_parts.append(response.voice_text or "")
+
+    full_text = "".join(text_parts)
+    full_voice = "".join(voice_parts)
+    assert "<artifact " in full_text
+    assert "?slide=1" in full_text
+    assert full_voice == "最初のスライドです。"
+    assert "artifact" not in full_voice
+    assert "speakerdeck.com" not in full_voice
+
+
+@pytest.mark.asyncio
+async def test_math_comparison_is_spoken_as_text(tmp_path):
+    service = ChunkedLLMServiceDummy(
+        response_chunks=["<answer>x<1かつy>1です。</answer>"],
+        system_prompt="test",
+        model="dummy",
+        voice_text_tag=["answer"],
+        db_connection_str=str(tmp_path / "context.db"),
+    )
+
+    voice_parts = []
+    async for response in service.chat_stream("context", "user", "compare values"):
+        voice_parts.append(response.voice_text or "")
+
+    assert "".join(voice_parts) == "x<1かつy>1です。"
+
+
+@pytest.mark.asyncio
+async def test_incomplete_known_control_tag_is_not_spoken(tmp_path):
+    service = ChunkedLLMServiceDummy(
+        response_chunks=["<answer>こちらです。<artifact type=\"presentation\" src=\"https://example.com?"],
+        system_prompt="test",
+        model="dummy",
+        voice_text_tag=["answer"],
+        db_connection_str=str(tmp_path / "context.db"),
+    )
+
+    text_parts = []
+    voice_parts = []
+    async for response in service.chat_stream("context", "user", "show it"):
+        text_parts.append(response.text or "")
+        voice_parts.append(response.voice_text or "")
+
+    assert "<artifact " in "".join(text_parts)
+    assert "".join(voice_parts) == "こちらです。"


### PR DESCRIPTION
Preserve punctuation in control tag attributes during response chunking. Omit incomplete known control tags from voice text without affecting comparisons.