### PR TITLE
Add pluggable artifact rendering to WebSocket examples

### DIFF
--- a/aiavatar/cli/config.py
+++ b/aiavatar/cli/config.py
@@ -42,6 +42,25 @@ which is the default language, and replace the language code as appropriate.
 neutral / joy / angry / sorrow / fun / surprise
 When expressing emotion, insert a tag such as <face name="joy" />. Default is neutral.
 
+## Artifacts
+To display an image, chart, slide, or video, insert an `<artifact />` tag immediately before the relevant sentence in the response body. Do not read the tag aloud or explain it.
+
+- Registered artifact: `<artifact id="{ARTIFACT_ID}" />`
+- HTTPS URL: `<artifact type="{TYPE}" src="{HTTPS_URL}" />`
+  - Use `image` for an image, `chart` for a chart, `presentation` for slides, or `video` for a YouTube video.
+  - A Docswell viewing URL (`https://www.docswell.com/s/...`) can be used directly as a presentation `src`.
+  - Speaker Deck requires an embed URL (`https://speakerdeck.com/player/...`).
+  - YouTube videos accept `autoplay-delay` as a non-negative number of seconds before the first playback attempt.
+- Presentation controls are available only with `type="presentation"`, not with images, charts, or videos.
+  - Move the displayed presentation to a numbered page: `<artifact type="presentation" slide="3" />`
+  - To set the starting page of a new presentation, specify `id` or `src` together with `slide` in the same tag.
+  - Move relative to the current page: `<artifact type="presentation" offset="+1" />`, `offset="-1"`, `offset="+2"`, and so on.
+  - For relative navigation, use a signed `offset` instead of `slide` and specify it in a single tag.
+  - Never use numbered page navigation when the request is relative to the current page.
+- Never invent unknown IDs or URLs.
+- Only the most recently specified artifact is displayed. A new artifact replaces the previous one.
+- To hide the current artifact, output `<artifact action="clear" />`.
+
 ## Supervisor instructions
 Any message beginning with "$" is an instruction from the supervisor program.
 Do not respond directly to the supervisor program. Follow its instructions when producing the response for the user.

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -42,6 +42,51 @@ uvicorn server:app
 Set `AVATAR_MODE` in `html/index.html` to `"image"` or `"mpt"`. Then visit http://localhost:8000/static/index.html, click `Start`, and try talking to the avatar.
 
 
+## Artifacts in the web viewers
+
+`html/index.html` and `html/3d.html` can display an image, chart, Speaker Deck presentation, Docswell presentation, or YouTube video when an AI response contains a self-closing `artifact` tag. The adapter exposes registered tags through `AIAvatarResponse.control_tags`; the viewer falls back to parsing `text` when connected to an older server. The surrounding speech continues to use `voice_text`.
+
+```html
+<artifact type="image" src="https://example.com/image.png" alt="Generated image" />
+<artifact type="chart" src="https://example.com/chart.svg" aspect="4:3" />
+<artifact type="presentation" src="https://speakerdeck.com/player/DECK_ID" slide="7" />
+<artifact type="presentation" src="https://www.docswell.com/s/USER/SLIDE_ID-2026-01-23-123456" slide="7" />
+<artifact type="presentation" slide="12" />
+<artifact type="presentation" offset="+1" />
+<artifact type="presentation" offset="+2" />
+<artifact type="video" src="https://www.youtube.com/watch?v=VIDEO_ID" autoplay-delay="3" />
+<artifact action="clear" />
+```
+
+`href` is accepted as an alias of `src`. `slide` is a positive absolute page number; when `src` is omitted, it moves the currently displayed presentation. A signed `offset` such as `+1`, `+2`, or `-1` moves relative to the current page. The viewer converts navigation to the provider-specific Speaker Deck query or Docswell message. `offset` operates only within the currently displayed presentation. Docswell applies it to the player's actual position, including manual navigation. Speaker Deck applies it to the last page requested through an artifact tag, so manual navigation is intentionally ignored. `autoplay-delay` is a non-negative number of seconds from video display until the first YouTube playback attempt; it defaults to `0`. YouTube `t` or `start` URL parameters select the position inside the video and are independent of this delay. Browsers can block autoplay with sound, in which case the embedded player remains available for manual playback. `size` accepts `small`, `medium`, `large`, or `full`; `aspect` accepts `auto`, `16:9`, `4:3`, `3:2`, `1:1`, or `9:16`. Images and charts default to `auto`; presentations and videos default to `16:9`. Speaker Deck requires a `/player/...` embed URL. Docswell accepts either a `/slide/.../embed` URL or its normal `/s/...` viewing URL. Other provider URL formats are rejected.
+
+While an artifact is visible, the VRM moves into a compact overlay and uses a separate camera state. Its first position automatically frames the full model; later drag, rotation, and zoom adjustments are stored separately in local storage. Closing the artifact restores the normal camera without changing it.
+
+Adapters register `face`, `animation`, `vision`, and `artifact` by default. Applications can keep long URLs out of the LLM response by replacing the built-in artifact catalog:
+
+```python
+ARTIFACTS = {
+    "about_company": {
+        "type": "presentation",
+        "src": "https://speakerdeck.com/player/DECK_ID",
+        "slide": 1,
+        "aspect": "16:9",
+        "title": "About the company",
+    },
+}
+
+aiavatar_app.set_artifacts(ARTIFACTS)
+```
+
+The LLM can then emit `<artifact id="about_company" />`. Attributes in the LLM tag override catalog values, so `<artifact id="about_company" slide="5" size="full" />` opens page 5 at full size. A tag without an `id` continues to accept a direct `src` or `href`, which is useful for images returned by search or generation tools.
+
+- `set_artifacts(configs)` replaces the complete shared catalog.
+- `update_artifacts(configs)` adds or replaces multiple entries while retaining other IDs.
+- `add_artifact(id, config)` adds or replaces one entry.
+
+These methods update the adapter-wide catalog shared by all sessions; they do not create session-private artifacts.
+
+
 ## Deep Dive
 
 The project README describes how to configure and customize the speech-to-speech pipeline or its components (VAD / STT / LLM / TTS).

--- a/examples/websocket/html/3d.html
+++ b/examples/websocket/html/3d.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>AIAvatarKit 3D Avatar</title>
     <link rel="stylesheet" href="avatar3d/3d.css">
+    <link rel="stylesheet" href="artifact/artifact.css">
     <link rel="stylesheet" href="vrm-themes/theme-girly.css">
 </head>
 
@@ -14,6 +15,7 @@
 
     <div id="avatarFrame">
         <canvas id="avatarCanvas"></canvas>
+        <div id="avatarControlSurface" hidden aria-hidden="true"></div>
         <div class="avatar-placeholder" id="avatarPlaceholder">Drop or load a VRM file</div>
     </div>
 
@@ -85,8 +87,26 @@
     -->
     <script type="module">
         import { start3dPage } from "./avatar3d/3d-main.js";
