### PR TITLE
Improve artifact control tag handling

### DIFF
--- a/aiavatar/adapter/base.py
+++ b/aiavatar/adapter/base.py
@@ -30,12 +30,12 @@ class Adapter(ABC):
 
         # Control tag pattern: receives (tag, attr) and returns a regex with two capture groups
         self.control_tag_pattern = r'\[{tag}:(\w+)\]|<{tag}\s[^>]*{attr}=["\'](\w+)["\']'
-        self._control_tag_parsers = {}
+        self._control_tag_resolvers = {}
         self.register_control_tag("face")
         self.register_control_tag("animation")
         self.register_control_tag("vision", value_attribute="source")
         self._artifact_resolver = ControlTagConfigResolver()
-        self.register_control_tag("artifact", parser=self._artifact_resolver)
+        self.register_control_tag("artifact", resolver=self._artifact_resolver)
 
         # Callbacks
         self._on_session_start_handlers: List[Callable[[AIAvatarRequest, Any], Awaitable[None]]] = []
@@ -77,40 +77,37 @@ class Adapter(ABC):
         name: str,
         *,
         value_attribute: str = "name",
-        parser: Optional[Callable[[Dict[str, str]], Optional[Dict[str, Any]]]] = None,
+        resolver: Optional[Callable[[Dict[str, str]], Optional[Dict[str, Any]]]] = None,
     ):
-        """Register a control tag and an optional attribute normalizer."""
+        """Register a control tag and an optional attribute resolver."""
         normalized_name = name.lower()
         if not re.fullmatch(r"[A-Za-z_]\w*", normalized_name):
             raise ValueError(f"Invalid control tag name: {name}")
-        self._control_tag_parsers[normalized_name] = (value_attribute.lower(), parser)
+        self._control_tag_resolvers[normalized_name] = (value_attribute.lower(), resolver)
 
     def set_artifacts(self, artifacts: Dict[str, Dict[str, Any]]):
         """Replace the application-owned artifact catalog."""
         self._artifact_resolver.set_configs(artifacts)
-        self.register_control_tag("artifact", parser=self._artifact_resolver)
 
     def update_artifacts(self, artifacts: Dict[str, Dict[str, Any]]):
         """Add or replace artifact catalog entries without clearing other IDs."""
         self._artifact_resolver.update_configs(artifacts)
-        self.register_control_tag("artifact", parser=self._artifact_resolver)
 
     def add_artifact(self, artifact_id: str, config: Dict[str, Any]):
         """Add or replace one artifact catalog entry."""
         self._artifact_resolver.set_config(artifact_id, config)
-        self.register_control_tag("artifact", parser=self._artifact_resolver)
 
     def parse_control_tags(self, text: str) -> List[ControlTag]:
         """Parse registered bracket or XML-style control tags in source order."""
         tags = []
-        parsers = getattr(self, "_control_tag_parsers", {})
+        resolvers = getattr(self, "_control_tag_resolvers", {})
         for match in _CONTROL_TAG_PATTERN.finditer(text or ""):
             name = (match.group("bracket_name") or match.group("xml_name")).lower()
-            registration = parsers.get(name)
+            registration = resolvers.get(name)
             if not registration:
                 continue
 
-            value_attribute, parser = registration
+            value_attribute, resolver = registration
             if match.group("bracket_name"):
                 attributes = {value_attribute: match.group("bracket_value").strip()}
             else:
@@ -119,9 +116,9 @@ class Adapter(ABC):
                     logger.warning("Ignored malformed control tag: %s", match.group(0))
                     continue
 
-            if parser:
+            if resolver:
                 try:
-                    attributes = parser(attributes)
+                    attributes = resolver(attributes)
                 except (TypeError, ValueError) as ex:
                     logger.warning("Ignored invalid %s control tag: %s", name, ex)
                     continue

--- a/aiavatar/adapter/control_tags.py
+++ b/aiavatar/adapter/control_tags.py
@@ -1,18 +1,31 @@
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from typing import Any, Dict, Optional
 
 
 class ControlTagConfigResolver:
-    """Resolve a control-tag identifier from an application-owned config map."""
+    """Resolve a control-tag identifier from an application-owned config map.
+
+    Attributes listed in ``protected_overrides`` retain their configured values
+    when an identifier is resolved. Tags without an identifier pass through.
+    """
 
     def __init__(
         self,
         configs: Optional[Mapping[str, Mapping[str, Any]]] = None,
         *,
         key_attribute: str = "id",
+        protected_overrides: Optional[Iterable[str]] = None,
     ):
         self.key_attribute = key_attribute.lower()
