### PR TITLE
Add extensible control tag parsing and artifact resolution

### DIFF
--- a/aiavatar/__init__.py
+++ b/aiavatar/__init__.py
@@ -1,1 +1,1 @@
-from .adapter import AvatarControlRequest, AIAvatarRequest, AIAvatarResponse
+from .adapter import ControlTag, ControlTagConfigResolver, AvatarControlRequest, AIAvatarRequest, AIAvatarResponse

--- a/aiavatar/adapter/__init__.py
+++ b/aiavatar/adapter/__init__.py
@@ -1,2 +1,3 @@
-from .models import AvatarControlRequest, AIAvatarRequest, AIAvatarResponse, AIAvatarException
+from .models import ControlTag, AvatarControlRequest, AIAvatarRequest, AIAvatarResponse, AIAvatarException
+from .control_tags import ControlTagConfigResolver
 from .base import Adapter

--- a/aiavatar/adapter/base.py
+++ b/aiavatar/adapter/base.py
@@ -1,12 +1,22 @@
 import re
 from abc import ABC, abstractmethod
 import logging
-from typing import Any, Callable, Awaitable, List, Optional
+from typing import Any, Callable, Awaitable, Dict, List, Optional
 from ..sts.models import STSResponse
 from ..sts.pipeline import STSPipeline, ResponseHandler
-from .models import AIAvatarRequest, AIAvatarResponse, AvatarControlRequest
+from .control_tags import ControlTagConfigResolver
+from .models import AIAvatarRequest, AIAvatarResponse, AvatarControlRequest, ControlTag
 
 logger = logging.getLogger(__name__)
+
+_CONTROL_TAG_PATTERN = re.compile(
+    r'''\[(?P<bracket_name>[A-Za-z_]\w*):(?P<bracket_value>[^\]]+)\]'''
+    r'''|<(?P<xml_name>[A-Za-z_]\w*)\b(?P<attributes>(?:"[^"]*"|'[^']*'|[^'"<>])*)>''',
+    re.IGNORECASE,
+)
+_CONTROL_ATTRIBUTE_PATTERN = re.compile(
+    r'''([A-Za-z_][\w-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')'''
+)
 
 
 class Adapter(ABC):
@@ -20,6 +30,12 @@ class Adapter(ABC):
 
         # Control tag pattern: receives (tag, attr) and returns a regex with two capture groups
         self.control_tag_pattern = r'\[{tag}:(\w+)\]|<{tag}\s[^>]*{attr}=["\'](\w+)["\']'
+        self._control_tag_parsers = {}
+        self.register_control_tag("face")
+        self.register_control_tag("animation")
+        self.register_control_tag("vision", value_attribute="source")
+        self._artifact_resolver = ControlTagConfigResolver()
+        self.register_control_tag("artifact", parser=self._artifact_resolver)
 
         # Callbacks
         self._on_session_start_handlers: List[Callable[[AIAvatarRequest, Any], Awaitable[None]]] = []
@@ -55,6 +71,84 @@ class Adapter(ABC):
     @abstractmethod
     async def stop_response(self, session_id: str, context_id: str):
         pass