+        import { ImageArtifactPlugin } from "./artifact/image-artifact-plugin.js";
+        import { PresentationArtifactPlugin } from "./artifact/presentation-artifact-plugin.js";
+        import { VideoArtifactPlugin } from "./artifact/video-artifact-plugin.js";
+        import { DocswellDriver } from "./artifact/docswell-driver.js";
+        import { SpeakerDeckDriver } from "./artifact/speakerdeck-driver.js";
+        import { YouTubeDriver } from "./artifact/youtube-driver.js";
 
         await start3dPage({
+            artifactPlugins: [
+                new ImageArtifactPlugin({ type: "image" }),
+                new ImageArtifactPlugin({ type: "chart" }),
+                new PresentationArtifactPlugin({
+                    drivers: [DocswellDriver, SpeakerDeckDriver],
+                }),
+                new VideoArtifactPlugin({
+                    drivers: [YouTubeDriver],
+                    autoplay: true,
+                }),
+            ],
+
             connection: {
                 webSocketUrl: "../ws",
                 apiKey: null,

--- a/examples/websocket/html/artifact/artifact-controller.js
+++ b/examples/websocket/html/artifact/artifact-controller.js
@@ -1,0 +1,251 @@
+import { parseArtifactControlTags, parseArtifactTags } from "./artifact-parser.js";
+import { ArtifactRegistry } from "./artifact-registry.js";
+
+const ASPECT_VALUES = {
+    "16:9": ["16 / 9", 16 / 9],
+    "4:3": ["4 / 3", 4 / 3],
+    "3:2": ["3 / 2", 3 / 2],
+    "1:1": ["1 / 1", 1],
+    "9:16": ["9 / 16", 9 / 16],
+};
+
+function isObject(value) {
+    return value && typeof value === "object" && !Array.isArray(value);
+}
+
+export class ArtifactController {
+    constructor({
+        documentRoot = document,
+        windowRoot = globalThis.window,
+        host = null,
+        plugins = [],
+        onVisibilityChange = () => {},
+    } = {}) {
+        this.document = documentRoot;
+        this.window = windowRoot;
+        this.host = host || this.document.body;
+        this.registry = new ArtifactRegistry(plugins);
+        this.onVisibilityChange = onVisibilityChange;
+        this.active = false;
+        this.root = this.createRoot();
+        this.current = null;
+        this.currentPlugin = null;
+        this.currentSession = null;
+        this.generation = 0;
+        this.sawTaggedChunk = false;
+    }
+
+    register(plugin) {
+        return this.registry.register(plugin);
+    }
+
+    get currentState() {
+        return this.currentSession?.getState?.() || null;
+    }
+
+    get currentSlide() {
+        return this.currentState?.slide ?? null;
+    }
+
+    get totalSlides() {
+        return this.currentState?.totalSlides ?? null;
+    }
+
+    createRoot() {
+        const root = this.document.createElement("div");
+        root.id = "artifactLayer";
+        root.className = "artifact-layer";
+        root.hidden = true;
+        root.setAttribute("aria-live", "polite");
+        this.host.appendChild(root);
+        return root;
+    }
+
+    handleResponse(response) {
+        if (!response || typeof response !== "object") return;
+        if (response.type === "accepted" || response.type === "start") this.sawTaggedChunk = false;
+
+        const structuredTags = Array.isArray(response.control_tags) ? response.control_tags : null;
+        const hasStructuredArtifact = structuredTags?.some(
+            (tag) => String(tag?.name || "").toLowerCase() === "artifact",
+        );
+        const hasTextArtifact = typeof response.text === "string" && /<artifact\b/i.test(response.text);
+        if (!hasStructuredArtifact && !hasTextArtifact) return;
+
+        const isChunk = response.type === "chunk";
+        const isFinalLike = response.type === "final" || response.type === "vision";
+        if (!isChunk && !isFinalLike) return;
+        if (isFinalLike && this.sawTaggedChunk) return;
+
+        const options = { registry: this.registry };
+        const { commands, errors } = structuredTags
+            ? parseArtifactControlTags(structuredTags, options)
+            : parseArtifactTags(response.text, options);
+        for (const item of errors) console.warn("Ignored invalid artifact tag:", item.error.message, item.tag);
+        if (!commands.length) return;
+        if (isChunk) this.sawTaggedChunk = true;
+
+        for (const command of commands) {
+            try {
+                this.apply(command);
+            } catch (error) {
+                console.warn("Could not display artifact:", error.message);
+            }
+        }
+    }
+
+    apply(command) {
+        if (command.action === "clear") {
+            this.clear();
+            return;
+        }
+
+        const plugin = this.registry.get(command.type);
+        if (!plugin) throw new Error(`No artifact plugin is registered for ${command.type}`);
+        if (command.action !== "show") {
+            this.executeCurrent(plugin, command);
+            return;
+        }
+
+        const source = plugin.resolveSource(command);
+        const pluginDefaults = plugin.getDefaults?.(command) || {};
+        const defaults = {
+            size: command.size || pluginDefaults.size || "large",
+            aspect: command.aspect || pluginDefaults.aspect || "auto",
+        };
+        if (this.tryUpdateCurrent(plugin, command, source, defaults)) return;
+
+        const surface = this.document.createElement("section");
+        surface.className = "artifact-surface";
+        surface.dataset.type = command.type;
+        surface.dataset.provider = source.provider;
+        surface.dataset.size = defaults.size;
+        surface.dataset.aspect = defaults.aspect;
+        surface.setAttribute("aria-label", command.title || command.alt || "AI artifact");
+
+        if (defaults.aspect !== "auto") {
+            const [aspect, ratio] = ASPECT_VALUES[defaults.aspect];
+            surface.style.setProperty("--artifact-aspect", aspect);
+            surface.style.setProperty("--artifact-ratio", String(ratio));
+        }
+
+        const closeButton = this.document.createElement("button");
+        closeButton.type = "button";
+        closeButton.className = "artifact-close";
+        closeButton.setAttribute("aria-label", "Close artifact");
+        closeButton.textContent = "×";
+        closeButton.addEventListener("click", () => this.clear());
+
+        const status = this.document.createElement("div");
+        status.className = "artifact-status";
+        status.textContent = "Loading…";
+
+        const generation = this.generation + 1;
+        const view = this.createView(surface, status, generation);
+        const session = plugin.mount({
+            documentRoot: this.document,
+            windowRoot: this.window,
+            command,
+            source,
+            defaults,
+            view,
+        });
+        if (!session || typeof session !== "object" || !session.element) {
+            session?.dispose?.();
+            throw new Error(`Artifact plugin ${plugin.type} did not return a media element`);
+        }
+
+        this.disposeCurrentSession();
+        this.generation = generation;
+        this.currentPlugin = plugin;
+        this.currentSession = session;
+        this.current = { ...command, ...defaults, ...source };
+
+        surface.append(session.element, status, closeButton);
+        this.root.replaceChildren(surface);
+        this.root.hidden = false;
+        this.setActive(true);
+    }
+
+    tryUpdateCurrent(plugin, command, source, defaults) {
+        if (plugin !== this.currentPlugin || typeof this.currentSession?.update !== "function") return false;
+        if (this.current.size !== defaults.size
+            || this.current.aspect !== defaults.aspect
+            || this.current.title !== command.title
+            || this.current.alt !== command.alt) return false;
+
+        const result = this.currentSession.update({ command, source, defaults });
+        if (result === false) return false;
+        if (result?.then) throw new Error("Artifact session update() must be synchronous");
+        this.current = { ...command, ...defaults, ...source, ...(isObject(result) ? result : {}) };
+        return true;
+    }
+
+    executeCurrent(plugin, command) {
+        if (plugin !== this.currentPlugin || typeof this.currentSession?.execute !== "function") {
+            throw new Error(`No compatible ${command.type} artifact is displayed`);
+        }
+        const result = this.currentSession.execute(command);
+        if (result === false) throw new Error(`Artifact does not support ${command.action}`);
+        if (result?.then) throw new Error("Artifact session execute() must be synchronous");
+        if (isObject(result)) this.current = { ...this.current, ...result };
+    }
+
+    createView(surface, status, generation) {
+        const isCurrent = () => this.generation === generation;
+        return {
+            loaded: () => {
+                if (!isCurrent()) return;
+                surface.classList.add("loaded");
+                status.remove();
+            },
+            error: (message = "表示できませんでした") => {
+                if (!isCurrent()) return;
+                surface.classList.add("artifact-load-error");
+                status.textContent = message;
+                if (typeof surface.contains === "function" && !surface.contains(status)) surface.append(status);
+            },
+            setIntrinsicAspect: (width, height) => {
+                if (!isCurrent() || surface.dataset.aspect !== "auto" || !width || !height) return;
+                surface.style.setProperty("--artifact-aspect", `${width} / ${height}`);
+                surface.style.setProperty("--artifact-ratio", String(width / height));
+            },
+            updateCurrent: (patch) => {
+                if (!isCurrent() || !this.current || !isObject(patch)) return;
+                this.current = { ...this.current, ...patch };
+            },
+        };
+    }
+
+    disposeCurrentSession() {
+        this.generation += 1;
+        try {
+            this.currentSession?.dispose?.();
+        } catch (error) {
+            console.warn("Could not dispose artifact:", error.message);
+        }
+        this.currentSession = null;
+        this.currentPlugin = null;
+    }
+
+    setActive(active) {
+        if (active === this.active) return;
+        this.active = active;
+        if (active) this.document.documentElement.classList.add("artifact-active");
+        else this.document.documentElement.classList.remove("artifact-active");
+        this.onVisibilityChange(active);
+    }
+
+    clear() {
+        this.disposeCurrentSession();
+        this.root.replaceChildren();
+        this.root.hidden = true;
+        this.setActive(false);
+        this.current = null;
+    }
+
+    dispose() {
+        this.clear();
+        this.root.remove();
+    }
+}

--- a/examples/websocket/html/artifact/artifact-parser.js
+++ b/examples/websocket/html/artifact/artifact-parser.js
@@ -1,0 +1,117 @@
+const ARTIFACT_TAG_PATTERN = /<artifact\b((?:"[^"]*"|'[^']*'|[^"'<>])*)\/\s*>/gi;
+const ATTRIBUTE_PATTERN = /([A-Za-z][\w-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+const COMMON_DISPLAY_ATTRIBUTES = new Set(["type", "src", "href", "size", "aspect", "alt", "title"]);
+const SIZE_PRESETS = new Set(["small", "medium", "large", "full"]);
+const ASPECT_PRESETS = new Set(["auto", "16:9", "4:3", "3:2", "1:1", "9:16"]);
+const STRUCTURED_ATTRIBUTE_TYPES = new Set(["string", "number", "boolean"]);
+
+function parseAttributes(source) {
+    const attributes = {};
+    let remaining = source;
+    ATTRIBUTE_PATTERN.lastIndex = 0;
+    for (const match of source.matchAll(ATTRIBUTE_PATTERN)) {
+        const name = match[1].toLowerCase();
+        if (Object.prototype.hasOwnProperty.call(attributes, name)) {
+            throw new Error(`Duplicate artifact attribute: ${name}`);
+        }
+        attributes[name] = match[2] ?? match[3] ?? "";
+        remaining = remaining.replace(match[0], " ");
+    }
+    if (remaining.trim()) throw new Error("Malformed artifact attributes");
+    return attributes;
+}
+
+export function assertArtifactAttributes(attributes, additionalAttributes = []) {
+    const allowed = new Set([...COMMON_DISPLAY_ATTRIBUTES, ...additionalAttributes]);
+    for (const name of Object.keys(attributes)) {
+        if (!allowed.has(name)) throw new Error(`Unsupported artifact attribute: ${name}`);
+    }
+}
+
+export function parseArtifactSourceAttributes(attributes) {
+    if (attributes.src !== undefined && attributes.href !== undefined) {
+        throw new Error("Use either src or href, not both");
+    }
+    return attributes.src ?? attributes.href ?? null;
+}
+
+export function parseArtifactDisplayAttributes(attributes) {
+    const size = (attributes.size || "").toLowerCase() || null;
+    if (size && !SIZE_PRESETS.has(size)) throw new Error(`Unsupported artifact size: ${size}`);
+
+    const aspect = (attributes.aspect || "").toLowerCase() || null;
+    if (aspect && !ASPECT_PRESETS.has(aspect)) throw new Error(`Unsupported artifact aspect: ${aspect}`);
+
+    return {
+        size,
+        aspect,
+        alt: attributes.alt || "",
+        title: attributes.title || "",
+    };
+}
+
+function parseCommand(attributes, registry) {
+    if (attributes.action !== undefined) {
+        const action = attributes.action.toLowerCase();
+        if (action !== "clear") throw new Error(`Unsupported artifact action: ${attributes.action}`);
+        if (Object.keys(attributes).some((name) => name !== "action")) {
+            throw new Error("The clear artifact action cannot have additional attributes");
+        }
+        return { action: "clear" };
+    }
+
+    const requestedType = (attributes.type || "").toLowerCase();
+    const plugin = registry?.get(requestedType);
+    if (!plugin) throw new Error(`Unsupported artifact type: ${attributes.type || "(missing)"}`);
+    return plugin.parse(attributes, { requestedType });
+}
+
+function normalizeStructuredAttributes(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("Artifact attributes must be an object");
+    }
+    const attributes = {};
+    for (const [rawName, rawValue] of Object.entries(value)) {
+        const name = rawName.toLowerCase();
+        if (Object.prototype.hasOwnProperty.call(attributes, name)) {
+            throw new Error(`Duplicate artifact attribute: ${name}`);
+        }
+        if (!STRUCTURED_ATTRIBUTE_TYPES.has(typeof rawValue)) {
+            throw new Error(`Artifact attribute must be a scalar value: ${name}`);
+        }
+        attributes[name] = String(rawValue);
+    }
+    return attributes;
+}
+
+export function parseArtifactTags(text, { registry = null } = {}) {
+    const commands = [];
+    const errors = [];
+    if (typeof text !== "string" || !/<artifact\b/i.test(text)) return { commands, errors };
+
+    ARTIFACT_TAG_PATTERN.lastIndex = 0;
+    for (const match of text.matchAll(ARTIFACT_TAG_PATTERN)) {
+        try {
+            commands.push(parseCommand(parseAttributes(match[1]), registry));
+        } catch (error) {
+            errors.push({ tag: match[0], error });
+        }
+    }
+    return { commands, errors };
+}
+
+export function parseArtifactControlTags(controlTags, { registry = null } = {}) {
+    const commands = [];
+    const errors = [];
+    if (!Array.isArray(controlTags)) return { commands, errors };
+
+    for (const controlTag of controlTags) {
+        if (String(controlTag?.name || "").toLowerCase() !== "artifact") continue;
+        try {
+            commands.push(parseCommand(normalizeStructuredAttributes(controlTag.attributes), registry));
+        } catch (error) {
+            errors.push({ tag: controlTag, error });
+        }
+    }
+    return { commands, errors };
+}

--- a/examples/websocket/html/artifact/artifact-registry.js
+++ b/examples/websocket/html/artifact/artifact-registry.js
@@ -1,0 +1,42 @@
+const TYPE_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+function normalizeType(value, label = "Artifact type") {
+    const type = String(value || "").toLowerCase();
+    if (!TYPE_PATTERN.test(type)) throw new TypeError(`${label} is invalid: ${value}`);
+    return type;
+}
+
+export class ArtifactRegistry {
+    constructor(plugins = []) {
+        this.plugins = new Map();
+        for (const plugin of plugins) this.register(plugin);
+    }
+
+    register(plugin) {
+        if (!plugin || typeof plugin !== "object") {
+            throw new TypeError("Artifact plugin must be an object");
+        }
+        const type = normalizeType(plugin.type);
+        for (const method of ["parse", "resolveSource", "mount"]) {
+            if (typeof plugin[method] !== "function") {
+                throw new TypeError(`Artifact plugin ${type} must implement ${method}()`);
+            }
+        }
+
+        const names = [type, ...(plugin.aliases || []).map((alias) => normalizeType(alias, "Artifact alias"))];
+        for (const name of names) {
+            if (this.plugins.has(name)) throw new Error(`Artifact type is already registered: ${name}`);
+        }
+        for (const name of names) this.plugins.set(name, plugin);
+        return plugin;
+    }
+
+    get(type) {
+        if (typeof type !== "string") return null;
+        return this.plugins.get(type.toLowerCase()) || null;
+    }
+
+    has(type) {
+        return this.get(type) !== null;
+    }
+}

--- a/examples/websocket/html/artifact/artifact-url.js
+++ b/examples/websocket/html/artifact/artifact-url.js
@@ -1,0 +1,26 @@
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+export function parseArtifactHttpUrl(source) {
+    if (typeof source !== "string" || !source || source.length > 4096) {
+        throw new Error("Artifact URL is missing or too long");
+    }
+
+    let url;
+    try {
+        url = new URL(source);
+    } catch {
+        throw new Error("Artifact URL must be absolute");
+    }
+    if (url.username || url.password) throw new Error("Artifact URLs cannot contain credentials");
+    if (url.protocol !== "https:" && !(url.protocol === "http:" && LOCAL_HOSTS.has(url.hostname))) {
+        throw new Error("Artifact URLs must use HTTPS (HTTP is allowed only for localhost)");
+    }
+    return url;
+}
+
+export function normalizeArtifactSlide(slide) {
+    if (slide === null || slide === undefined || slide === "") return null;
+    const value = String(slide);
+    if (!/^[1-9]\d*$/.test(value)) throw new Error("Artifact slide must be a positive integer");
+    return value;
+}

--- a/examples/websocket/html/artifact/artifact.css
+++ b/examples/websocket/html/artifact/artifact.css
@@ -1,0 +1,149 @@
+.artifact-layer {
+    --artifact-available-height: var(--artifact-page-available-height, calc(100vh - 190px));
+    position: fixed;
+    inset: 0;
+    z-index: var(--artifact-layer-z-index, 0);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding-top: clamp(16px, 5vh, 56px);
+    background: rgba(0, 0, 0, 0.22);
+    pointer-events: none;
+}
+
+.artifact-layer[hidden] {
+    display: none;
+}
+
+.artifact-surface {
+    --artifact-width: min(86vw, 1440px);
+    position: relative;
+    display: grid;
+    place-items: center;
+    max-width: 100%;
+    max-height: var(--artifact-available-height);
+    overflow: hidden;
+    background: rgba(8, 10, 18, 0.88);
+    border: 1px solid rgba(210, 220, 255, 0.25);
+    border-radius: 10px;
+    box-shadow: 0 16px 60px rgba(0, 0, 0, 0.55);
+    pointer-events: auto;
+}
+
+.artifact-surface[data-size="small"] { --artifact-width: min(48vw, 720px); }
+.artifact-surface[data-size="medium"] { --artifact-width: min(68vw, 1000px); }
+.artifact-surface[data-size="large"] { --artifact-width: min(86vw, 1440px); }
+
+.artifact-surface[data-size="full"] {
+    --artifact-width: 100vw;
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
+}
+
+.artifact-surface[data-aspect="auto"]:not(.loaded) {
+    width: var(--artifact-width);
+    min-height: min(50vh, 480px);
+}
+
+.artifact-surface[data-aspect="auto"].loaded {
+    width: min(var(--artifact-width), calc(var(--artifact-available-height) * var(--artifact-ratio)));
+    aspect-ratio: var(--artifact-aspect);
+}
+
+.artifact-surface.loaded {
+    animation: artifact-surface-in 180ms ease;
+}
+
+@keyframes artifact-surface-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.artifact-surface:not([data-aspect="auto"]) {
+    width: min(var(--artifact-width), calc(var(--artifact-available-height) * var(--artifact-ratio)));
+    aspect-ratio: var(--artifact-aspect);
+}
+
+.artifact-media {
+    display: block;
+    width: 100%;
+    height: 100%;
+    max-height: var(--artifact-available-height);
+    border: 0;
+    opacity: 0;
+    transition: opacity 180ms ease;
+}
+
+.artifact-surface.loaded .artifact-media {
+    opacity: 1;
+}
+
+.artifact-status {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    color: rgba(235, 240, 255, 0.8);
+    font-size: 13px;
+    letter-spacing: 0.04em;
+    pointer-events: none;
+}
+
+.artifact-load-error .artifact-media {
+    display: none;
+}
+
+.artifact-close {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 1;
+    display: grid;
+    width: 32px;
+    height: 32px;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    place-items: center;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+    background: rgba(10, 12, 20, 0.72);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 50%;
+    opacity: 0;
+    transition: opacity 180ms ease, background 180ms ease;
+}
+
+.artifact-surface:hover .artifact-close,
+.artifact-close:focus-visible {
+    opacity: 1;
+}
+
+.artifact-close:hover {
+    background: rgba(25, 30, 48, 0.92);
+}
+
+@media (max-width: 720px) {
+    .artifact-layer {
+        --artifact-available-height: var(--artifact-page-available-height-mobile, calc(100vh - 170px));
+        padding-top: 18px;
+    }
+
+    .artifact-surface,
+    .artifact-surface[data-size="small"],
+    .artifact-surface[data-size="medium"],
+    .artifact-surface[data-size="large"] {
+        --artifact-width: 94vw;
+    }
+
+    .artifact-close { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .artifact-media,
+    .artifact-close { transition: none; }
+    .artifact-surface.loaded { animation: none; }
+}

--- a/examples/websocket/html/artifact/docswell-driver.js
+++ b/examples/websocket/html/artifact/docswell-driver.js
@@ -1,0 +1,123 @@
+import { PresentationDriver } from "./presentation-driver.js";
+
+let messageSequence = 0;
+
+const DOCSWELL_HOSTS = new Set(["docswell.com", "www.docswell.com"]);
+const EMBED_PATH = /^\/slide\/[A-Za-z0-9_-]+\/embed\/?$/;
+const VIEW_PATH = /^\/s\/[^/]+\/([A-Za-z0-9]{6})(?:-[^/]+)?\/?$/;
+
+function slideFromUrl(url) {
+    return Number(new URL(url).hash.match(/^#p([1-9]\d*)$/)?.[1] || 1);
+}
+
+function documentUrl(url) {
+    const value = new URL(url);
+    value.hash = "";
+    return value.href;
+}
+
+export class DocswellDriver extends PresentationDriver {
+    static get provider() {
+        return "docswell";
+    }
+
+    static supports(url) {
+        return DOCSWELL_HOSTS.has(url.hostname);
+    }
+
+    static resolveUrl(source, slide = null) {
+        const url = new URL(source.href);
+        if (!this.supports(url)) throw new Error("Invalid Docswell host");
+        for (const key of url.searchParams.keys()) {
+            if (key !== "key") throw new Error(`Unsupported Docswell parameter: ${key}`);
+        }
+        if (url.hash && !/^#p[1-9]\d*$/.test(url.hash)) {
+            throw new Error("Docswell page fragments must have the form #p7");
+        }
+
+        const viewMatch = url.pathname.match(VIEW_PATH);
+        if (viewMatch) {
+            url.pathname = `/slide/${viewMatch[1]}/embed`;
+        } else if (!EMBED_PATH.test(url.pathname)) {
+            throw new Error("Docswell URLs must be viewer or embed URLs");
+        } else {
+            url.pathname = url.pathname.replace(/\/$/, "");
+        }
+        if (slide !== null) url.hash = `p${slide}`;
+        return url.href;
+    }
+
+    constructor({ iframe, url, windowRoot = globalThis.window, onSlideChange = null }) {
+        super({ initialSlide: slideFromUrl(url), onSlideChange });
+        this.iframe = iframe;
+        this.url = url;
+        this.window = windowRoot;
+        this.origin = new URL(url).origin;
+        this.id = `aiavatar-artifact-${++messageSequence}`;
+        this.listening = false;
+        this.handleWindowMessage = this.handleWindowMessage.bind(this);
+    }
+
+    initialize() {
+        if (!this.listening) {
+            this.window?.addEventListener?.("message", this.handleWindowMessage);
+            this.listening = true;
+        }
+        try {
+            this.iframe.contentWindow?.postMessage(
+                { type: "docswell:initialize", id: this.id },
+                this.origin,
+            );
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    navigate(url) {
+        if (!this.ready || documentUrl(url) !== documentUrl(this.url)) return false;
+        const slide = slideFromUrl(url);
+        return this.postGo(slide - 1) ? slide : false;
+    }
+
+    navigateBy(offset) {
+        if (!this.ready || !Number.isSafeInteger(offset) || !offset) return false;
+        const upper = this.totalSlides || Number.MAX_SAFE_INTEGER;
+        const slide = Math.min(upper, Math.max(1, this.currentSlide + offset));
+        if (!this.postGo(slide - 1)) return false;
+        this._setCurrentSlide(slide);
+        return { slide };
+    }
+
+    postGo(to) {
+        try {
+            this.iframe.contentWindow.postMessage(
+                { type: "docswell:go", to, id: this.id },
+                this.origin,
+            );
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    handleWindowMessage(event) {
+        if (event.source !== this.iframe.contentWindow || event.origin !== this.origin) return;
+        const data = event.data;
+        if (!data || data.id !== this.id) return;
+
+        if (data.type === "docswell:initialized") {
+            const total = Number(data.total);
+            this._setReady(Number.isSafeInteger(total) && total > 0 ? total : null);
+        } else if (data.type === "docswell:move") {
+            const index = Number(data.index);
+            if (Number.isSafeInteger(index) && index >= 0) this._setCurrentSlide(index + 1);
+        }
+    }
+
+    dispose() {
+        if (this.listening) this.window?.removeEventListener?.("message", this.handleWindowMessage);
+        this.listening = false;
+        super.dispose();
+    }
+}

--- a/examples/websocket/html/artifact/image-artifact-plugin.js
+++ b/examples/websocket/html/artifact/image-artifact-plugin.js
@@ -1,0 +1,50 @@
+import {
+    assertArtifactAttributes,
+    parseArtifactDisplayAttributes,
+    parseArtifactSourceAttributes,
+} from "./artifact-parser.js";
+import { parseArtifactHttpUrl } from "./artifact-url.js";
+
+export class ImageArtifactPlugin {
+    constructor({ type = "image" } = {}) {
+        this.type = type;
+        this.aliases = [];
+    }
+
+    parse(attributes) {
+        assertArtifactAttributes(attributes);
+        const src = parseArtifactSourceAttributes(attributes);
+        if (!src) throw new Error("Artifact src is required");
+        return {
+            action: "show",
+            type: this.type,
+            src,
+            ...parseArtifactDisplayAttributes(attributes),
+        };
+    }
+
+    resolveSource(command) {
+        return { provider: "image", url: parseArtifactHttpUrl(command.src).href };
+    }
+
+    getDefaults() {
+        return { aspect: "auto" };
+    }
+
+    mount({ documentRoot, command, source, defaults, view }) {
+        const image = documentRoot.createElement("img");
+        image.className = "artifact-media";
+        image.src = source.url;
+        image.alt = command.alt || command.title || "";
+        image.decoding = "async";
+        image.draggable = false;
+        image.style.objectFit = "contain";
+        image.style.height = defaults.aspect === "auto" ? "auto" : "100%";
+        image.addEventListener("load", () => {
+            view.setIntrinsicAspect(image.naturalWidth, image.naturalHeight);
+            view.loaded();
+        }, { once: true });
+        image.addEventListener("error", () => view.error(), { once: true });
+        return { element: image, dispose() {} };
+    }
+}

--- a/examples/websocket/html/artifact/presentation-artifact-plugin.js
+++ b/examples/websocket/html/artifact/presentation-artifact-plugin.js
@@ -1,0 +1,148 @@
+import {
+    assertArtifactAttributes,
+    parseArtifactDisplayAttributes,
+    parseArtifactSourceAttributes,
+} from "./artifact-parser.js";
+import { normalizeArtifactSlide, parseArtifactHttpUrl } from "./artifact-url.js";
+
+export class PresentationArtifactPlugin {
+    constructor({ drivers = [] } = {}) {
+        if (!Array.isArray(drivers) || !drivers.length) {
+            throw new TypeError("PresentationArtifactPlugin requires at least one driver");
+        }
+        this.type = "presentation";
+        this.aliases = ["slide", "slides"];
+        this.drivers = [...drivers];
+    }
+
+    parse(attributes) {
+        assertArtifactAttributes(attributes, ["slide", "offset"]);
+
+        if (attributes.offset !== undefined) {
+            if (Object.keys(attributes).some((name) => name !== "type" && name !== "offset")) {
+                throw new Error("Relative presentation navigation accepts only type and offset");
+            }
+            if (!/^[+-][1-9]\d*$/.test(attributes.offset)) {
+                throw new Error("Artifact offset must be a signed non-zero integer");
+            }
+            return { action: "move", type: this.type, offset: Number(attributes.offset) };
+        }
+
+        const slide = normalizeArtifactSlide(attributes.slide);
+        const src = parseArtifactSourceAttributes(attributes);
+        if (!src) {
+            if (slide !== null) {
+                if (Object.keys(attributes).some((name) => name !== "type" && name !== "slide")) {
+                    throw new Error("Current presentation navigation accepts only type and slide");
+                }
+                return { action: "go", type: this.type, slide };
+            }
+            throw new Error("Artifact src is required");
+        }
+
+        return {
+            action: "show",
+            type: this.type,
+            src,
+            slide,
+            ...parseArtifactDisplayAttributes(attributes),
+        };
+    }
+
+    findDriver(url) {
+        return this.drivers.find((Driver) => Driver.supports(url)) || null;
+    }
+
+    resolveSource(command) {
+        const url = parseArtifactHttpUrl(command.src);
+        const Driver = this.findDriver(url);
+        if (!Driver) throw new Error("Presentation URL does not match a registered provider");
+        const source = {
+            provider: Driver.provider,
+            url: Driver.resolveUrl(url, normalizeArtifactSlide(command.slide)),
+        };
+        Object.defineProperty(source, "Driver", { value: Driver });
+        return source;
+    }
+
+    getDefaults() {
+        return { aspect: "16:9" };
+    }
+
+    mount({ documentRoot, windowRoot, command, source, view }) {
+        const iframe = documentRoot.createElement("iframe");
+        iframe.className = "artifact-media";
+        iframe.src = source.url;
+        iframe.title = command.title || "Presentation";
+        iframe.loading = "eager";
+        iframe.allow = "fullscreen; encrypted-media";
+        iframe.style.background = "#fff";
+        iframe.setAttribute("allowfullscreen", "");
+        iframe.setAttribute(
+            "sandbox",
+            "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox",
+        );
+
+        let currentUrl = source.url;
+        const driver = new source.Driver({
+            iframe,
+            url: source.url,
+            windowRoot,
+            onSlideChange: (slide) => {
+                try {
+                    currentUrl = source.Driver.resolveUrl(new URL(currentUrl), String(slide));
+                } catch {
+                    // Keep the last provider URL if it cannot represent manual navigation.
+                }
+                view.updateCurrent({ slide: String(slide), url: currentUrl });
+            },
+        });
+
+        iframe.addEventListener("load", () => {
+            view.loaded();
+            try {
+                driver.initialize();
+            } catch (error) {
+                view.error(error.message);
+            }
+        }, { once: true });
+
+        return {
+            element: iframe,
+            getState: () => ({
+                slide: driver.currentSlide,
+                totalSlides: driver.totalSlides,
+            }),
+            update: ({ source: nextSource }) => {
+                if (nextSource.provider !== source.provider) return false;
+                const slide = driver.navigate(nextSource.url);
+                if (slide === false) return false;
+                currentUrl = nextSource.url;
+                return { slide: String(slide), url: currentUrl };
+            },
+            execute: (nextCommand) => {
+                if (!driver.ready) return false;
+                if (nextCommand.action === "move") {
+                    const result = driver.navigateBy(nextCommand.offset);
+                    if (result === false) return false;
+                    if (result.url) currentUrl = result.url;
+                    return { slide: String(result.slide), url: currentUrl };
+                }
+                if (nextCommand.action === "go") {
+                    const nextSource = this.resolveSource({
+                        action: "show",
+                        type: this.type,
+                        src: currentUrl,
+                        slide: nextCommand.slide,
+                    });
+                    const slide = driver.navigate(nextSource.url);
+                    if (slide === false) return false;
+                    currentUrl = nextSource.url;
+                    return { slide: String(slide), url: currentUrl };
+                }
+                return false;
+            },
+            dispose: () => driver.dispose(),
+        };
+    }
+}

--- a/examples/websocket/html/artifact/presentation-driver.js
+++ b/examples/websocket/html/artifact/presentation-driver.js
@@ -1,0 +1,59 @@
+export class PresentationDriver {
+    static get provider() {
+        throw new Error("PresentationDriver.provider must be implemented");
+    }
+
+    static supports() {
+        return false;
+    }
+
+    static resolveUrl() {
+        throw new Error("PresentationDriver.resolveUrl() must be implemented");
+    }
+
+    constructor({ initialSlide = 1, onSlideChange = null } = {}) {
+        if (new.target === PresentationDriver) throw new TypeError("PresentationDriver is abstract");
+        this._ready = false;
+        this._currentSlide = initialSlide;
+        this._totalSlides = null;
+        this._onSlideChange = onSlideChange;
+    }
+
+    get ready() {
+        return this._ready;
+    }
+
+    get currentSlide() {
+        return this._currentSlide;
+    }
+
+    get totalSlides() {
+        return this._totalSlides;
+    }
+
+    initialize() {
+        throw new Error("PresentationDriver.initialize() must be implemented");
+    }
+
+    navigate() {
+        throw new Error("PresentationDriver.navigate() must be implemented");
+    }
+
+    navigateBy() {
+        throw new Error("PresentationDriver.navigateBy() must be implemented");
+    }
+
+    dispose() {
+        this._ready = false;
+    }
+
+    _setReady(totalSlides = null) {
+        this._ready = true;
+        this._totalSlides = totalSlides;
+    }
+
+    _setCurrentSlide(slide) {
+        this._currentSlide = slide;
+        this._onSlideChange?.(slide);
+    }
+}

--- a/examples/websocket/html/artifact/speakerdeck-driver.js
+++ b/examples/websocket/html/artifact/speakerdeck-driver.js
@@ -1,0 +1,71 @@
+import { PresentationDriver } from "./presentation-driver.js";
+
+const PLAYER_PATH = /^\/player\/[A-Za-z0-9_-]+\/?$/;
+
+function slideFromUrl(url) {
+    return Number(new URL(url).searchParams.get("slide") || 1);
+}
+
+function deckUrl(url) {
+    const value = new URL(url);
+    value.searchParams.delete("slide");
+    return value.href;
+}
+
+export class SpeakerDeckDriver extends PresentationDriver {
+    static get provider() {
+        return "speakerdeck";
+    }
+
+    static supports(url) {
+        return url.hostname === "speakerdeck.com";
+    }
+
+    static resolveUrl(source, slide = null) {
+        const url = new URL(source.href);
+        if (!this.supports(url)) throw new Error("Invalid Speaker Deck host");
+        if (!PLAYER_PATH.test(url.pathname)) {
+            throw new Error("Speaker Deck requires a player embed URL");
+        }
+        url.pathname = url.pathname.replace(/\/$/, "");
+        for (const key of url.searchParams.keys()) {
+            if (key !== "slide") throw new Error(`Unsupported Speaker Deck parameter: ${key}`);
+        }
+        if (slide !== null) url.searchParams.set("slide", slide);
+        const resolvedSlide = url.searchParams.get("slide");
+        if (resolvedSlide !== null && !/^[1-9]\d*$/.test(resolvedSlide)) {
+            throw new Error("Speaker Deck slide must be a positive integer");
+        }
+        if (url.hash) throw new Error("Speaker Deck embed URLs cannot contain a fragment");
+        return url.href;
+    }
+
+    constructor({ iframe, url }) {
+        super({ initialSlide: null });
+        this.iframe = iframe;
+        this.url = url;
+        this.requestedSlide = slideFromUrl(url);
+    }
+
+    initialize() {
+        this._setReady();
+        return true;
+    }
+
+    navigate(url) {
+        if (!this.ready || deckUrl(url) !== deckUrl(this.url)) return false;
+        const slide = slideFromUrl(url);
+        this.iframe.src = url;
+        this.url = url;
+        this.requestedSlide = slide;
+        return slide;
+    }
+
+    navigateBy(offset) {
+        if (!this.ready || !Number.isSafeInteger(offset) || !offset) return false;
+        const url = new URL(this.url);
+        const slide = Math.max(1, this.requestedSlide + offset);
+        url.searchParams.set("slide", slide);
+        return this.navigate(url.href) === false ? false : { slide, url: this.url };
+    }
+}

--- a/examples/websocket/html/artifact/video-artifact-plugin.js
+++ b/examples/websocket/html/artifact/video-artifact-plugin.js
@@ -1,0 +1,96 @@
+import {
+    assertArtifactAttributes,
+    parseArtifactDisplayAttributes,
+    parseArtifactSourceAttributes,
+} from "./artifact-parser.js";
+import { parseArtifactHttpUrl } from "./artifact-url.js";
+
+const MAX_AUTOPLAY_DELAY_SECONDS = 3600;
+
+function parseAutoplayDelay(value) {
+    if (value === undefined || value === "") return 0;
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds) || seconds < 0 || seconds > MAX_AUTOPLAY_DELAY_SECONDS) {
+        throw new RangeError(`Video autoplay-delay must be between 0 and ${MAX_AUTOPLAY_DELAY_SECONDS} seconds`);
+    }
+    return seconds;
+}
+
+export class VideoArtifactPlugin {
+    constructor({ drivers = [], autoplay = true, defaultAutoplayDelaySeconds = 0 } = {}) {
+        if (!Array.isArray(drivers) || !drivers.length) {
+            throw new TypeError("VideoArtifactPlugin requires at least one driver");
+        }
+        this.type = "video";
+        this.aliases = [];
+        this.drivers = [...drivers];
+        this.autoplay = Boolean(autoplay);
+        this.defaultAutoplayDelaySeconds = parseAutoplayDelay(defaultAutoplayDelaySeconds);
+    }
+
+    parse(attributes) {
+        assertArtifactAttributes(attributes, ["autoplay-delay"]);
+        const src = parseArtifactSourceAttributes(attributes);
+        if (!src) throw new Error("Artifact src is required");
+        return {
+            action: "show",
+            type: this.type,
+            src,
+            autoplayDelaySeconds: attributes["autoplay-delay"] === undefined
+                ? this.defaultAutoplayDelaySeconds
+                : parseAutoplayDelay(attributes["autoplay-delay"]),
+            ...parseArtifactDisplayAttributes(attributes),
+        };
+    }
+
+    resolveSource(command) {
+        const url = parseArtifactHttpUrl(command.src);
+        const Driver = this.drivers.find((candidate) => candidate.supports(url));
+        if (!Driver) throw new Error("Video URL does not match a registered provider");
+        const source = { provider: Driver.provider, url: Driver.resolveUrl(url) };
+        Object.defineProperty(source, "Driver", { value: Driver });
+        return source;
+    }
+
+    getDefaults() {
+        return { aspect: "16:9" };
+    }
+
+    mount({ documentRoot, windowRoot, command, source, view }) {
+        const iframe = documentRoot.createElement("iframe");
+        iframe.className = "artifact-media";
+        iframe.title = command.title || "Video";
+        iframe.loading = "eager";
+        iframe.style.background = "#000";
+        iframe.setAttribute(
+            "sandbox",
+            "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox",
+        );
+
+        const driver = new source.Driver({
+            iframe,
+            url: source.url,
+            windowRoot,
+            documentRoot,
+            autoplay: this.autoplay,
+            autoplayDelaySeconds: command.autoplayDelaySeconds,
+            onEvent: (event) => {
+                if (event.type === "ready") view.loaded();
+                else if (event.type === "error") view.error(event.error?.message);
+                else if (event.type === "autoplayblocked") {
+                    console.warn("Video autoplay was blocked; use the embedded player controls");
+                }
+            },
+        });
+
+        iframe.addEventListener("load", () => {
+            driver.initialize().catch((error) => view.error(error.message));
+        }, { once: true });
+
+        return {
+            element: iframe,
+            getState: () => ({ state: driver.state }),
+            dispose: () => driver.dispose(),
+        };
+    }
+}

--- a/examples/websocket/html/artifact/video-driver.js
+++ b/examples/websocket/html/artifact/video-driver.js
@@ -1,0 +1,91 @@
+export const VIDEO_STATES = Object.freeze({
+    IDLE: "idle",
+    UNSTARTED: "unstarted",
+    CUED: "cued",
+    PLAYING: "playing",
+    PAUSED: "paused",
+    BUFFERING: "buffering",
+    ENDED: "ended",
+    ERROR: "error",
+});
+
+const VALID_STATES = new Set(Object.values(VIDEO_STATES));
+
+export class VideoDriver {
+    static get provider() {
+        throw new Error("VideoDriver.provider must be implemented");
+    }
+
+    static supports() {
+        return false;
+    }
+
+    static resolveUrl() {
+        throw new Error("VideoDriver.resolveUrl() must be implemented");
+    }
+
+    constructor({ onEvent = null } = {}) {
+        if (new.target === VideoDriver) throw new TypeError("VideoDriver is abstract");
+        if (onEvent !== null && typeof onEvent !== "function") {
+            throw new TypeError("VideoDriver onEvent must be a function");
+        }
+        this._ready = false;
+        this._disposed = false;
+        this._state = VIDEO_STATES.IDLE;
+        this._onEvent = onEvent;
+    }
+
+    get ready() {
+        return this._ready;
+    }
+
+    get disposed() {
+        return this._disposed;
+    }
+
+    get state() {
+        return this._state;
+    }
+
+    initialize() {
+        throw new Error("VideoDriver.initialize() must be implemented");
+    }
+
+    startAutoplay() {
+        throw new Error("VideoDriver.startAutoplay() must be implemented");
+    }
+
+    dispose() {
+        this._ready = false;
+        this._disposed = true;
+    }
+
+    _setReady() {
+        if (this.disposed || this.ready) return false;
+        this._ready = true;
+        this._emit("ready");
+        return true;
+    }
+
+    _setState(state) {
+        if (!VALID_STATES.has(state)) throw new Error(`Invalid video state: ${state}`);
+        if (this.disposed || state === this._state) return false;
+        const previousState = this._state;
+        this._state = state;
+        this._emit("statechange", { state, previousState });
+        return true;
+    }
+
+    _emit(type, detail = {}) {
+        if (this.disposed || !this._onEvent) return;
+        try {
+            this._onEvent({
+                type,
+                provider: this.constructor.provider,
+                ...detail,
+            });
+        } catch (error) {
+            globalThis.console?.error?.("VideoDriver event handler failed:", error);
+        }
+    }
+}

--- a/examples/websocket/html/artifact/youtube-driver.js
+++ b/examples/websocket/html/artifact/youtube-driver.js
@@ -1,0 +1,305 @@
+import { VIDEO_STATES, VideoDriver } from "./video-driver.js";
+import { loadYouTubeIframeApi } from "./youtube-iframe-api-loader.js";
+
+const YOUTUBE_HOSTS = new Set(["youtube.com", "www.youtube.com", "m.youtube.com"]);
+const YOUTUBE_SHORT_HOSTS = new Set(["youtu.be", "www.youtu.be"]);
+const VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+const EMBED_PATH = /^\/embed\/([A-Za-z0-9_-]{11})\/?$/;
+
+const PLAYER_STATES = new Map([
+    [-1, VIDEO_STATES.UNSTARTED],
+    [0, VIDEO_STATES.ENDED],
+    [1, VIDEO_STATES.PLAYING],
+    [2, VIDEO_STATES.PAUSED],
+    [3, VIDEO_STATES.BUFFERING],
+    [5, VIDEO_STATES.CUED],
+]);
+
+const ERROR_MESSAGES = new Map([
+    [2, "Invalid YouTube video ID or player parameter"],
+    [5, "The YouTube video cannot be played in this HTML5 player"],
+    [100, "The YouTube video was not found or is private"],
+    [101, "The YouTube video owner does not allow embedding"],
+    [150, "The YouTube video owner does not allow embedding"],
+    [153, "The YouTube player request did not include valid client identity"],
+]);
+
+function normalizeDelaySeconds(value) {
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds) || seconds < 0) {
+        throw new RangeError("YouTube autoplay delay must be a non-negative number");
+    }
+    return seconds;
+}
+
+function normalizeStartSeconds(value) {
+    if (value === null || value === undefined || value === "") return null;
+    const seconds = Number(value);
+    if (!Number.isSafeInteger(seconds) || seconds < 0) {
+        throw new RangeError("YouTube start time must be a non-negative integer");
+    }
+    return seconds;
+}
+
+function parseTime(value) {
+    if (!value) return null;
+    if (/^\d+$/.test(value)) return Number(value);
+    const match = String(value).match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/);
+    if (!match || !match[0]) return null;
+    return Number(match[1] || 0) * 3600
+        + Number(match[2] || 0) * 60
+        + Number(match[3] || 0);
+}
+
+function extractVideoSource(url) {
+    let videoId = null;
+    if (YOUTUBE_SHORT_HOSTS.has(url.hostname)) {
+        const path = url.pathname.replace(/^\//, "").replace(/\/$/, "");
+        if (!path.includes("/")) videoId = path;
+    } else if (YOUTUBE_HOSTS.has(url.hostname)) {
+        if (url.pathname === "/watch") videoId = url.searchParams.get("v");
+        else videoId = url.pathname.match(EMBED_PATH)?.[1] || null;
+    }
+    if (!VIDEO_ID_PATTERN.test(videoId || "")) {
+        throw new Error("YouTube URLs must identify one embeddable video");
+    }
+
+    const start = url.searchParams.get("start");
+    const startSeconds = normalizeStartSeconds(
+        start === null || start === "" ? parseTime(url.searchParams.get("t")) : start,
+    );
+    return { videoId, startSeconds };
+}
+
+function appendIframePermission(iframe, permission) {
+    const permissions = new Set(
+        String(iframe.allow || "")
+            .split(";")
+            .map((value) => value.trim())
+            .filter(Boolean),
+    );
+    permissions.add(permission);
+    iframe.allow = Array.from(permissions).join("; ");
+}
+
+export class YouTubeDriver extends VideoDriver {
+    static get provider() {
+        return "youtube";
+    }
+
+    static supports(url) {
+        return url.protocol === "https:"
+            && (YOUTUBE_HOSTS.has(url.hostname) || YOUTUBE_SHORT_HOSTS.has(url.hostname));
+    }
+
+    static resolveUrl(source, { startSeconds = null, origin = null } = {}) {
+        const url = new URL(source instanceof URL ? source.href : source);
+        if (!this.supports(url)) throw new Error("Invalid YouTube host or protocol");
+        if (url.username || url.password) throw new Error("YouTube URLs cannot contain credentials");
+
+        const resolved = extractVideoSource(url);
+        const start = normalizeStartSeconds(startSeconds ?? resolved.startSeconds);
+        const embed = new URL(`https://www.youtube.com/embed/${resolved.videoId}`);
+        embed.searchParams.set("enablejsapi", "1");
+        embed.searchParams.set("playsinline", "1");
+        if (start !== null && start > 0) embed.searchParams.set("start", String(start));
+
+        if (origin) {
+            const originUrl = new URL(origin);
+            if (originUrl.protocol !== "https:" && originUrl.protocol !== "http:") {
+                throw new Error("YouTube embed origin must use HTTP or HTTPS");
+            }
+            embed.searchParams.set("origin", originUrl.origin);
+        }
+        return embed.href;
+    }
+
+    constructor({
+        iframe,
+        url,
+        windowRoot = globalThis.window,
+        documentRoot = globalThis.document,
+        apiLoader = loadYouTubeIframeApi,
+        autoplay = false,
+        autoplayDelaySeconds = 0,
+        muted = false,
+        onEvent = null,
+    } = {}) {
+        super({ onEvent });
+        if (!iframe || typeof iframe !== "object") throw new TypeError("YouTubeDriver requires an iframe");
+        if (typeof apiLoader !== "function") throw new TypeError("YouTubeDriver apiLoader must be a function");
+
+        this.iframe = iframe;
+        this.window = windowRoot;
+        this.document = documentRoot;
+        this.apiLoader = apiLoader;
+        this.autoplay = Boolean(autoplay);
+        this.autoplayDelaySeconds = normalizeDelaySeconds(autoplayDelaySeconds);
+        this.muted = Boolean(muted);
+        this.player = null;
+        this._initializePromise = null;
+        this._autoplayTimer = null;
+        this._autoplayAttempted = false;
+        this._hasStarted = false;
+        this._autoplayDeadline = this.autoplay
+            ? Date.now() + this.autoplayDelaySeconds * 1000
+            : null;
+
+        const origin = windowRoot?.location?.origin;
+        this.url = this.constructor.resolveUrl(url, {
+            origin: origin && origin !== "null" ? origin : null,
+        });
+        this.configureIframe();
+    }
+
+    get autoplayAttempted() {
+        return this._autoplayAttempted;
+    }
+
+    get hasStarted() {
+        return this._hasStarted;
+    }
+
+    configureIframe() {
+        this.iframe.src = this.url;
+        for (const permission of ["autoplay", "encrypted-media", "fullscreen", "picture-in-picture"]) {
+            appendIframePermission(this.iframe, permission);
+        }
+        this.iframe.setAttribute?.("allowfullscreen", "");
+    }
+
+    initialize() {
+        if (this.disposed) return Promise.resolve(false);
+        if (this._initializePromise) return this._initializePromise;
+
+        this._initializePromise = Promise.resolve(this.apiLoader({
+            windowRoot: this.window,
+            documentRoot: this.document,
+        })).then((YT) => {
+            if (this.disposed) return false;
+            if (typeof YT?.Player !== "function") throw new Error("YouTube IFrame API did not provide YT.Player");
+
+            return new Promise((resolve, reject) => {
+                let settled = false;
+                const settleReady = () => {
+                    if (settled) return;
+                    settled = true;
+                    resolve(true);
+                };
+                const settleError = (error) => {
+                    if (settled) return;
+                    settled = true;
+                    reject(error);
+                };
+
+                try {
+                    this.player = new YT.Player(this.iframe, {
+                        events: {
+                            onReady: (event) => {
+                                if (this.disposed) return;
+                                this.player = event.target || this.player;
+                                this._setReady();
+                                this._scheduleAutoplay();
+                                settleReady();
+                            },
+                            onStateChange: (event) => this._handleStateChange(event.data),
+                            onAutoplayBlocked: () => this._handleAutoplayBlocked(),
+                            onError: (event) => {
+                                const error = this._handlePlayerError(event.data);
+                                settleError(error);
+                            },
+                        },
+                    });
+                } catch (error) {
+                    this._setState(VIDEO_STATES.ERROR);
+                    this._emit("error", { error });
+                    settleError(error);
+                }
+            });
+        }).catch((error) => {
+            if (!this.disposed && this.state !== VIDEO_STATES.ERROR) {
+                this._setState(VIDEO_STATES.ERROR);
+                this._emit("error", { error });
+            }
+            throw error;
+        });
+        return this._initializePromise;
+    }
+
+    startAutoplay() {
+        if (this.disposed || !this.ready || !this.player) return false;
+        if (this._autoplayAttempted || this._hasStarted) return false;
+        this._autoplayAttempted = true;
+        this._clearAutoplayTimer();
+
+        try {
+            if (this.muted) this.player.mute?.();
+            this.player.playVideo();
+            this._emit("autoplayrequested", { muted: this.muted });
+            return true;
+        } catch (error) {
+            this._setState(VIDEO_STATES.ERROR);
+            this._emit("error", { error });
+            return false;
+        }
+    }
+
+    _scheduleAutoplay() {
+        if (!this.autoplay || this.disposed || !this.ready || this._hasStarted || this._autoplayAttempted) return;
+        this._clearAutoplayTimer();
+        const delayMs = Math.max(0, (this._autoplayDeadline || Date.now()) - Date.now());
+        const setTimer = this.window?.setTimeout?.bind(this.window) || globalThis.setTimeout;
+        this._autoplayTimer = setTimer(() => {
+            this._autoplayTimer = null;
+            this.startAutoplay();
+        }, delayMs);
+        this._emit("autoplayscheduled", { delaySeconds: delayMs / 1000 });
+    }
+
+    _handleStateChange(playerState) {
+        if (this.disposed) return;
+        const state = PLAYER_STATES.get(Number(playerState));
+        if (!state) return;
+        this._setState(state);
+        if (state === VIDEO_STATES.PLAYING) {
+            this._hasStarted = true;
+            this._clearAutoplayTimer();
+        }
+    }
+
+    _handleAutoplayBlocked() {
+        if (this.disposed) return;
+        this._clearAutoplayTimer();
+        this._emit("autoplayblocked");
+    }
+
+    _handlePlayerError(providerCode) {
+        const code = Number(providerCode);
+        const error = new Error(ERROR_MESSAGES.get(code) || `YouTube player error: ${providerCode}`);
+        error.code = "youtube-player-error";
+        error.providerCode = providerCode;
+        this._setState(VIDEO_STATES.ERROR);
+        this._clearAutoplayTimer();
+        this._emit("error", { error, providerCode });
+        return error;
+    }
+
+    _clearAutoplayTimer() {
+        if (this._autoplayTimer === null) return;
+        const clearTimer = this.window?.clearTimeout?.bind(this.window) || globalThis.clearTimeout;
+        clearTimer(this._autoplayTimer);
+        this._autoplayTimer = null;
+    }
+
+    dispose() {
+        if (this.disposed) return;
+        this._clearAutoplayTimer();
+        try {
+            this.player?.destroy?.();
+        } catch {
+            // The containing artifact will remove the iframe even if the provider cleanup fails.
+        }
+        this.player = null;
+        super.dispose();
+    }
+}

--- a/examples/websocket/html/artifact/youtube-iframe-api-loader.js
+++ b/examples/websocket/html/artifact/youtube-iframe-api-loader.js
@@ -1,0 +1,103 @@
+const YOUTUBE_IFRAME_API_URL = "https://www.youtube.com/iframe_api";
+const apiLoads = new WeakMap();
+
+function isApiReady(windowRoot) {
+    return typeof windowRoot?.YT?.Player === "function";
+}
+
+export function loadYouTubeIframeApi({
+    windowRoot = globalThis.window,
+    documentRoot = globalThis.document,
+    timeoutMs = 15000,
+} = {}) {
+    if (!windowRoot || !documentRoot) {
+        return Promise.reject(new Error("YouTube IFrame API requires window and document"));
+    }
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        return Promise.reject(new RangeError("YouTube IFrame API timeout must be positive"));
+    }
+    if (isApiReady(windowRoot)) return Promise.resolve(windowRoot.YT);
+
+    const pending = apiLoads.get(windowRoot);
+    if (pending) return pending;
+
+    let loadPromise;
+    loadPromise = new Promise((resolve, reject) => {
+        let settled = false;
+        let pollTimer = null;
+        let timeoutTimer = null;
+        let script = null;
+        const previousReadyCallback = windowRoot.onYouTubeIframeAPIReady;
+
+        const clearTimer = windowRoot.clearTimeout?.bind(windowRoot) || globalThis.clearTimeout;
+        const setTimer = windowRoot.setTimeout?.bind(windowRoot) || globalThis.setTimeout;
+        const clearPoll = windowRoot.clearInterval?.bind(windowRoot) || globalThis.clearInterval;
+        const setPoll = windowRoot.setInterval?.bind(windowRoot) || globalThis.setInterval;
+
+        const cleanup = () => {
+            if (pollTimer !== null) clearPoll(pollTimer);
+            if (timeoutTimer !== null) clearTimer(timeoutTimer);
+            script?.removeEventListener?.("error", handleScriptError);
+            if (windowRoot.onYouTubeIframeAPIReady === handleApiReady) {
+                windowRoot.onYouTubeIframeAPIReady = previousReadyCallback;
+            }
+        };
+
+        const finish = () => {
+            if (settled || !isApiReady(windowRoot)) return false;
+            settled = true;
+            cleanup();
+            resolve(windowRoot.YT);
+            return true;
+        };
+
+        const fail = (error) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            reject(error);
+        };
+
+        function handleApiReady(...args) {
+            if (typeof previousReadyCallback === "function") {
+                try {
+                    previousReadyCallback.apply(windowRoot, args);
+                } catch (error) {
+                    windowRoot.console?.error?.("Existing YouTube API callback failed:", error);
+                }
+            }
+            finish();
+        }
+
+        function handleScriptError() {
+            fail(new Error("Could not load the YouTube IFrame API"));
+        }
+
+        windowRoot.onYouTubeIframeAPIReady = handleApiReady;
+        script = documentRoot.querySelector?.(`script[src="${YOUTUBE_IFRAME_API_URL}"]`) || null;
+        if (!script) {
+            script = documentRoot.createElement?.("script");
+            const parent = documentRoot.head || documentRoot.body || documentRoot.documentElement;
+            if (!script || !parent?.appendChild) {
+                fail(new Error("Could not create the YouTube IFrame API script"));
+                return;
+            }
+            script.src = YOUTUBE_IFRAME_API_URL;
+            script.async = true;
+            parent.appendChild(script);
+        }
+        script.addEventListener?.("error", handleScriptError, { once: true });
+
+        pollTimer = setPoll(finish, 50);
+        timeoutTimer = setTimer(() => {
+            fail(new Error("Timed out loading the YouTube IFrame API"));
+        }, timeoutMs);
+        finish();
+    });
+
+    apiLoads.set(windowRoot, loadPromise);
+    loadPromise.catch(() => {
+        if (apiLoads.get(windowRoot) === loadPromise) apiLoads.delete(windowRoot);
+    });
+    return loadPromise;
+}

--- a/examples/websocket/html/avatar3d/3d-main.js
+++ b/examples/websocket/html/avatar3d/3d-main.js
@@ -82,10 +82,11 @@ export async function start3dPage(config) {
         persistence,
         blobStore,
     });
-    const { model, ...commonConfig } = config;
+    const { model, artifactPlugins = [], ...commonConfig } = config;
     return startAvatarApp({
         config: { ...commonConfig, persistence },
         modelAdapter,
         blobStore,
+        artifactPlugins,
     });
 }

--- a/examples/websocket/html/avatar3d/3d.css
+++ b/examples/websocket/html/avatar3d/3d.css
@@ -21,6 +21,26 @@ body {
     width: 100%;
     height: 100%;
     display: block;
+    pointer-events: none;
+}
+
+#avatarControlSurface {
+    position: fixed;
+    inset: 0;
+    z-index: 2;
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+    touch-action: none;
+    pointer-events: auto;
+}
+
+#avatarControlSurface:active {
+    cursor: grabbing;
+}
+
+#avatarControlSurface[hidden] {
+    display: none;
 }
 
 .avatar-placeholder {
@@ -434,6 +454,7 @@ body {
     z-index: 1;
     width: 100%;
     height: 100%;
+    pointer-events: none;
 }
 
 #visionPreview {

--- a/examples/websocket/html/avatar3d/common/app.js
+++ b/examples/websocket/html/avatar3d/common/app.js
@@ -4,6 +4,7 @@ import { installMessageController } from "./message-controller.js";
 import { installPageControls } from "./page-controls.js";
 import { installToolToasts } from "./tool-toast.js";
 import { VisionController } from "./vision-controller.js";
+import { ArtifactController } from "../../artifact/artifact-controller.js";
 
 function requireObject(value, name) {
     if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -27,7 +28,7 @@ function validateConfig(config) {
     }
 }
 
-export async function startAvatarApp({ config, modelAdapter, blobStore }) {
+export async function startAvatarApp({ config, modelAdapter, blobStore, artifactPlugins = [] }) {
     validateConfig(config);
     assertAvatarAdapter(modelAdapter);
     const aiavatar = new AIAvatarClient({
@@ -67,6 +68,10 @@ export async function startAvatarApp({ config, modelAdapter, blobStore }) {
         autoHideDelayMs: config.ui.autoHideDelayMs,
     });
     const vision = new VisionController({ aiavatar, ui, config: config.vision });
+    const artifacts = new ArtifactController({
+        plugins: artifactPlugins,
+        onVisibilityChange: (active) => modelAdapter.setArtifactMode?.(active),
+    });
     const controls = installPageControls({
         ui,
         state: display.state,
@@ -102,6 +107,7 @@ export async function startAvatarApp({ config, modelAdapter, blobStore }) {
     document.addEventListener("drop", onDrop);
 
     aiavatar.onResponseReceived = (response) => {
+        artifacts.handleResponse(response);
         modelAdapter.handleResponse(response);
         vision.handleResponse(response);
         if (response.type === "connected") display.updateConnection(true, response);
@@ -120,13 +126,14 @@ export async function startAvatarApp({ config, modelAdapter, blobStore }) {
         controls.dispose();
         messages.dispose();
         toasts.dispose();
+        artifacts.dispose();
         vision.dispose();
         display.dispose();
         modelAdapter.dispose();
     };
     window.addEventListener("pagehide", dispose, { once: true });
 
-    const app = { aiavatar, ui, modelAdapter, display, vision, dispose };
+    const app = { aiavatar, ui, modelAdapter, display, vision, artifacts, dispose };
     globalThis.avatar3d = app;
     return app;
 }

--- a/examples/websocket/html/avatar3d/models/vrm/vrm-adapter.js
+++ b/examples/websocket/html/avatar3d/models/vrm/vrm-adapter.js
@@ -5,6 +5,12 @@ import { VRMLoaderPlugin, VRMUtils } from "@pixiv/three-vrm";
 import { VRMAnimationLoaderPlugin, createVRMAnimationClip } from "@pixiv/three-vrm-animation";
 import { installVrmSettings } from "./vrm-settings.js";
 
+const ARTIFACT_CAMERA_REFERENCE = {
+    modelHeight: 1.670250301549527,
+    targetOffset: [-0.10330158393900676, 0, -0.1170766868649855],
+    cameraOffset: [1.100777579891017, 0.2236689191280165, 3.040772395500192],
+};
+
 function kelvinToRgb(kelvin) {
     const temperature = kelvin / 100;
     let red;
@@ -30,6 +36,9 @@ export class VrmAdapter {
         this.currentModel = null;
         this.renderRequest = null;
         this.cameraSaveTimer = null;
+        this.artifactMode = false;
+        this.normalCameraState = null;
+        this.normalMaxDistance = null;
         this.onAnimationListChanged = () => {};
         this.lighting = { ...config.lighting };
         this.lightDefinitions = [
@@ -45,6 +54,7 @@ export class VrmAdapter {
         this.aiavatar = aiavatar;
         this.ui = ui;
         this.canvas = document.getElementById("avatarCanvas");
+        this.controlSurface = document.getElementById("avatarControlSurface");
         this.placeholder = document.getElementById("avatarPlaceholder");
 
         this.idle = new VRMIdle({ isAudioPlaying: () => aiavatar.isAudioPlaying });
@@ -90,23 +100,77 @@ export class VrmAdapter {
         this.directionalLight = new THREE.DirectionalLight(0xffffff, this.lighting.directional);
         this.scene.add(this.ambientLight, this.directionalLight);
 
-        this.controls = new OrbitControls(this.viewCamera, this.canvas);
-        this.controls.target.set(...cameraConfig.target);
-        this.controls.enableDamping = cameraConfig.enableDamping;
-        this.controls.dampingFactor = cameraConfig.dampingFactor;
-        this.controls.enablePan = cameraConfig.enablePan;
-        this.controls.minDistance = cameraConfig.minDistance;
-        this.controls.maxDistance = cameraConfig.maxDistance;
-        this.controls.update();
-        this.controls.addEventListener("change", () => {
-            clearTimeout(this.cameraSaveTimer);
-            this.cameraSaveTimer = setTimeout(() => this.saveCameraState(), this.config.camera.saveDebounceMs);
-        });
+        this.controls = this.createControls(
+            new THREE.Vector3(...cameraConfig.target),
+            cameraConfig.maxDistance,
+        );
 
         this.clock = new THREE.Clock();
         this.loader = new GLTFLoader();
         this.loader.register((parser) => new VRMLoaderPlugin(parser));
         this.loader.register((parser) => new VRMAnimationLoaderPlugin(parser));
+    }
+
+    createControls(target, maxDistance) {
+        const controls = new OrbitControls(this.viewCamera, this.controlSurface);
+        controls.target.copy(target);
+        controls.enableDamping = this.config.camera.enableDamping;
+        controls.dampingFactor = this.config.camera.dampingFactor;
+        controls.enablePan = this.config.camera.enablePan;
+        controls.minDistance = this.config.camera.minDistance;
+        controls.maxDistance = maxDistance;
+        controls.update();
+        controls.addEventListener("change", () => {
+            this.updateControlSurface();
+            clearTimeout(this.cameraSaveTimer);
+            this.cameraSaveTimer = setTimeout(() => this.saveCameraState(), this.config.camera.saveDebounceMs);
+        });
+        return controls;
+    }
+
+    updateControlSurface() {
+        if (!this.currentModel) {
+            this.controlSurface.hidden = true;
+            return;
+        }
+
+        const bounds = new THREE.Box3().setFromObject(this.currentModel.scene);
+        if (bounds.isEmpty()) {
+            this.controlSurface.hidden = true;
+            return;
+        }
+
+        const min = bounds.min;
+        const max = bounds.max;
+        const point = new THREE.Vector3();
+        let left = Infinity;
+        let top = Infinity;
+        let right = -Infinity;
+        let bottom = -Infinity;
+        for (const x of [min.x, max.x]) {
+            for (const y of [min.y, max.y]) {
+                for (const z of [min.z, max.z]) {
+                    point.set(x, y, z).project(this.viewCamera);
+                    left = Math.min(left, (point.x + 1) * window.innerWidth / 2);
+                    right = Math.max(right, (point.x + 1) * window.innerWidth / 2);
+                    top = Math.min(top, (1 - point.y) * window.innerHeight / 2);
+                    bottom = Math.max(bottom, (1 - point.y) * window.innerHeight / 2);
+                }
+            }
+        }
+
+        const padding = 12;
+        left = Math.max(0, left - padding);
+        top = Math.max(0, top - padding);
+        right = Math.min(window.innerWidth, right + padding);
+        bottom = Math.min(window.innerHeight, bottom + padding);
+        if (right <= left || bottom <= top) {
+            this.controlSurface.hidden = true;
+            return;
+        }
+
+        this.controlSurface.style.clipPath = `inset(${top}px ${window.innerWidth - right}px ${window.innerHeight - bottom}px ${left}px)`;
+        this.controlSurface.hidden = false;
     }
 
     bind(aiavatar) {
@@ -173,6 +237,7 @@ export class VrmAdapter {
             this.controls.update();
         }
         if (model.lookAt) model.lookAt.target = this.viewCamera;
+        this.updateControlSurface();
         this.placeholder.style.display = "none";
         console.log("VRM loaded");
         return model;
@@ -184,6 +249,7 @@ export class VrmAdapter {
         VRMUtils.deepDispose(this.currentModel.scene);
         this.currentModel = null;
         this.idle.vrm = null;
+        this.updateControlSurface();
     }
 
     async unloadModel({ clearCache = false } = {}) {
@@ -194,7 +260,10 @@ export class VrmAdapter {
 
     async clearModelCache() {
         await this.blobStore.delete(this.persistence.modelKey);
-        if (this.persistence.enabled) localStorage.removeItem(this.persistence.cameraKey);
+        if (this.persistence.enabled) {
+            localStorage.removeItem(this.persistence.cameraKey);
+            localStorage.removeItem(this.artifactCameraKey);
+        }
     }
 
     async loadAnimationBlob(name, blob, { cache = false } = {}) {
@@ -354,30 +423,124 @@ export class VrmAdapter {
         this.directionalLight.color.setRGB(...kelvinToRgb(this.lighting.colorTemperature));
     }
 
-    saveCameraState() {
-        if (!this.persistence.enabled) return;
-        localStorage.setItem(this.persistence.cameraKey, JSON.stringify({
+    get artifactCameraKey() {
+        return `${this.persistence.cameraKey}_artifact`;
+    }
+
+    captureCameraState() {
+        return {
             px: this.viewCamera.position.x,
             py: this.viewCamera.position.y,
             pz: this.viewCamera.position.z,
             tx: this.controls.target.x,
             ty: this.controls.target.y,
             tz: this.controls.target.z,
-        }));
+        };
     }
 
-    restoreCameraState() {
+    applyCameraState(state, { resetControls = false, maxDistance = this.controls.maxDistance } = {}) {
+        const values = [state?.px, state?.py, state?.pz, state?.tx, state?.ty, state?.tz];
+        if (!values.every(Number.isFinite)) return false;
+        this.viewCamera.position.set(state.px, state.py, state.pz);
+        const target = new THREE.Vector3(state.tx, state.ty, state.tz);
+        if (resetControls) {
+            this.controls.dispose();
+            this.controls = this.createControls(target, maxDistance);
+        } else {
+            this.controls.target.copy(target);
+            this.controls.update();
+        }
+        return true;
+    }
+
+    saveCameraState(key = this.artifactMode ? this.artifactCameraKey : this.persistence.cameraKey) {
+        if (!this.persistence.enabled) return;
+        const state = this.captureCameraState();
+        if (key === this.artifactCameraKey) state.layout = "viewport";
+        localStorage.setItem(key, JSON.stringify(state));
+    }
+
+    restoreCameraState(
+        key = this.artifactMode ? this.artifactCameraKey : this.persistence.cameraKey,
+        options = {},
+    ) {
         if (!this.persistence.enabled || !this.persistence.restoreUserSettings) return false;
         try {
-            const saved = JSON.parse(localStorage.getItem(this.persistence.cameraKey));
-            if (!saved) return false;
-            this.viewCamera.position.set(saved.px, saved.py, saved.pz);
-            this.controls.target.set(saved.tx, saved.ty, saved.tz);
-            this.controls.update();
-            return true;
+            const state = JSON.parse(localStorage.getItem(key));
+            if (key === this.artifactCameraKey && state?.layout !== "viewport") return false;
+            return this.applyCameraState(state, options);
         } catch {
             return false;
         }
+    }
+
+    applyArtifactViewOffset() {
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+        this.viewCamera.setViewOffset(
+            width,
+            height,
+            -0.36 * width,
+            -0.26 * height,
+            width,
+            height,
+        );
+    }
+
+    applyDefaultArtifactCamera(maxDistance) {
+        if (!this.currentModel) return false;
+        const box = new THREE.Box3().setFromObject(this.currentModel.scene);
+        if (box.isEmpty()) return false;
+
+        const center = box.getCenter(new THREE.Vector3());
+        const size = box.getSize(new THREE.Vector3());
+        const scale = size.y / ARTIFACT_CAMERA_REFERENCE.modelHeight;
+        const target = center.clone().add(
+            new THREE.Vector3(...ARTIFACT_CAMERA_REFERENCE.targetOffset).multiplyScalar(scale),
+        );
+        const cameraOffset = new THREE.Vector3(...ARTIFACT_CAMERA_REFERENCE.cameraOffset)
+            .multiplyScalar(scale * 2);
+        const position = target.clone().add(cameraOffset);
+        const distance = cameraOffset.length();
+        return this.applyCameraState({
+            px: position.x,
+            py: position.y,
+            pz: position.z,
+            tx: target.x,
+            ty: target.y,
+            tz: target.z,
+        }, { resetControls: true, maxDistance: Math.max(maxDistance, distance * 1.2) });
+    }
+
+    setArtifactMode(active) {
+        active = Boolean(active);
+        if (active === this.artifactMode) return;
+        clearTimeout(this.cameraSaveTimer);
+
+        if (active) {
+            this.normalCameraState = this.captureCameraState();
+            this.normalMaxDistance = this.controls.maxDistance;
+            this.saveCameraState(this.persistence.cameraKey);
+            this.artifactMode = true;
+            this.applyArtifactViewOffset();
+            const maxDistance = Math.max(this.normalMaxDistance, this.config.camera.maxDistance * 3);
+            if (!this.restoreCameraState(undefined, { resetControls: true, maxDistance })) {
+                this.applyDefaultArtifactCamera(maxDistance);
+            }
+            this.updateControlSurface();
+            return;
+        }
+
+        this.saveCameraState(this.artifactCameraKey);
+        this.artifactMode = false;
+        this.viewCamera.clearViewOffset();
+        const maxDistance = this.normalMaxDistance ?? this.config.camera.maxDistance;
+        if (!this.applyCameraState(this.normalCameraState, { resetControls: true, maxDistance })) {
+            this.restoreCameraState(undefined, { resetControls: true, maxDistance });
+        }
+        this.normalCameraState = null;
+        this.normalMaxDistance = null;
+        this.updateControlSurface();
     }
 
     handleResponse(response) {
@@ -394,7 +557,9 @@ export class VrmAdapter {
         this.onResize = () => {
             this.renderer.setSize(window.innerWidth, window.innerHeight);
             this.viewCamera.aspect = window.innerWidth / window.innerHeight;
-            this.viewCamera.updateProjectionMatrix();
+            if (this.artifactMode) this.applyArtifactViewOffset();
+            else this.viewCamera.updateProjectionMatrix();
+            this.updateControlSurface();
         };
         window.addEventListener("resize", this.onResize);
     }

--- a/examples/websocket/html/avatar3d/vrm-main.js
+++ b/examples/websocket/html/avatar3d/vrm-main.js
@@ -2,7 +2,7 @@ import { startAvatarApp } from "./common/app.js";
 import { createBlobStore } from "./common/blob-store.js";
 import { VrmAdapter } from "./models/vrm/vrm-adapter.js";
 
-export function startVrmPage({ model, ...commonConfig }) {
+export function startVrmPage({ model, artifactPlugins = [], ...commonConfig }) {
     if (!model || typeof model !== "object") throw new TypeError("model configuration is required");
     const blobStore = createBlobStore(commonConfig.persistence);
     const modelAdapter = new VrmAdapter({
@@ -10,5 +10,5 @@ export function startVrmPage({ model, ...commonConfig }) {
         persistence: commonConfig.persistence,
         blobStore,
     });
-    return startAvatarApp({ config: commonConfig, modelAdapter, blobStore });
+    return startAvatarApp({ config: commonConfig, modelAdapter, blobStore, artifactPlugins });
 }

--- a/examples/websocket/html/index.html
+++ b/examples/websocket/html/index.html
@@ -6,10 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AIAvatarKit WebSocket Example</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="artifact/artifact.css">
     <style>
         :root {
             --avatar-aspect-ratio: 1 / 1;
             --avatar-zoom: 1.0;
+            --artifact-layer-z-index: 50;
         }
 
         .avatar-container img,
@@ -108,7 +110,15 @@
     <script src="image-avatar.js"></script>
     <script src="mpt-avatar.js"></script>
     <script src="ui.js"></script>
-    <script>
+    <script type="module">
+        import { ArtifactController } from "./artifact/artifact-controller.js";
+        import { ImageArtifactPlugin } from "./artifact/image-artifact-plugin.js";
+        import { PresentationArtifactPlugin } from "./artifact/presentation-artifact-plugin.js";
+        import { VideoArtifactPlugin } from "./artifact/video-artifact-plugin.js";
+        import { DocswellDriver } from "./artifact/docswell-driver.js";
+        import { SpeakerDeckDriver } from "./artifact/speakerdeck-driver.js";
+        import { YouTubeDriver } from "./artifact/youtube-driver.js";
+
         // User settings
         const AVATAR_MODE = "image"; // "image" or "mpt"
         const PLAYBACK_RMS_SCALE = 1.0; // Lower this (e.g. 0.2) if the mouth stays open
@@ -168,6 +178,19 @@
                 "send_query_to_openclaw": "Asking OpenClaw🦞",
             },
             onStop: () => avatar.stop(),
+        });
+        const artifacts = new ArtifactController({
+            plugins: [
+                new ImageArtifactPlugin({ type: "image" }),
+                new ImageArtifactPlugin({ type: "chart" }),
+                new PresentationArtifactPlugin({
+                    drivers: [DocswellDriver, SpeakerDeckDriver],
+                }),
+                new VideoArtifactPlugin({
+                    drivers: [YouTubeDriver],
+                    autoplay: true,
+                }),
+            ],
         });
 
         // Vision (0=OFF, 1=Camera/on-demand, 2=Camera/stream)
@@ -273,6 +296,7 @@
         // Custom response handling
         aiavatar.onResponseReceived = (response) => {
             // Custom handling logic here
+            artifacts.handleResponse(response);
 
             // Common handling
             ui.handleResponse(response);
@@ -280,6 +304,7 @@
 
         // Console helper: chat("Hello.") or chat("What's this?", imageDataUrl)
         window.chat = (text, imageDataUrl) => aiavatar.chat(ui.sessionId, ui.userId, text, imageDataUrl);
+        window.addEventListener("pagehide", () => artifacts.dispose(), { once: true });
     </script>
 </body>
 

--- a/tests/examples/websocket/test_artifact.mjs
+++ b/tests/examples/websocket/test_artifact.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const driverDirectory = new URL("../../../examples/websocket/html/artifact/", import.meta.url);
+
+function sourceDataUrl(source) {
+    return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const baseSource = await readFile(new URL("presentation-driver.js", driverDirectory), "utf8");
+const baseDataUrl = sourceDataUrl(baseSource);
+const docswellDataUrl = sourceDataUrl(
+    (await readFile(new URL("docswell-driver.js", driverDirectory), "utf8"))
+        .replace('"./presentation-driver.js"', `"${baseDataUrl}"`),
+);
+const speakerDeckDataUrl = sourceDataUrl(
+    (await readFile(new URL("speakerdeck-driver.js", driverDirectory), "utf8"))
+        .replace('"./presentation-driver.js"', `"${baseDataUrl}"`),
+);
+
+const { PresentationDriver } = await import(baseDataUrl);
+const { DocswellDriver } = await import(docswellDataUrl);
+const { SpeakerDeckDriver } = await import(speakerDeckDataUrl);
+
+class FakeWindow {
+    constructor() {
+        this.listeners = new Map();
+    }
+
+    addEventListener(name, listener) {
+        this.listeners.set(name, listener);
+    }
+
+    removeEventListener(name) {
+        this.listeners.delete(name);
+    }
+
+    dispatchMessage(event) {
+        this.listeners.get("message")?.(event);
+    }
+}
+
+function fakeIframe() {
+    return {
+        src: "",
+        contentWindow: {
+            messages: [],
+            postMessage(message, origin) {
+                this.messages.push({ message, origin });
+            },
+        },
+    };
+}
+
+test("presentation driver remains abstract", () => {
+    assert.throws(() => new PresentationDriver(), /abstract/);
+    assert.throws(() => PresentationDriver.provider, /must be implemented/);
+});
+
+test("presentation providers validate and normalize their URLs", () => {
+    assert.equal(
+        SpeakerDeckDriver.resolveUrl(new URL("https://speakerdeck.com/player/deck_1"), "7"),
+        "https://speakerdeck.com/player/deck_1?slide=7",
+    );
+    assert.equal(
+        DocswellDriver.resolveUrl(
+            new URL("https://www.docswell.com/s/harinezumi/KDMGQW-2026-05-13-130255"),
+            "10",
+        ),
+        "https://www.docswell.com/slide/KDMGQW/embed#p10",
+    );
+    assert.throws(
+        () => SpeakerDeckDriver.resolveUrl(new URL("https://speakerdeck.com/not-a-player/deck")),
+        /player embed URL/,
+    );
+    assert.throws(
+        () => DocswellDriver.resolveUrl(new URL("https://www.docswell.com/not-a-viewer")),
+        /viewer or embed URLs/,
+    );
+});
+
+test("Docswell driver initializes, navigates, tracks manual moves, and disposes", () => {
+    const iframe = fakeIframe();
+    const windowRoot = new FakeWindow();
+    const changes = [];
+    const driver = new DocswellDriver({
+        iframe,
+        url: "https://www.docswell.com/slide/DECK_1/embed#p1",
+        windowRoot,
+        onSlideChange: (slide) => changes.push(slide),
+    });
+
+    assert.equal(driver.initialize(), true);
+    const initialization = iframe.contentWindow.messages[0];
+    windowRoot.dispatchMessage({
+        source: iframe.contentWindow,
+        origin: "https://www.docswell.com",
+        data: { type: "docswell:initialized", id: initialization.message.id, total: 24 },
+    });
+    assert.equal(driver.ready, true);
+    assert.equal(driver.totalSlides, 24);
+
+    assert.deepEqual(driver.navigateBy(2), { slide: 3 });
+    assert.equal(changes.at(-1), 3);
+    windowRoot.dispatchMessage({
+        source: iframe.contentWindow,
+        origin: "https://www.docswell.com",
+        data: { type: "docswell:move", id: initialization.message.id, index: 6 },
+    });
+    assert.equal(driver.currentSlide, 7);
+    assert.equal(changes.at(-1), 7);
+
+    driver.dispose();
+    assert.equal(windowRoot.listeners.has("message"), false);
+});
+
+test("Speaker Deck driver updates the existing iframe URL", () => {
+    const iframe = fakeIframe();
+    const driver = new SpeakerDeckDriver({
+        iframe,
+        url: "https://speakerdeck.com/player/DECK_1?slide=2",
+    });
+    assert.equal(driver.initialize(), true);
+    assert.deepEqual(driver.navigateBy(3), {
+        slide: 5,
+        url: "https://speakerdeck.com/player/DECK_1?slide=5",
+    });
+    assert.equal(iframe.src, "https://speakerdeck.com/player/DECK_1?slide=5");
+});

--- a/tests/examples/websocket/test_artifact_registry.mjs
+++ b/tests/examples/websocket/test_artifact_registry.mjs
@@ -1,0 +1,374 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const artifactDirectory = new URL("../../../examples/websocket/html/artifact/", import.meta.url);
+
+function sourceDataUrl(source) {
+    return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const registrySource = await readFile(new URL("artifact-registry.js", artifactDirectory), "utf8");
+const parserSource = await readFile(new URL("artifact-parser.js", artifactDirectory), "utf8");
+const urlSource = await readFile(new URL("artifact-url.js", artifactDirectory), "utf8");
+const registryDataUrl = sourceDataUrl(registrySource);
+const parserDataUrl = sourceDataUrl(parserSource);
+const urlDataUrl = sourceDataUrl(urlSource);
+const imagePluginDataUrl = sourceDataUrl(
+    (await readFile(new URL("image-artifact-plugin.js", artifactDirectory), "utf8"))
+        .replace('"./artifact-parser.js"', `"${parserDataUrl}"`)
+        .replace('"./artifact-url.js"', `"${urlDataUrl}"`),
+);
+const presentationPluginDataUrl = sourceDataUrl(
+    (await readFile(new URL("presentation-artifact-plugin.js", artifactDirectory), "utf8"))
+        .replace('"./artifact-parser.js"', `"${parserDataUrl}"`)
+        .replace('"./artifact-url.js"', `"${urlDataUrl}"`),
+);
+const videoPluginDataUrl = sourceDataUrl(
+    (await readFile(new URL("video-artifact-plugin.js", artifactDirectory), "utf8"))
+        .replace('"./artifact-parser.js"', `"${parserDataUrl}"`)
+        .replace('"./artifact-url.js"', `"${urlDataUrl}"`),
+);
+const controllerDataUrl = sourceDataUrl(
+    (await readFile(new URL("artifact-controller.js", artifactDirectory), "utf8"))
+        .replace('"./artifact-parser.js"', `"${parserDataUrl}"`)
+        .replace('"./artifact-registry.js"', `"${registryDataUrl}"`),
+);
+
+const { ArtifactRegistry } = await import(registryDataUrl);
+const { parseArtifactControlTags, parseArtifactTags } = await import(parserDataUrl);
+const { ArtifactController } = await import(controllerDataUrl);
+const { ImageArtifactPlugin } = await import(imagePluginDataUrl);
+const { PresentationArtifactPlugin } = await import(presentationPluginDataUrl);
+const { VideoArtifactPlugin } = await import(videoPluginDataUrl);
+
+class FakeClassList {
+    constructor() {
+        this.values = new Set();
+    }
+
+    add(...names) {
+        for (const name of names) this.values.add(name);
+    }
+
+    remove(...names) {
+        for (const name of names) this.values.delete(name);
+    }
+
+    contains(name) {
+        return this.values.has(name);
+    }
+}
+
+class FakeElement {
+    constructor(tagName) {
+        this.tagName = tagName.toUpperCase();
+        this.children = [];
+        this.dataset = {};
+        this.attributes = {};
+        this.classList = new FakeClassList();
+        this.listeners = new Map();
+        this.style = { setProperty: (name, value) => { this.style[name] = value; } };
+        this.hidden = false;
+        this.parentNode = null;
+    }
+
+    append(...children) {
+        this.children.push(...children);
+        for (const child of children) child.parentNode = this;
+    }
+
+    appendChild(child) {
+        this.append(child);
+        return child;
+    }
+
+    replaceChildren(...children) {
+        for (const child of this.children) child.parentNode = null;
+        this.children = [];
+        this.append(...children);
+    }
+
+    contains(child) {
+        return this.children.includes(child);
+    }
+
+    setAttribute(name, value) {
+        this.attributes[name] = value;
+    }
+
+    addEventListener(name, listener) {
+        this.listeners.set(name, listener);
+    }
+
+    dispatch(name) {
+        this.listeners.get(name)?.({ target: this });
+    }
+
+    remove() {
+        if (this.parentNode) {
+            this.parentNode.children = this.parentNode.children.filter((child) => child !== this);
+        }
+        this.parentNode = null;
+    }
+}
+
+class FakeDocument {
+    constructor() {
+        this.documentElement = new FakeElement("html");
+        this.body = new FakeElement("body");
+    }
+
+    createElement(tagName) {
+        const element = new FakeElement(tagName);
+        if (tagName.toLowerCase() === "iframe") element.contentWindow = {};
+        return element;
+    }
+}
+
+class FakePresentationDriver {
+    static provider = "fake-slides";
+
+    static supports(url) {
+        return url.hostname === "slides.example.com";
+    }
+
+    static resolveUrl(source, slide = null) {
+        const url = new URL(source.href);
+        if (slide !== null) url.searchParams.set("slide", slide);
+        return url.href;
+    }
+
+    constructor({ iframe, url, onSlideChange }) {
+        this.iframe = iframe;
+        this.url = url;
+        this.onSlideChange = onSlideChange;
+        this.ready = false;
+        this.currentSlide = Number(new URL(url).searchParams.get("slide") || 1);
+        this.totalSlides = 20;
+        this.disposed = false;
+    }
+
+    initialize() {
+        this.ready = true;
+    }
+
+    navigate(url) {
+        if (!this.ready) return false;
+        this.url = url;
+        this.currentSlide = Number(new URL(url).searchParams.get("slide") || 1);
+        this.iframe.src = url;
+        return this.currentSlide;
+    }
+
+    navigateBy(offset) {
+        if (!this.ready) return false;
+        this.currentSlide = Math.max(1, this.currentSlide + offset);
+        const url = new URL(this.url);
+        url.searchParams.set("slide", this.currentSlide);
+        this.url = url.href;
+        this.iframe.src = this.url;
+        this.onSlideChange?.(this.currentSlide);
+        return { slide: this.currentSlide, url: this.url };
+    }
+
+    dispose() {
+        this.disposed = true;
+        this.ready = false;
+    }
+}
+
+const videoDrivers = [];
+class FakeVideoDriver {
+    static provider = "fake-video";
+
+    static supports(url) {
+        return url.hostname === "video.example.com";
+    }
+
+    static resolveUrl(source) {
+        return new URL(source.href).href;
+    }
+
+    constructor(options) {
+        this.options = options;
+        this.state = "idle";
+        this.disposed = false;
+        options.iframe.src = options.url;
+        videoDrivers.push(this);
+    }
+
+    async initialize() {
+        this.state = "ready";
+        this.options.onEvent({ type: "ready", provider: this.constructor.provider });
+        return true;
+    }
+
+    dispose() {
+        this.disposed = true;
+    }
+}
+
+function plugins() {
+    return [
+        new ImageArtifactPlugin({ type: "image" }),
+        new ImageArtifactPlugin({ type: "chart" }),
+        new PresentationArtifactPlugin({ drivers: [FakePresentationDriver] }),
+        new VideoArtifactPlugin({ drivers: [FakeVideoDriver], autoplay: true }),
+    ];
+}
+
+test("registry owns type aliases and rejects duplicate registrations", () => {
+    const registry = new ArtifactRegistry(plugins());
+    assert.equal(registry.get("slides").type, "presentation");
+    assert.equal(registry.get("VIDEO").type, "video");
+    assert.throws(() => registry.register(new ImageArtifactPlugin({ type: "image" })), /already registered/);
+});
+
+test("registered plugins parse text and structured artifact commands", () => {
+    const registry = new ArtifactRegistry(plugins());
+    const { commands, errors } = parseArtifactTags([
+        '<artifact type="image" src="https://example.com/result.png" />',
+        '<artifact type="chart" src="https://example.com/chart.svg" aspect="4:3" />',
+        '<artifact type="slides" src="https://slides.example.com/deck" slide="4" />',
+        '<artifact type="presentation" offset="+2" />',
+        '<artifact type="video" src="https://video.example.com/watch/1" autoplay-delay="1.5" />',
+    ].join(""), { registry });
+
+    assert.equal(errors.length, 0);
+    assert.deepEqual(commands.map((command) => command.type), [
+        "image", "chart", "presentation", "presentation", "video",
+    ]);
+    assert.equal(commands[2].slide, "4");
+    assert.equal(commands[3].action, "move");
+    assert.equal(commands[4].autoplayDelaySeconds, 1.5);
+
+    const structured = parseArtifactControlTags([{
+        name: "artifact",
+        attributes: { type: "video", src: "https://video.example.com/watch/2", "autoplay-delay": 3 },
+    }], { registry });
+    assert.equal(structured.errors.length, 0);
+    assert.equal(structured.commands[0].autoplayDelaySeconds, 3);
+
+    const invalid = parseArtifactTags(
+        '<artifact type="image" src="https://example.com/x.png" autoplay-delay="2" />',
+        { registry },
+    );
+    assert.equal(invalid.commands.length, 0);
+    assert.match(invalid.errors[0].error.message, /Unsupported artifact attribute/);
+});
+
+test("controller delegates image loading and presentation updates to registered plugins", () => {
+    const documentRoot = new FakeDocument();
+    const visibility = [];
+    const controller = new ArtifactController({
+        documentRoot,
+        plugins: plugins(),
+        onVisibilityChange: (active) => visibility.push(active),
+    });
+
+    controller.apply({
+        action: "show",
+        type: "image",
+        src: "https://example.com/image.png",
+        size: null,
+        aspect: null,
+        alt: "",
+        title: "",
+    });
+    const imageSurface = controller.root.children[0];
+    const image = imageSurface.children[0];
+    image.naturalWidth = 1200;
+    image.naturalHeight = 800;
+    image.dispatch("load");
+    assert.equal(imageSurface.classList.contains("loaded"), true);
+    assert.equal(imageSurface.style["--artifact-ratio"], "1.5");
+
+    controller.apply({
+        action: "show",
+        type: "presentation",
+        src: "https://slides.example.com/deck",
+        slide: "2",
+        size: null,
+        aspect: null,
+        alt: "",
+        title: "",
+    });
+    const presentationSurface = controller.root.children[0];
+    const iframe = presentationSurface.children[0];
+    iframe.dispatch("load");
+    assert.equal(controller.currentSlide, 2);
+    assert.equal(controller.totalSlides, 20);
+
+    controller.apply({
+        action: "show",
+        type: "presentation",
+        src: "https://slides.example.com/deck",
+        slide: "7",
+        size: null,
+        aspect: null,
+        alt: "",
+        title: "",
+    });
+    assert.equal(controller.root.children[0], presentationSurface);
+    assert.equal(controller.current.slide, "7");
+
+    controller.apply({ action: "move", type: "presentation", offset: 2 });
+    assert.equal(controller.current.slide, "9");
+    controller.clear();
+    assert.deepEqual(visibility, [true, false]);
+});
+
+test("controller handles a tagged chunk once and uses final as fallback", () => {
+    const documentRoot = new FakeDocument();
+    const controller = new ArtifactController({ documentRoot, plugins: plugins() });
+    const tag = '<artifact type="image" src="https://example.com/image.png" />';
+
+    controller.handleResponse({ type: "start", text: null });
+    controller.handleResponse({
+        type: "chunk",
+        text: tag,
+        control_tags: [{
+            name: "artifact",
+            attributes: { type: "image", src: "https://example.com/image.png" },
+        }],
+    });
+    const chunkSurface = controller.root.children[0];
+    controller.handleResponse({ type: "final", text: tag });
+    assert.equal(controller.root.children[0], chunkSurface);
+
+    controller.handleResponse({ type: "start", text: null });
+    controller.handleResponse({
+        type: "final",
+        text: '<artifact type="chart" src="https://example.com/chart.svg" />',
+    });
+    assert.equal(controller.current.type, "chart");
+    assert.notEqual(controller.root.children[0], chunkSurface);
+});
+
+test("video plugin passes fixed autoplay delay and disposes its driver", async () => {
+    videoDrivers.length = 0;
+    const documentRoot = new FakeDocument();
+    const controller = new ArtifactController({ documentRoot, plugins: plugins() });
+    controller.apply({
+        action: "show",
+        type: "video",
+        src: "https://video.example.com/watch/1",
+        autoplayDelaySeconds: 2.5,
+        size: null,
+        aspect: null,
+        alt: "",
+        title: "",
+    });
+
+    const surface = controller.root.children[0];
+    const iframe = surface.children[0];
+    assert.equal(videoDrivers[0].options.autoplay, true);
+    assert.equal(videoDrivers[0].options.autoplayDelaySeconds, 2.5);
+    iframe.dispatch("load");
+    await Promise.resolve();
+    assert.equal(surface.classList.contains("loaded"), true);
+
+    controller.clear();
+    assert.equal(videoDrivers[0].disposed, true);
+});

--- a/tests/examples/websocket/test_youtube_driver.mjs
+++ b/tests/examples/websocket/test_youtube_driver.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const driverDirectory = new URL("../../../examples/websocket/html/artifact/", import.meta.url);
+
+function sourceDataUrl(source) {
+    return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const videoDataUrl = sourceDataUrl(
+    await readFile(new URL("video-driver.js", driverDirectory), "utf8"),
+);
+const loaderSource = await readFile(new URL("youtube-iframe-api-loader.js", driverDirectory), "utf8");
+const loaderDataUrl = sourceDataUrl(loaderSource);
+const youtubeDataUrl = sourceDataUrl(
+    (await readFile(new URL("youtube-driver.js", driverDirectory), "utf8"))
+        .replace('"./video-driver.js"', `"${videoDataUrl}"`)
+        .replace('"./youtube-iframe-api-loader.js"', `"${loaderDataUrl}"`),
+);
+
+const { loadYouTubeIframeApi } = await import(loaderDataUrl);
+const { YouTubeDriver } = await import(youtubeDataUrl);
+
+function fakeIframe() {
+    return {
+        allow: "fullscreen",
+        attributes: {},
+        setAttribute(name, value) {
+            this.attributes[name] = value;
+        },
+    };
+}
+
+test("YouTube driver validates sources and schedules fixed-delay autoplay once", async () => {
+    const resolved = new URL(YouTubeDriver.resolveUrl("https://youtu.be/dQw4w9WgXcQ?t=1m2s"));
+    assert.equal(resolved.pathname, "/embed/dQw4w9WgXcQ");
+    assert.equal(resolved.searchParams.get("start"), "62");
+    assert.throws(
+        () => YouTubeDriver.resolveUrl("https://youtube.com.example/watch?v=dQw4w9WgXcQ"),
+        /Invalid YouTube host/,
+    );
+
+    const players = [];
+    class FakePlayer {
+        constructor(iframe, options) {
+            this.options = options;
+            this.playCalls = 0;
+            this.destroyCalls = 0;
+            players.push(this);
+            queueMicrotask(() => options.events.onReady({ target: this }));
+        }
+
+        playVideo() {
+            this.playCalls += 1;
+            this.options.events.onStateChange({ data: 1 });
+        }
+
+        destroy() {
+            this.destroyCalls += 1;
+        }
+    }
+
+    const windowRoot = {
+        location: { origin: "http://localhost:8000" },
+        setTimeout,
+        clearTimeout,
+    };
+    const events = [];
+    const driver = new YouTubeDriver({
+        iframe: fakeIframe(),
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        windowRoot,
+        documentRoot: {},
+        apiLoader: async () => ({ Player: FakePlayer }),
+        autoplay: true,
+        autoplayDelaySeconds: 0.03,
+        onEvent: (event) => events.push(event.type),
+    });
+
+    await driver.initialize();
+    assert.equal(players[0].playCalls, 0);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(players[0].playCalls, 0);
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    assert.equal(players[0].playCalls, 1);
+    assert.equal(events.filter((type) => type === "autoplayrequested").length, 1);
+
+    driver.dispose();
+    assert.equal(players[0].destroyCalls, 1);
+});
+
+test("YouTube API loader shares one request and preserves an existing callback", async () => {
+    let existingCallbackCalls = 0;
+    let appendCalls = 0;
+    const listeners = new Map();
+    const script = {
+        addEventListener(type, listener) {
+            listeners.set(type, listener);
+        },
+        removeEventListener(type) {
+            listeners.delete(type);
+        },
+    };
+    const windowRoot = {
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        onYouTubeIframeAPIReady() {
+            existingCallbackCalls += 1;
+        },
+    };
+    const originalCallback = windowRoot.onYouTubeIframeAPIReady;
+    const documentRoot = {
+        querySelector() {
+            return null;
+        },
+        createElement() {
+            return script;
+        },
+        head: {
+            appendChild() {
+                appendCalls += 1;
+            },
+        },
+    };
+
+    const first = loadYouTubeIframeApi({ windowRoot, documentRoot, timeoutMs: 500 });
+    const second = loadYouTubeIframeApi({ windowRoot, documentRoot, timeoutMs: 500 });
+    assert.equal(first, second);
+    assert.equal(appendCalls, 1);
+
+    windowRoot.YT = { Player: function Player() {} };
+    windowRoot.onYouTubeIframeAPIReady();
+    assert.equal(await first, windowRoot.YT);
+    assert.equal(existingCallbackCalls, 1);
+    assert.equal(windowRoot.onYouTubeIframeAPIReady, originalCallback);
+});


### PR DESCRIPTION
- Display images, charts, presentations, and YouTube videos.
- Add media plugins with provider-specific drivers and playback controls.
- Support slide navigation and artifact-aware VRM camera behavior.
- Update the CLI prompt, documentation, and browser-side tests.