+        if protected_overrides is None:
+            protected_overrides = {"type", "src"}
+        elif isinstance(protected_overrides, str):
+            raise TypeError("Protected overrides must be an iterable of attribute names")
+        self.protected_overrides = frozenset(
+            self._normalize_attribute_name(name)
+            for name in protected_overrides
+        )
         self._configs = {}
         self.set_configs(configs or {})
 
@@ -27,6 +40,12 @@ class ControlTagConfigResolver:
 
     def set_config(self, config_id: str, attributes: Mapping[str, Any]):
         self.update_configs({config_id: attributes})
+
+    @staticmethod
+    def _normalize_attribute_name(name: str) -> str:
+        if not isinstance(name, str) or not name:
+            raise ValueError("Protected override names must be non-empty strings")
+        return name.lower()
 
     @staticmethod
     def _normalize_configs(configs: Mapping[str, Mapping[str, Any]]) -> Dict[str, Dict[str, Any]]:
@@ -58,6 +77,6 @@ class ControlTagConfigResolver:
         resolved.update({
             name: value
             for name, value in attributes.items()
-            if name != self.key_attribute
+            if name != self.key_attribute and name not in self.protected_overrides
         })
         return resolved

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -44,7 +44,7 @@ Set `AVATAR_MODE` in `html/index.html` to `"image"` or `"mpt"`. Then visit http:
 
 ## Artifacts in the web viewers
 
-`html/index.html` and `html/3d.html` can display an image, chart, Speaker Deck presentation, Docswell presentation, or YouTube video when an AI response contains a self-closing `artifact` tag. The adapter exposes registered tags through `AIAvatarResponse.control_tags`; the viewer falls back to parsing `text` when connected to an older server. The surrounding speech continues to use `voice_text`.
+`html/index.html` and `html/3d.html` can display an image, chart, Speaker Deck presentation, Docswell presentation, or YouTube video when an AI response contains a self-closing `artifact` tag. The adapter parses and resolves registered tags into `AIAvatarResponse.control_tags`, which is the viewer's only artifact command source. The viewer does not parse tags from response `text`. The surrounding speech continues to use `voice_text`.
 
 ```html
 <artifact type="image" src="https://example.com/image.png" alt="Generated image" />
@@ -58,7 +58,7 @@ Set `AVATAR_MODE` in `html/index.html` to `"image"` or `"mpt"`. Then visit http:
 <artifact action="clear" />
 ```
 
-`href` is accepted as an alias of `src`. `slide` is a positive absolute page number; when `src` is omitted, it moves the currently displayed presentation. A signed `offset` such as `+1`, `+2`, or `-1` moves relative to the current page. The viewer converts navigation to the provider-specific Speaker Deck query or Docswell message. `offset` operates only within the currently displayed presentation. Docswell applies it to the player's actual position, including manual navigation. Speaker Deck applies it to the last page requested through an artifact tag, so manual navigation is intentionally ignored. `autoplay-delay` is a non-negative number of seconds from video display until the first YouTube playback attempt; it defaults to `0`. YouTube `t` or `start` URL parameters select the position inside the video and are independent of this delay. Browsers can block autoplay with sound, in which case the embedded player remains available for manual playback. `size` accepts `small`, `medium`, `large`, or `full`; `aspect` accepts `auto`, `16:9`, `4:3`, `3:2`, `1:1`, or `9:16`. Images and charts default to `auto`; presentations and videos default to `16:9`. Speaker Deck requires a `/player/...` embed URL. Docswell accepts either a `/slide/.../embed` URL or its normal `/s/...` viewing URL. Other provider URL formats are rejected.
+`href` is accepted as an alias of `src`. `slide` is a positive absolute page number; when `src` is omitted, it moves the currently displayed presentation. A signed `offset` such as `+1`, `+2`, or `-1` moves relative to the current page. The viewer converts navigation to the provider-specific Speaker Deck query or Docswell message. `offset` operates only within the currently displayed presentation. Docswell applies it to the player's actual position, including manual navigation. Speaker Deck applies it to the last page requested through an artifact tag, so manual navigation is intentionally ignored. `autoplay-delay` is a number from `0` to `3600` seconds from video display until the first YouTube playback attempt; it defaults to `0`. YouTube `t` or `start` URL parameters select the position inside the video and are independent of this delay. Browsers can block autoplay with sound, in which case the embedded player remains available for manual playback. `size` accepts `small`, `medium`, `large`, or `full`; `aspect` accepts `auto`, `16:9`, `4:3`, `3:2`, `1:1`, or `9:16`. Images and charts default to `auto`; presentations and videos default to `16:9`. Speaker Deck requires a `/player/...` embed URL. Docswell accepts either a `/slide/.../embed` URL or its normal `/s/...` viewing URL. Other provider URL formats are rejected.
 
 While an artifact is visible, the VRM moves into a compact overlay and uses a separate camera state. Its first position automatically frames the full model; later drag, rotation, and zoom adjustments are stored separately in local storage. Closing the artifact restores the normal camera without changing it.
 