+
+    def register_control_tag(
+        self,
+        name: str,
+        *,
+        value_attribute: str = "name",
+        parser: Optional[Callable[[Dict[str, str]], Optional[Dict[str, Any]]]] = None,
+    ):
+        """Register a control tag and an optional attribute normalizer."""
+        normalized_name = name.lower()
+        if not re.fullmatch(r"[A-Za-z_]\w*", normalized_name):
+            raise ValueError(f"Invalid control tag name: {name}")
+        self._control_tag_parsers[normalized_name] = (value_attribute.lower(), parser)
+
+    def set_artifacts(self, artifacts: Dict[str, Dict[str, Any]]):
+        """Replace the application-owned artifact catalog."""
+        self._artifact_resolver.set_configs(artifacts)
+        self.register_control_tag("artifact", parser=self._artifact_resolver)
+
+    def update_artifacts(self, artifacts: Dict[str, Dict[str, Any]]):
+        """Add or replace artifact catalog entries without clearing other IDs."""
+        self._artifact_resolver.update_configs(artifacts)
+        self.register_control_tag("artifact", parser=self._artifact_resolver)
+
+    def add_artifact(self, artifact_id: str, config: Dict[str, Any]):
+        """Add or replace one artifact catalog entry."""
+        self._artifact_resolver.set_config(artifact_id, config)
+        self.register_control_tag("artifact", parser=self._artifact_resolver)
+
+    def parse_control_tags(self, text: str) -> List[ControlTag]:
+        """Parse registered bracket or XML-style control tags in source order."""
+        tags = []
+        parsers = getattr(self, "_control_tag_parsers", {})
+        for match in _CONTROL_TAG_PATTERN.finditer(text or ""):
+            name = (match.group("bracket_name") or match.group("xml_name")).lower()
+            registration = parsers.get(name)
+            if not registration:
+                continue
+
+            value_attribute, parser = registration
+            if match.group("bracket_name"):
+                attributes = {value_attribute: match.group("bracket_value").strip()}
+            else:
+                attributes = self._parse_control_attributes(match.group("attributes"))
+                if attributes is None:
+                    logger.warning("Ignored malformed control tag: %s", match.group(0))
+                    continue
+
+            if parser:
+                try:
+                    attributes = parser(attributes)
+                except (TypeError, ValueError) as ex:
+                    logger.warning("Ignored invalid %s control tag: %s", name, ex)
+                    continue
+                if attributes is None:
+                    continue
+            tags.append(ControlTag(name=name, attributes=attributes))
+        return tags
+
+    @staticmethod
+    def _parse_control_attributes(source: str) -> Optional[Dict[str, str]]:
+        source = source.strip()
+        if source.endswith("/"):
+            source = source[:-1].rstrip()
+
+        attributes = {}
+        position = 0
+        for match in _CONTROL_ATTRIBUTE_PATTERN.finditer(source):
+            if source[position:match.start()].strip():
+                return None
+            name = match.group(1).lower()
+            if name in attributes:
+                return None
+            attributes[name] = match.group(2) if match.group(2) is not None else match.group(3)
+            position = match.end()
+        if source[position:].strip():
+            return None
+        return attributes
 
     def parse_control_tag(self, text: str, tag: str, attr: str = "name") -> Optional[str]:
         if not text:

--- a/aiavatar/adapter/control_tags.py
+++ b/aiavatar/adapter/control_tags.py
@@ -1,0 +1,63 @@
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any, Dict, Optional
+
+
+class ControlTagConfigResolver:
+    """Resolve a control-tag identifier from an application-owned config map."""
+
+    def __init__(
+        self,
+        configs: Optional[Mapping[str, Mapping[str, Any]]] = None,
+        *,
+        key_attribute: str = "id",
+    ):
+        self.key_attribute = key_attribute.lower()
+        self._configs = {}
+        self.set_configs(configs or {})
+
+    def set_configs(self, configs: Mapping[str, Mapping[str, Any]]):
+        self._configs = self._normalize_configs(configs)
+
+    def update_configs(self, configs: Mapping[str, Mapping[str, Any]]):
+        self._configs = {
+            **self._configs,
+            **self._normalize_configs(configs),
+        }
+
+    def set_config(self, config_id: str, attributes: Mapping[str, Any]):
+        self.update_configs({config_id: attributes})
+
+    @staticmethod
+    def _normalize_configs(configs: Mapping[str, Mapping[str, Any]]) -> Dict[str, Dict[str, Any]]:
+        if not isinstance(configs, Mapping):
+            raise TypeError("Control tag configs must be a mapping")
+
+        normalized = {}
+        for config_id, attributes in configs.items():
+            if not isinstance(config_id, str) or not config_id:
+                raise ValueError("Control tag config IDs must be non-empty strings")
+            if not isinstance(attributes, Mapping):
+                raise TypeError(f"Control tag config must be a mapping: {config_id}")
+            normalized[config_id] = deepcopy(dict(attributes))
+        return normalized
+
+    def __call__(self, attributes: Dict[str, Any]) -> Dict[str, Any]:
+        config_id = attributes.get(self.key_attribute)
+        if config_id is None:
+            return dict(attributes)
+        if not isinstance(config_id, str) or not config_id:
+            raise ValueError(f"{self.key_attribute} must be a non-empty string")
+
+        configured = self._configs.get(config_id)
+        if configured is None:
+            raise ValueError(f"Unknown control tag config ID: {config_id}")
+
+        resolved = deepcopy(configured)
+        resolved.pop(self.key_attribute, None)
+        resolved.update({
+            name: value
+            for name, value in attributes.items()
+            if name != self.key_attribute
+        })
+        return resolved

--- a/aiavatar/adapter/http/server.py
+++ b/aiavatar/adapter/http/server.py
@@ -320,6 +320,7 @@ class AIAvatarHttpServer(Adapter):
                             context_id=response.context_id,
                             text=response.text,
                             voice_text=response.voice_text,
+                            control_tags=(self.parse_control_tags(response.text) or None) if response.type == "chunk" else None,
                             audio_data=response.audio_data,
                             metadata=response.metadata or {},
                             structured_content=response.structured_content

--- a/aiavatar/adapter/linebot/server.py
+++ b/aiavatar/adapter/linebot/server.py
@@ -439,6 +439,7 @@ class AIAvatarLineBotServer(Adapter):
             text=response.text,
             voice_text=response.voice_text,
             language=response.language,
+            control_tags=(self.parse_control_tags(response.text) or None) if response.type == "chunk" else None,
             audio_data=response.audio_data,
             metadata=response.metadata or {},
             structured_content=response.structured_content,

--- a/aiavatar/adapter/local/server.py
+++ b/aiavatar/adapter/local/server.py
@@ -219,6 +219,7 @@ class AIAvatarLocalServer(Adapter):
             context_id=response.context_id,
             text=response.text,
             voice_text=response.voice_text,
+            control_tags=(self.parse_control_tags(response.text) or None) if response.type == "chunk" else None,
             audio_data=response.audio_data,
             metadata=response.metadata or {},
             structured_content=response.structured_content

--- a/aiavatar/adapter/models.py
+++ b/aiavatar/adapter/models.py
@@ -1,5 +1,10 @@
-from typing import List, Dict, Optional, Union
+from typing import Any, List, Dict, Optional, Union
 from pydantic import BaseModel
+
+
+class ControlTag(BaseModel):
+    name: str
+    attributes: Dict[str, Any]
 
 
 class AvatarControlRequest(BaseModel):
@@ -31,6 +36,7 @@ class AIAvatarResponse(BaseModel):
     text: Optional[str] = None
     voice_text: Optional[str] = None
     language: Optional[str] = None
+    control_tags: Optional[List[ControlTag]] = None
     avatar_control_request: Optional[AvatarControlRequest] = None
     audio_data: Optional[Union[bytes, str]] = None
     metadata: Optional[Dict] = None

--- a/aiavatar/adapter/twilio/server.py
+++ b/aiavatar/adapter/twilio/server.py
@@ -449,6 +449,7 @@ class AIAvatarTwilioServer(Adapter):
             context_id=response.context_id,
             text=response.text,
             voice_text=response.voice_text,
+            control_tags=(self.parse_control_tags(response.text) or None) if response.type == "chunk" else None,
             audio_data=response.audio_data,
             metadata=response.metadata or {},
             structured_content=response.structured_content
@@ -868,6 +869,7 @@ class AIAvatarTwilioSMSServer(Adapter):
             text=response.text,
             voice_text=response.voice_text,
             language=response.language,