@@ -78,13 +78,51 @@ ARTIFACTS = {
 aiavatar_app.set_artifacts(ARTIFACTS)
 ```
 
-The LLM can then emit `<artifact id="about_company" />`. Attributes in the LLM tag override catalog values, so `<artifact id="about_company" slide="5" size="full" />` opens page 5 at full size. A tag without an `id` continues to accept a direct `src` or `href`, which is useful for images returned by search or generation tools.
+The LLM can then emit `<artifact id="about_company" />`. Display and navigation attributes in the LLM tag override catalog values, so `<artifact id="about_company" slide="5" size="full" />` opens page 5 at full size. When an `id` is present, the configured `type` and `src` are protected and cannot be replaced by tag attributes. A tag without an `id` continues to accept a direct `src` or `href`, which is useful for images returned by search or generation tools.
 
 - `set_artifacts(configs)` replaces the complete shared catalog.
 - `update_artifacts(configs)` adds or replaces multiple entries while retaining other IDs.
 - `add_artifact(id, config)` adds or replaces one entry.
 
 These methods update the adapter-wide catalog shared by all sessions; they do not create session-private artifacts.
+
+Direct artifact URLs cause the browser to request the resolved location. The server application is responsible for allowing only URLs that are safe for its users and environment. An `on_response` handler receives `AIAvatarResponse.control_tags` after ID resolution, and can validate, rewrite, or remove artifacts before they are sent:
+
+```python
+from urllib.parse import urlsplit
+
+TRUSTED_ARTIFACT_HOSTS = {"cdn.example.com"}
+
+def is_trusted_artifact_url(source):
+    try:
+        url = urlsplit(source)
+        return (
+            url.scheme == "https"
+            and url.hostname in TRUSTED_ARTIFACT_HOSTS
+            and url.username is None
+            and url.password is None
+        )
+    except ValueError:
+        return False
+
+@aiavatar_app.on_response
+async def validate_artifact_urls(response, _):
+    if not response.control_tags:
+        return
+
+    validated = []
+    for tag in response.control_tags:
+        if tag.name != "artifact":
+            validated.append(tag)
+            continue
+
+        source = tag.attributes.get("src") or tag.attributes.get("href")
+        if source and not is_trusted_artifact_url(source):
+            continue
+        validated.append(tag)
+
+    response.control_tags = validated
+```
 
 
 ## Deep Dive

--- a/examples/websocket/html/artifact/artifact-controller.js
+++ b/examples/websocket/html/artifact/artifact-controller.js
@@ -1,4 +1,4 @@
-import { parseArtifactControlTags, parseArtifactTags } from "./artifact-parser.js";
+import { parseArtifactControlTags } from "./artifact-parser.js";
 import { ArtifactRegistry } from "./artifact-registry.js";
 
 const ASPECT_VALUES = {
@@ -32,7 +32,6 @@ export class ArtifactController {
         this.currentPlugin = null;
         this.currentSession = null;
         this.generation = 0;
-        this.sawTaggedChunk = false;
     }
 
     register(plugin) {
@@ -63,27 +62,17 @@ export class ArtifactController {
 
     handleResponse(response) {
         if (!response || typeof response !== "object") return;
-        if (response.type === "accepted" || response.type === "start") this.sawTaggedChunk = false;
 
-        const structuredTags = Array.isArray(response.control_tags) ? response.control_tags : null;
-        const hasStructuredArtifact = structuredTags?.some(
+        if (!Array.isArray(response.control_tags)) return;
+        const hasStructuredArtifact = response.control_tags.some(
             (tag) => String(tag?.name || "").toLowerCase() === "artifact",
         );
-        const hasTextArtifact = typeof response.text === "string" && /<artifact\b/i.test(response.text);
-        if (!hasStructuredArtifact && !hasTextArtifact) return;
-
-        const isChunk = response.type === "chunk";
-        const isFinalLike = response.type === "final" || response.type === "vision";
-        if (!isChunk && !isFinalLike) return;
-        if (isFinalLike && this.sawTaggedChunk) return;
+        if (!hasStructuredArtifact) return;
 
         const options = { registry: this.registry };
-        const { commands, errors } = structuredTags
-            ? parseArtifactControlTags(structuredTags, options)
-            : parseArtifactTags(response.text, options);
+        const { commands, errors } = parseArtifactControlTags(response.control_tags, options);
         for (const item of errors) console.warn("Ignored invalid artifact tag:", item.error.message, item.tag);
         if (!commands.length) return;
-        if (isChunk) this.sawTaggedChunk = true;
 
         for (const command of commands) {
             try {

--- a/examples/websocket/html/artifact/artifact-parser.js
+++ b/examples/websocket/html/artifact/artifact-parser.js
@@ -1,25 +1,7 @@
-const ARTIFACT_TAG_PATTERN = /<artifact\b((?:"[^"]*"|'[^']*'|[^"'<>])*)\/\s*>/gi;
-const ATTRIBUTE_PATTERN = /([A-Za-z][\w-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
 const COMMON_DISPLAY_ATTRIBUTES = new Set(["type", "src", "href", "size", "aspect", "alt", "title"]);
 const SIZE_PRESETS = new Set(["small", "medium", "large", "full"]);
 const ASPECT_PRESETS = new Set(["auto", "16:9", "4:3", "3:2", "1:1", "9:16"]);
 const STRUCTURED_ATTRIBUTE_TYPES = new Set(["string", "number", "boolean"]);
-
-function parseAttributes(source) {
-    const attributes = {};
-    let remaining = source;
-    ATTRIBUTE_PATTERN.lastIndex = 0;
-    for (const match of source.matchAll(ATTRIBUTE_PATTERN)) {
-        const name = match[1].toLowerCase();
-        if (Object.prototype.hasOwnProperty.call(attributes, name)) {
-            throw new Error(`Duplicate artifact attribute: ${name}`);
-        }
-        attributes[name] = match[2] ?? match[3] ?? "";
-        remaining = remaining.replace(match[0], " ");
-    }
-    if (remaining.trim()) throw new Error("Malformed artifact attributes");
-    return attributes;
-}
 
 export function assertArtifactAttributes(attributes, additionalAttributes = []) {
     const allowed = new Set([...COMMON_DISPLAY_ATTRIBUTES, ...additionalAttributes]);
@@ -82,22 +64,6 @@ function normalizeStructuredAttributes(value) {
         attributes[name] = String(rawValue);
     }
     return attributes;
-}
-
-export function parseArtifactTags(text, { registry = null } = {}) {
-    const commands = [];
-    const errors = [];
-    if (typeof text !== "string" || !/<artifact\b/i.test(text)) return { commands, errors };
-
-    ARTIFACT_TAG_PATTERN.lastIndex = 0;
-    for (const match of text.matchAll(ARTIFACT_TAG_PATTERN)) {
-        try {
-            commands.push(parseCommand(parseAttributes(match[1]), registry));
-        } catch (error) {
-            errors.push({ tag: match[0], error });
-        }
-    }
-    return { commands, errors };
 }
 
 export function parseArtifactControlTags(controlTags, { registry = null } = {}) {

--- a/tests/adapter/test_control_tags.py
+++ b/tests/adapter/test_control_tags.py
@@ -56,15 +56,15 @@ def test_parse_registered_control_tags_in_source_order():
     ]
 
 
-def test_register_control_tag_with_attribute_normalizer():
+def test_register_control_tag_with_attribute_resolver():
     adapter = create_adapter()
 
-    def parse_navigation(attributes):
+    def resolve_navigation(attributes):
         if "page" not in attributes:
             raise ValueError("page is required")
         return {"page": int(attributes["page"])}
 
-    adapter.register_control_tag("navigation", parser=parse_navigation)
+    adapter.register_control_tag("navigation", resolver=resolve_navigation)
 
     tags = adapter.parse_control_tags(
         '<navigation page="3" /><navigation target="ignored" />'
@@ -75,7 +75,7 @@ def test_register_control_tag_with_attribute_normalizer():
     ]
 
 
-def test_config_resolver_merges_llm_attributes_over_config():
+def test_config_resolver_protects_type_and_src_from_llm_overrides():
     resolver = ControlTagConfigResolver({
         "about_company": {
             "type": "presentation",
@@ -85,7 +85,13 @@ def test_config_resolver_merges_llm_attributes_over_config():
         },
     })
 
-    assert resolver({"id": "about_company", "slide": "5", "size": "full"}) == {
+    assert resolver({
+        "id": "about_company",
+        "type": "image",
+        "src": "https://attacker.example/image.png",
+        "slide": "5",
+        "size": "full",
+    }) == {
         "type": "presentation",
         "src": "https://speakerdeck.com/player/deck_1",
         "slide": "5",
@@ -95,6 +101,24 @@ def test_config_resolver_merges_llm_attributes_over_config():
     assert resolver({"type": "image", "src": "https://example.com/generated.png"}) == {
         "type": "image",
         "src": "https://example.com/generated.png",
+    }
+
+
+def test_config_resolver_accepts_custom_protected_overrides():
+    resolver = ControlTagConfigResolver({
+        "about_company": {
+            "type": "presentation",
+            "src": "https://speakerdeck.com/player/deck_1",
+        },
+    }, protected_overrides={"src"})
+
+    assert resolver({
+        "id": "about_company",
+        "type": "image",
+        "src": "https://attacker.example/image.png",
+    }) == {
+        "type": "image",
+        "src": "https://speakerdeck.com/player/deck_1",
     }
 
 
@@ -146,6 +170,30 @@ def test_update_and_add_artifacts_preserve_other_entries():
         "type": "image",
         "src": "https://example.com/replaced.png",
     }
+
+
+def test_artifact_catalog_updates_do_not_replace_registered_resolver():
+    adapter = create_adapter()
+
+    def resolve_artifact(_):
+        return {"type": "image", "src": "https://example.com/custom.png"}
+
+    updates = [
+        lambda: adapter.set_artifacts({
+            "first": {"type": "image", "src": "https://example.com/first.png"},
+        }),
+        lambda: adapter.update_artifacts({
+            "second": {"type": "image", "src": "https://example.com/second.png"},
+        }),
+        lambda: adapter.add_artifact(
+            "third", {"type": "image", "src": "https://example.com/third.png"},
+        ),
+    ]
+    for update in updates:
+        adapter.register_control_tag("artifact", resolver=resolve_artifact)
+        update()
+        artifact = adapter.parse_control_tags('<artifact id="first" />')[0]
+        assert artifact.attributes["src"] == "https://example.com/custom.png"
 
 
 def test_malformed_registered_tag_is_ignored():
@@ -214,3 +262,44 @@ async def test_websocket_attaches_control_tags_to_chunks_only():
         },
     }]
     assert final_response.control_tags is None
+
+
+@pytest.mark.asyncio
+async def test_websocket_on_response_receives_resolved_control_tags():
+    server = object.__new__(AIAvatarWebSocketServer)
+    Adapter.__init__(server, StubPipeline())
+    server.sessions = {"session": WebSocketSessionData()}
+    server.response_audio_chunk_size = 0
+    server.debug = False
+    server.send_response = AsyncMock()
+    server.set_artifacts({
+        "about_company": {
+            "type": "presentation",
+            "src": "https://speakerdeck.com/player/deck_1",
+        },
+    })
+    resolved_attributes = []
+
+    @server.on_response
+    async def validate_artifacts(aiavatar_response, _):
+        if aiavatar_response.type != "chunk":
+            return
+        resolved_attributes.append(dict(aiavatar_response.control_tags[0].attributes))
+        aiavatar_response.control_tags = []
+
+    await server.handle_response(STSResponse(
+        type="chunk",
+        session_id="session",
+        text=(
+            '<artifact id="about_company" type="image" '
+            'src="https://attacker.example/image.png" />'
+        ),
+        voice_text="",
+        metadata={},
+    ))
+
+    assert resolved_attributes == [{
+        "type": "presentation",
+        "src": "https://speakerdeck.com/player/deck_1",
+    }]
+    assert server.send_response.await_args.args[0].control_tags == []

--- a/tests/examples/websocket/test_artifact_registry.mjs
+++ b/tests/examples/websocket/test_artifact_registry.mjs
@@ -36,7 +36,7 @@ const controllerDataUrl = sourceDataUrl(
 );
 
 const { ArtifactRegistry } = await import(registryDataUrl);
-const { parseArtifactControlTags, parseArtifactTags } = await import(parserDataUrl);
+const { parseArtifactControlTags } = await import(parserDataUrl);
 const { ArtifactController } = await import(controllerDataUrl);
 const { ImageArtifactPlugin } = await import(imagePluginDataUrl);
 const { PresentationArtifactPlugin } = await import(presentationPluginDataUrl);
@@ -225,15 +225,15 @@ test("registry owns type aliases and rejects duplicate registrations", () => {
     assert.throws(() => registry.register(new ImageArtifactPlugin({ type: "image" })), /already registered/);
 });
 
-test("registered plugins parse text and structured artifact commands", () => {
+test("registered plugins parse structured artifact commands", () => {
     const registry = new ArtifactRegistry(plugins());
-    const { commands, errors } = parseArtifactTags([
-        '<artifact type="image" src="https://example.com/result.png" />',
-        '<artifact type="chart" src="https://example.com/chart.svg" aspect="4:3" />',
-        '<artifact type="slides" src="https://slides.example.com/deck" slide="4" />',
-        '<artifact type="presentation" offset="+2" />',
-        '<artifact type="video" src="https://video.example.com/watch/1" autoplay-delay="1.5" />',
-    ].join(""), { registry });
+    const { commands, errors } = parseArtifactControlTags([
+        { name: "artifact", attributes: { type: "image", src: "https://example.com/result.png" } },
+        { name: "artifact", attributes: { type: "chart", src: "https://example.com/chart.svg", aspect: "4:3" } },
+        { name: "artifact", attributes: { type: "slides", src: "https://slides.example.com/deck", slide: 4 } },
+        { name: "artifact", attributes: { type: "presentation", offset: "+2" } },
+        { name: "artifact", attributes: { type: "video", src: "https://video.example.com/watch/1", "autoplay-delay": 1.5 } },
+    ], { registry });
 
     assert.equal(errors.length, 0);
     assert.deepEqual(commands.map((command) => command.type), [
@@ -250,10 +250,10 @@ test("registered plugins parse text and structured artifact commands", () => {
     assert.equal(structured.errors.length, 0);
     assert.equal(structured.commands[0].autoplayDelaySeconds, 3);
 
-    const invalid = parseArtifactTags(
-        '<artifact type="image" src="https://example.com/x.png" autoplay-delay="2" />',
-        { registry },
-    );
+    const invalid = parseArtifactControlTags([{
+        name: "artifact",
+        attributes: { type: "image", src: "https://example.com/x.png", "autoplay-delay": 2 },
+    }], { registry });
     assert.equal(invalid.commands.length, 0);
     assert.match(invalid.errors[0].error.message, /Unsupported artifact attribute/);
 });
@@ -319,12 +319,11 @@ test("controller delegates image loading and presentation updates to registered 
     assert.deepEqual(visibility, [true, false]);
 });
 
-test("controller handles a tagged chunk once and uses final as fallback", () => {
+test("controller handles structured control tags and ignores raw response text", () => {
     const documentRoot = new FakeDocument();
     const controller = new ArtifactController({ documentRoot, plugins: plugins() });
     const tag = '<artifact type="image" src="https://example.com/image.png" />';
 
-    controller.handleResponse({ type: "start", text: null });
     controller.handleResponse({
         type: "chunk",
         text: tag,
@@ -334,16 +333,16 @@ test("controller handles a tagged chunk once and uses final as fallback", () => 
         }],
     });
     const chunkSurface = controller.root.children[0];
-    controller.handleResponse({ type: "final", text: tag });
-    assert.equal(controller.root.children[0], chunkSurface);
+    assert.equal(controller.current.type, "image");
 
-    controller.handleResponse({ type: "start", text: null });
+    controller.clear();
     controller.handleResponse({
         type: "final",
         text: '<artifact type="chart" src="https://example.com/chart.svg" />',
     });
-    assert.equal(controller.current.type, "chart");
-    assert.notEqual(controller.root.children[0], chunkSurface);
+    assert.equal(controller.current, null);
+    assert.equal(controller.root.hidden, true);
+    assert.equal(chunkSurface.parentNode, null);
 });
 
 test("video plugin passes fixed autoplay delay and disposes its driver", async () => {


### PR DESCRIPTION
- Rename the control tag parser hook to resolver
- Prevent type and src overrides for ID-based artifacts
- Keep registered resolvers when updating the artifact catalog
- Remove raw-text artifact parsing from the web viewers
- Document URL validation through on_response