+            control_tags=(self.parse_control_tags(response.text) or None) if response.type == "chunk" else None,
             audio_data=response.audio_data,
             metadata=response.metadata or {},
             structured_content=response.structured_content,

--- a/aiavatar/adapter/websocket/server.py
+++ b/aiavatar/adapter/websocket/server.py
@@ -369,6 +369,7 @@ class AIAvatarWebSocketServer(Adapter):
             context_id=response.context_id,
             text=response.text,
             voice_text=response.voice_text,
+            control_tags=(self.parse_control_tags(response.text) or None) if response.type == "chunk" else None,
             audio_data=response.audio_data,
             metadata=response.metadata or {},
             structured_content=response.structured_content

--- a/tests/adapter/test_control_tags.py
+++ b/tests/adapter/test_control_tags.py
@@ -1,0 +1,216 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aiavatar.adapter import Adapter, AIAvatarResponse, ControlTagConfigResolver
+from aiavatar.adapter.websocket.server import AIAvatarWebSocketServer, WebSocketSessionData
+from aiavatar.sts.models import STSResponse
+
+
+class StubPipeline:
+    def add_response_handler(self, handler):
+        self.response_handler = handler
+
+
+class StubAdapter(Adapter):
+    async def handle_response(self, response):
+        pass
+
+    async def stop_response(self, session_id: str, context_id: str):
+        pass
+
+
+def create_adapter():
+    return StubAdapter(StubPipeline())
+
+
+def test_parse_registered_control_tags_in_source_order():
+    adapter = create_adapter()
+
+    tags = adapter.parse_control_tags(
+        'x<1 [face:joy] '
+        '<artifact type="presentation" src="https://example.com/player?id=1" /> '
+        '<artifact type="presentation" offset="-1" /> '
+        '<unknown value="ignored" /> '
+        "<vision source='screen_shot' />"
+    )
+
+    assert [tag.model_dump() for tag in tags] == [
+        {"name": "face", "attributes": {"name": "joy"}},
+        {
+            "name": "artifact",
+            "attributes": {
+                "type": "presentation",
+                "src": "https://example.com/player?id=1",
+            },
+        },
+        {
+            "name": "artifact",
+            "attributes": {
+                "type": "presentation",
+                "offset": "-1",
+            },
+        },
+        {"name": "vision", "attributes": {"source": "screen_shot"}},
+    ]
+
+
+def test_register_control_tag_with_attribute_normalizer():
+    adapter = create_adapter()
+
+    def parse_navigation(attributes):
+        if "page" not in attributes:
+            raise ValueError("page is required")
+        return {"page": int(attributes["page"])}
+
+    adapter.register_control_tag("navigation", parser=parse_navigation)
+
+    tags = adapter.parse_control_tags(
+        '<navigation page="3" /><navigation target="ignored" />'
+    )
+
+    assert [tag.model_dump() for tag in tags] == [
+        {"name": "navigation", "attributes": {"page": 3}},
+    ]
+
+
+def test_config_resolver_merges_llm_attributes_over_config():
+    resolver = ControlTagConfigResolver({
+        "about_company": {
+            "type": "presentation",
+            "src": "https://speakerdeck.com/player/deck_1",
+            "slide": 1,
+            "aspect": "16:9",
+        },
+    })
+
+    assert resolver({"id": "about_company", "slide": "5", "size": "full"}) == {
+        "type": "presentation",
+        "src": "https://speakerdeck.com/player/deck_1",
+        "slide": "5",
+        "aspect": "16:9",
+        "size": "full",
+    }
+    assert resolver({"type": "image", "src": "https://example.com/generated.png"}) == {
+        "type": "image",
+        "src": "https://example.com/generated.png",
+    }
+
+
+def test_set_artifacts_replaces_the_catalog():
+    adapter = create_adapter()
+    adapter.set_artifacts({
+        "first": {
+            "type": "image",
+            "src": "https://example.com/first.png",
+            "aspect": "1:1",
+        },
+    })
+    assert adapter.parse_control_tags('<artifact id="first" />')[0].attributes["src"].endswith("first.png")
+
+    adapter.set_artifacts({
+        "second": {"type": "image", "src": "https://example.com/second.png"},
+    })
+    assert adapter.parse_control_tags('<artifact id="first" />') == []
+    assert adapter.parse_control_tags('<artifact id="second" />')[0].attributes["src"].endswith("second.png")
+
+
+def test_update_and_add_artifacts_preserve_other_entries():
+    adapter = create_adapter()
+    adapter.set_artifacts({
+        "first": {
+            "type": "image",
+            "src": "https://example.com/first.png",
+            "aspect": "1:1",
+        },
+    })
+    adapter.update_artifacts({
+        "second": {"type": "image", "src": "https://example.com/second.png"},
+    })
+    adapter.add_artifact(
+        "third",
+        {"type": "image", "src": "https://example.com/third.png"},
+    )
+
+    for artifact_id in ("first", "second", "third"):
+        tags = adapter.parse_control_tags(f'<artifact id="{artifact_id}" />')
+        assert tags[0].attributes["src"].endswith(f"{artifact_id}.png")
+
+    adapter.add_artifact(
+        "first",
+        {"type": "image", "src": "https://example.com/replaced.png"},
+    )
+    first = adapter.parse_control_tags('<artifact id="first" />')[0]
+    assert first.attributes == {
+        "type": "image",
+        "src": "https://example.com/replaced.png",
+    }
+
+
+def test_malformed_registered_tag_is_ignored():
+    adapter = create_adapter()
+
+    assert adapter.parse_control_tags(
+        '<artifact type="image" type="chart" src="https://example.com/a.png" />'
+    ) == []
+
+
+def test_control_tags_are_serialized_on_aiavatar_response():
+    adapter = create_adapter()
+    response = AIAvatarResponse(
+        type="chunk",
+        control_tags=adapter.parse_control_tags("[animation:wave]"),
+    )
+
+    payload = json.loads(response.model_dump_json())
+    assert payload["control_tags"] == [
+        {"name": "animation", "attributes": {"name": "wave"}},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_websocket_attaches_control_tags_to_chunks_only():
+    server = object.__new__(AIAvatarWebSocketServer)
+    Adapter.__init__(server, StubPipeline())
+    server.sessions = {"session": WebSocketSessionData()}
+    server.response_audio_chunk_size = 0
+    server.debug = False
+    server.send_response = AsyncMock()
+    server.set_artifacts({
+        "about_company": {
+            "type": "presentation",
+            "src": "https://speakerdeck.com/player/deck_1",
+            "slide": 1,
+            "aspect": "16:9",
+        },
+    })
+    text = '<artifact id="about_company" slide="3" />'
+
+    await server.handle_response(STSResponse(
+        type="chunk",
+        session_id="session",
+        text=text,
+        voice_text="",
+        metadata={},
+    ))
+    await server.handle_response(STSResponse(
+        type="final",
+        session_id="session",
+        text=text,
+        voice_text="",
+        metadata={},
+    ))
+
+    chunk_response = server.send_response.await_args_list[0].args[0]
+    final_response = server.send_response.await_args_list[1].args[0]
+    assert [tag.model_dump() for tag in chunk_response.control_tags] == [{
+        "name": "artifact",
+        "attributes": {
+            "type": "presentation",
+            "src": "https://speakerdeck.com/player/deck_1",
+            "slide": "3",
+            "aspect": "16:9",
+        },
+    }]
+    assert final_response.control_tags is None


### PR DESCRIPTION
- Generalize control tag parsing with per-tag registration.
- Add built-in artifact configuration and ID resolution.
- Expose parsed control tags on streaming responses.