### PR TITLE
Fix oversized VRM interaction area and add view reset

### DIFF
--- a/examples/websocket/html/avatar3d/models/vrm/vrm-adapter.js
+++ b/examples/websocket/html/avatar3d/models/vrm/vrm-adapter.js
@@ -10,6 +10,8 @@ const ARTIFACT_CAMERA_REFERENCE = {
     targetOffset: [-0.10330158393900676, 0, -0.1170766868649855],
     cameraOffset: [1.100777579891017, 0.2236689191280165, 3.040772395500192],
 };
+const SKELETON_HEAD_PADDING_RATIO = 0.18;
+const SKELETON_FOOT_PADDING_RATIO = 0.04;
 
 function kelvinToRgb(kelvin) {
     const temperature = kelvin / 100;
@@ -34,6 +36,8 @@ export class VrmAdapter {
         this.persistence = persistence;
         this.blobStore = blobStore;
         this.currentModel = null;
+        this.modelSkeletonFrame = null;
+        this.modelDefaultCameraState = null;
         this.renderRequest = null;
         this.cameraSaveTimer = null;
         this.artifactMode = false;
@@ -121,55 +125,138 @@ export class VrmAdapter {
         controls.maxDistance = maxDistance;
         controls.update();
         controls.addEventListener("change", () => {
-            this.updateControlSurface();
             clearTimeout(this.cameraSaveTimer);
             this.cameraSaveTimer = setTimeout(() => this.saveCameraState(), this.config.camera.saveDebounceMs);
         });
         return controls;
     }
 
+    getRawSkeletonBones() {
+        const humanoid = this.currentModel?.humanoid;
+        const hips = humanoid?.getRawBoneNode("hips");
+        const head = humanoid?.getRawBoneNode("head");
+        const feet = [
+            humanoid?.getRawBoneNode("leftFoot"),
+            humanoid?.getRawBoneNode("rightFoot"),
+        ].filter(Boolean);
+        return hips && head && feet.length > 0 ? { hips, head, feet } : null;
+    }
+
+    captureRawSkeletonFrame() {
+        const skeleton = this.getRawSkeletonBones();
+        if (!skeleton) return null;
+
+        this.currentModel.scene.updateMatrixWorld(true);
+        const hips = skeleton.hips.getWorldPosition(new THREE.Vector3());
+        const head = skeleton.head.getWorldPosition(new THREE.Vector3());
+        const feet = skeleton.feet.map((bone) => bone.getWorldPosition(new THREE.Vector3()));
+        const feetY = Math.min(...feet.map(({ y }) => y));
+        const skeletonHeight = head.y - feetY;
+        if (![hips.x, hips.y, hips.z, head.y, feetY, skeletonHeight].every(Number.isFinite)) {
+            return null;
+        }
+        if (skeletonHeight <= 0) return null;
+
+        const top = head.y + skeletonHeight * SKELETON_HEAD_PADDING_RATIO;
+        const bottom = feetY - skeletonHeight * SKELETON_FOOT_PADDING_RATIO;
+        const center = hips.clone();
+        center.y = (top + bottom) / 2;
+        return { center, height: top - bottom };
+    }
+
+    captureDefaultModelCameraState() {
+        const head = this.getRawSkeletonBones()?.head;
+        if (!head) return null;
+
+        this.currentModel.scene.updateMatrixWorld(true);
+        const headPosition = head.getWorldPosition(new THREE.Vector3());
+        if (![headPosition.x, headPosition.y, headPosition.z].every(Number.isFinite)) return null;
+
+        return {
+            px: 0,
+            py: headPosition.y,
+            pz: this.config.camera.autoFrameDistance,
+            tx: 0,
+            ty: headPosition.y - 0.05,
+            tz: 0,
+        };
+    }
+
+    applyDefaultModelCamera({ resetControls = false } = {}) {
+        const state = this.modelDefaultCameraState || this.captureDefaultModelCameraState();
+        if (!state) return false;
+        return this.applyCameraState(state, {
+            resetControls,
+            maxDistance: this.config.camera.maxDistance,
+        });
+    }
+
     updateControlSurface() {
-        if (!this.currentModel) {
+        const skeleton = this.getRawSkeletonBones();
+        if (!skeleton) {
             this.controlSurface.hidden = true;
             return;
         }
 
-        const bounds = new THREE.Box3().setFromObject(this.currentModel.scene);
-        if (bounds.isEmpty()) {
-            this.controlSurface.hidden = true;
-            return;
-        }
-
-        const min = bounds.min;
-        const max = bounds.max;
+        this.viewCamera.updateMatrixWorld(true);
         const point = new THREE.Vector3();
-        let left = Infinity;
-        let top = Infinity;
-        let right = -Infinity;
-        let bottom = -Infinity;
-        for (const x of [min.x, max.x]) {
-            for (const y of [min.y, max.y]) {
-                for (const z of [min.z, max.z]) {
-                    point.set(x, y, z).project(this.viewCamera);
-                    left = Math.min(left, (point.x + 1) * window.innerWidth / 2);
-                    right = Math.max(right, (point.x + 1) * window.innerWidth / 2);
-                    top = Math.min(top, (1 - point.y) * window.innerHeight / 2);
-                    bottom = Math.max(bottom, (1 - point.y) * window.innerHeight / 2);
-                }
-            }
+        const projectBone = (bone) => {
+            bone.getWorldPosition(point);
+            point.project(this.viewCamera);
+            if (![point.x, point.y, point.z].every(Number.isFinite)) return null;
+            if (point.z < -1 || point.z > 1) return null;
+            return {
+                x: (point.x + 1) * window.innerWidth / 2,
+                y: (1 - point.y) * window.innerHeight / 2,
+            };
+        };
+        const projectedHips = projectBone(skeleton.hips);
+        const projectedHead = projectBone(skeleton.head);
+        const projectedFeet = skeleton.feet.map(projectBone).filter(Boolean);
+        if (!projectedHips || !projectedHead || projectedFeet.length === 0) {
+            this.controlSurface.hidden = true;
+            return;
         }
 
-        const padding = 12;
-        left = Math.max(0, left - padding);
-        top = Math.max(0, top - padding);
-        right = Math.min(window.innerWidth, right + padding);
-        bottom = Math.min(window.innerHeight, bottom + padding);
+        const feetY = Math.max(...projectedFeet.map(({ y }) => y));
+        const skeletonHeight = feetY - projectedHead.y;
+        if (!Number.isFinite(skeletonHeight) || skeletonHeight < 8) {
+            this.controlSurface.hidden = true;
+            return;
+        }
+
+        const topPadding = skeletonHeight * SKELETON_HEAD_PADDING_RATIO;
+        const bottomPadding = skeletonHeight * SKELETON_FOOT_PADDING_RATIO;
+        const projectedHeight = skeletonHeight + topPadding + bottomPadding;
+        const controlWidth = Math.min(320, Math.max(140, projectedHeight * 0.22));
+        let left = projectedHips.x - controlWidth / 2;
+        let top = projectedHead.y - topPadding;
+        let right = projectedHips.x + controlWidth / 2;
+        let bottom = feetY + bottomPadding;
+        if (right <= 0 || left >= window.innerWidth || bottom <= 0 || top >= window.innerHeight) {
+            this.controlSurface.hidden = true;
+            return;
+        }
+
+        left = Math.max(0, left);
+        top = Math.max(0, top);
+        right = Math.min(window.innerWidth, right);
+        bottom = Math.min(window.innerHeight, bottom);
         if (right <= left || bottom <= top) {
             this.controlSurface.hidden = true;
             return;
         }
 
-        this.controlSurface.style.clipPath = `inset(${top}px ${window.innerWidth - right}px ${window.innerHeight - bottom}px ${left}px)`;
+        const insets = [
+            top,
+            window.innerWidth - right,
+            window.innerHeight - bottom,
+            left,
+        ].map(Math.round);
+        const clipPath = `inset(${insets.map((value) => `${value}px`).join(" ")})`;
+        if (this.controlSurface.style.clipPath !== clipPath) {
+            this.controlSurface.style.clipPath = clipPath;
+        }
         this.controlSurface.hidden = false;
     }
 
@@ -225,19 +312,10 @@ export class VrmAdapter {
         this.idle.vrm = model;
         VRMUtils.rotateVRM0(model);
         this.scene.add(model.scene);
-
-        const head = model.humanoid?.getNormalizedBoneNode("head");
-        if (head) {
-            const headPosition = new THREE.Vector3();
-            head.getWorldPosition(headPosition);
-            const distance = this.config.camera.autoFrameDistance;
-            this.viewCamera.position.set(0, headPosition.y, distance);
-            this.viewCamera.lookAt(0, headPosition.y - 0.05, 0);
-            this.controls.target.set(0, headPosition.y - 0.05, 0);
-            this.controls.update();
-        }
+        this.modelSkeletonFrame = this.captureRawSkeletonFrame();
+        this.modelDefaultCameraState = this.captureDefaultModelCameraState();
+        this.applyDefaultModelCamera();
         if (model.lookAt) model.lookAt.target = this.viewCamera;
-        this.updateControlSurface();
         this.placeholder.style.display = "none";
         console.log("VRM loaded");
         return model;
@@ -248,8 +326,10 @@ export class VrmAdapter {
         this.scene.remove(this.currentModel.scene);
         VRMUtils.deepDispose(this.currentModel.scene);
         this.currentModel = null;
+        this.modelSkeletonFrame = null;
+        this.modelDefaultCameraState = null;
         this.idle.vrm = null;
-        this.updateControlSurface();
+        this.controlSurface.hidden = true;
     }
 
     async unloadModel({ clearCache = false } = {}) {
@@ -488,14 +568,11 @@ export class VrmAdapter {
     }
 
     applyDefaultArtifactCamera(maxDistance) {
-        if (!this.currentModel) return false;
-        const box = new THREE.Box3().setFromObject(this.currentModel.scene);
-        if (box.isEmpty()) return false;
+        const frame = this.modelSkeletonFrame || this.captureRawSkeletonFrame();
+        if (!frame) return false;
 
-        const center = box.getCenter(new THREE.Vector3());
-        const size = box.getSize(new THREE.Vector3());
-        const scale = size.y / ARTIFACT_CAMERA_REFERENCE.modelHeight;
-        const target = center.clone().add(
+        const scale = frame.height / ARTIFACT_CAMERA_REFERENCE.modelHeight;
+        const target = frame.center.clone().add(
             new THREE.Vector3(...ARTIFACT_CAMERA_REFERENCE.targetOffset).multiplyScalar(scale),
         );
         const cameraOffset = new THREE.Vector3(...ARTIFACT_CAMERA_REFERENCE.cameraOffset)
@@ -510,6 +587,31 @@ export class VrmAdapter {
             ty: target.y,
             tz: target.z,
         }, { resetControls: true, maxDistance: Math.max(maxDistance, distance * 1.2) });
+    }
+
+    resetView() {
+        if (!this.currentModel) return false;
+        clearTimeout(this.cameraSaveTimer);
+        this.cameraSaveTimer = null;
+        this.viewCamera.zoom = 1;
+        this.viewCamera.updateProjectionMatrix();
+
+        let reset;
+        let persistenceKey;
+        if (this.artifactMode) {
+            const normalMaxDistance = this.normalMaxDistance ?? this.config.camera.maxDistance;
+            const maxDistance = Math.max(normalMaxDistance, this.config.camera.maxDistance * 3);
+            reset = this.applyDefaultArtifactCamera(maxDistance);
+            persistenceKey = this.artifactCameraKey;
+        } else {
+            reset = this.applyDefaultModelCamera({ resetControls: true });
+            persistenceKey = this.persistence.cameraKey;
+        }
+        if (!reset) return false;
+
+        this.saveCameraState(persistenceKey);
+        this.controlSurface.hidden = true;
+        return true;
     }
 
     setArtifactMode(active) {
@@ -527,7 +629,7 @@ export class VrmAdapter {
             if (!this.restoreCameraState(undefined, { resetControls: true, maxDistance })) {
                 this.applyDefaultArtifactCamera(maxDistance);
             }
-            this.updateControlSurface();
+            this.controlSurface.hidden = true;
             return;
         }
 
@@ -540,7 +642,7 @@ export class VrmAdapter {
         }
         this.normalCameraState = null;
         this.normalMaxDistance = null;
-        this.updateControlSurface();
+        this.controlSurface.hidden = true;
     }
 
     handleResponse(response) {
@@ -559,7 +661,6 @@ export class VrmAdapter {
             this.viewCamera.aspect = window.innerWidth / window.innerHeight;
             if (this.artifactMode) this.applyArtifactViewOffset();
             else this.viewCamera.updateProjectionMatrix();
-            this.updateControlSurface();
         };
         window.addEventListener("resize", this.onResize);
     }
@@ -570,6 +671,7 @@ export class VrmAdapter {
             this.renderRequest = requestAnimationFrame(render);
             this.controls.update();
             this.idle.update(this.clock.getDelta());
+            this.updateControlSurface();
             this.renderer.render(this.scene, this.viewCamera);
         };
         render();

--- a/examples/websocket/html/avatar3d/models/vrm/vrm-settings.js
+++ b/examples/websocket/html/avatar3d/models/vrm/vrm-settings.js
@@ -59,6 +59,11 @@ export function installVrmSettings(adapter) {
         });
         panel.append(modelButton, modelInput);
 
+        const resetViewButton = button("Reset view");
+        resetViewButton.style.marginLeft = "6px";
+        resetViewButton.addEventListener("click", () => adapter.resetView());
+        panel.appendChild(resetViewButton);
+
         const unloadButton = button("Unload");
         unloadButton.style.marginLeft = "6px";
         unloadButton.addEventListener("click", () => adapter.unloadModel({ clearCache: true }));

--- a/tests/examples/websocket/test_vrm_control_surface.mjs
+++ b/tests/examples/websocket/test_vrm_control_surface.mjs
@@ -1,0 +1,432 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const vrmDirectory = new URL(
+    "../../../examples/websocket/html/avatar3d/models/vrm/",
+    import.meta.url,
+);
+
+function sourceDataUrl(source) {
+    return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const threeDataUrl = sourceDataUrl(`
+    export class Vector3 {
+        constructor(x = 0, y = 0, z = 0) {
+            this.set(x, y, z);
+        }
+        set(x, y, z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            return this;
+        }
+        clone() {
+            return new Vector3(this.x, this.y, this.z);
+        }
+        add(other) {
+            this.x += other.x;
+            this.y += other.y;
+            this.z += other.z;
+            return this;
+        }
+        multiplyScalar(value) {
+            this.x *= value;
+            this.y *= value;
+            this.z *= value;
+            return this;
+        }
+        length() {
+            return Math.hypot(this.x, this.y, this.z);
+        }
+        project(camera) {
+            if (!camera.matrixWorldIsCurrent) throw new Error("projected with a stale camera matrix");
+            this.x -= camera.projectOffsetX || 0;
+            return this;
+        }
+    }
+
+    export class Box3 {
+        constructor() {
+            throw new Error("the control surface must not use cached model bounds");
+        }
+    }
+`);
+const loaderDataUrl = sourceDataUrl("export class GLTFLoader {}");
+const controlsDataUrl = sourceDataUrl("export class OrbitControls {}");
+const vrmDataUrl = sourceDataUrl("export class VRMLoaderPlugin {}; export const VRMUtils = {};");
+const animationDataUrl = sourceDataUrl(`
+    export class VRMAnimationLoaderPlugin {}
+    export function createVRMAnimationClip() {}
+`);
+const settingsDataUrl = sourceDataUrl("export function installVrmSettings() {}");
+const actualSettingsDataUrl = sourceDataUrl(
+    await readFile(new URL("vrm-settings.js", vrmDirectory), "utf8"),
+);
+
+const adapterDataUrl = sourceDataUrl(
+    (await readFile(new URL("vrm-adapter.js", vrmDirectory), "utf8"))
+        .replace('"three"', `"${threeDataUrl}"`)
+        .replace('"three/addons/loaders/GLTFLoader.js"', `"${loaderDataUrl}"`)
+        .replace('"three/addons/controls/OrbitControls.js"', `"${controlsDataUrl}"`)
+        .replace('"@pixiv/three-vrm"', `"${vrmDataUrl}"`)
+        .replace('"@pixiv/three-vrm-animation"', `"${animationDataUrl}"`)
+        .replace('"./vrm-settings.js"', `"${settingsDataUrl}"`),
+);
+const { VrmAdapter } = await import(adapterDataUrl);
+const { installVrmSettings } = await import(actualSettingsDataUrl);
+
+function bone(position) {
+    return {
+        getWorldPosition(point) {
+            return point.set(...position);
+        },
+    };
+}
+
+function createControlSurfaceAdapter({
+    bones = {
+        hips: bone([0.1, 0, 0]),
+        head: bone([0, 0.5, 0]),
+        leftFoot: bone([-0.1, -0.5, 0]),
+        rightFoot: bone([0.1, -0.5, 0]),
+    },
+} = {}) {
+    let modelMatrixUpdates = 0;
+    let cameraMatrixUpdates = 0;
+    const rawBoneRequests = [];
+    const adapter = Object.create(VrmAdapter.prototype);
+    adapter.currentModel = {
+        scene: {
+            updateMatrixWorld(force) {
+                assert.equal(force, true);
+                modelMatrixUpdates += 1;
+            },
+        },
+        humanoid: {
+            getRawBoneNode(name) {
+                rawBoneRequests.push(name);
+                return bones[name] || null;
+            },
+            getNormalizedBoneNode() {
+                throw new Error("the rendered hit area must not use normalized proxy bones");
+            },
+        },
+    };
+    adapter.viewCamera = {
+        matrixWorldIsCurrent: false,
+        projectOffsetX: 0,
+        position: {
+            set(x) {
+                adapter.viewCamera.projectOffsetX = x * 0.2;
+                adapter.viewCamera.matrixWorldIsCurrent = false;
+            },
+        },
+        updateMatrixWorld(force) {
+            assert.equal(force, true);
+            this.matrixWorldIsCurrent = true;
+            cameraMatrixUpdates += 1;
+        },
+    };
+    adapter.controls = {
+        maxDistance: 5,
+        target: { copy() {} },
+        update() {},
+    };
+    adapter.controlSurface = { hidden: true, style: {} };
+    return {
+        adapter,
+        rawBoneRequests,
+        modelMatrixUpdates: () => modelMatrixUpdates,
+        cameraMatrixUpdates: () => cameraMatrixUpdates,
+    };
+}
+
+function withViewport(callback) {
+    const previousWindow = globalThis.window;
+    globalThis.window = { innerWidth: 1000, innerHeight: 800 };
+    try {
+        callback();
+    } finally {
+        if (previousWindow === undefined) delete globalThis.window;
+        else globalThis.window = previousWindow;
+    }
+}
+
+test("control surface projects raw rendered bones with the current camera matrix", () => {
+    withViewport(() => {
+        const {
+            adapter,
+            rawBoneRequests,
+            modelMatrixUpdates,
+            cameraMatrixUpdates,
+        } = createControlSurfaceAdapter();
+
+        adapter.updateControlSurface();
+
+        assert.equal(modelMatrixUpdates(), 0);
+        assert.equal(cameraMatrixUpdates(), 1);
+        assert.deepEqual(rawBoneRequests, ["hips", "head", "leftFoot", "rightFoot"]);
+        assert.equal(adapter.controlSurface.hidden, false);
+        assert.equal(
+            adapter.controlSurface.style.clipPath,
+            "inset(128px 380px 184px 480px)",
+        );
+    });
+});
+
+test("render loop updates the surface after the VRM pose update", () => {
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const events = [];
+    globalThis.requestAnimationFrame = () => 17;
+
+    try {
+        const adapter = Object.create(VrmAdapter.prototype);
+        adapter.renderRequest = null;
+        adapter.controls = { update: () => events.push("controls") };
+        adapter.clock = { getDelta: () => 0.016 };
+        adapter.idle = { update: () => events.push("idle") };
+        adapter.updateControlSurface = () => events.push("surface");
+        adapter.renderer = { render: () => events.push("render") };
+        adapter.scene = {};
+        adapter.viewCamera = {};
+
+        adapter.start();
+
+        assert.equal(adapter.renderRequest, 17);
+        assert.deepEqual(events, ["controls", "idle", "surface", "render"]);
+    } finally {
+        if (previousRequestAnimationFrame === undefined) {
+            delete globalThis.requestAnimationFrame;
+        } else {
+            globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+        }
+    }
+});
+
+test("render loop measures the raw pose produced by the same idle tick", () => {
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const previousWindow = globalThis.window;
+    const headPosition = [0, 0.1, 0];
+    const footPosition = [0, -0.1, 0];
+    globalThis.requestAnimationFrame = () => 19;
+    globalThis.window = { innerWidth: 1000, innerHeight: 800 };
+
+    try {
+        const { adapter } = createControlSurfaceAdapter({
+            bones: {
+                hips: bone([0.1, 0, 0]),
+                head: bone(headPosition),
+                leftFoot: bone(footPosition),
+            },
+        });
+        adapter.renderRequest = null;
+        adapter.clock = { getDelta: () => 0.016 };
+        adapter.idle = {
+            update() {
+                headPosition[1] = 0.5;
+                footPosition[1] = -0.5;
+            },
+        };
+        adapter.renderer = { render() {} };
+        adapter.scene = {};
+
+        adapter.start();
+
+        assert.equal(adapter.renderRequest, 19);
+        assert.equal(
+            adapter.controlSurface.style.clipPath,
+            "inset(128px 380px 184px 480px)",
+        );
+    } finally {
+        if (previousRequestAnimationFrame === undefined) {
+            delete globalThis.requestAnimationFrame;
+        } else {
+            globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+        }
+        if (previousWindow === undefined) delete globalThis.window;
+        else globalThis.window = previousWindow;
+    }
+});
+
+test("camera state changes are projected by the next rendered frame", () => {
+    withViewport(() => {
+        const { adapter, cameraMatrixUpdates } = createControlSurfaceAdapter();
+
+        const restored = adapter.applyCameraState({
+            px: 1,
+            py: 2,
+            pz: 3,
+            tx: 0,
+            ty: 1,
+            tz: 0,
+        });
+
+        assert.equal(restored, true);
+        assert.equal(cameraMatrixUpdates(), 0);
+        assert.equal(adapter.controlSurface.hidden, true);
+
+        adapter.updateControlSurface();
+
+        assert.equal(cameraMatrixUpdates(), 1);
+        assert.equal(adapter.controlSurface.hidden, false);
+        assert.equal(
+            adapter.controlSurface.style.clipPath,
+            "inset(128px 480px 184px 380px)",
+        );
+    });
+});
+
+test("one rendered foot is sufficient and missing vertical anchors hide the surface", () => {
+    withViewport(() => {
+        const bones = {
+            hips: bone([0, 0, 0]),
+            head: bone([0, 0.5, 0]),
+            leftFoot: bone([0, -0.5, 0]),
+        };
+        const { adapter } = createControlSurfaceAdapter({ bones });
+
+        adapter.updateControlSurface();
+        assert.equal(adapter.controlSurface.hidden, false);
+
+        delete bones.leftFoot;
+        adapter.updateControlSurface();
+        assert.equal(adapter.controlSurface.hidden, true);
+    });
+});
+
+test("default artifact camera uses the cached raw skeleton frame instead of model bounds", () => {
+    const { adapter, modelMatrixUpdates } = createControlSurfaceAdapter();
+    let applied = null;
+    adapter.modelSkeletonFrame = adapter.captureRawSkeletonFrame();
+    adapter.applyCameraState = (state, options) => {
+        applied = { state, options };
+        return true;
+    };
+
+    const result = adapter.applyDefaultArtifactCamera(5);
+
+    assert.equal(result, true);
+    assert.equal(modelMatrixUpdates(), 1);
+    assert.ok(Object.values(applied.state).every(Number.isFinite));
+    assert.ok(applied.options.maxDistance >= 5);
+});
+
+test("reset view restores the default camera for the current mode without unloading the model", () => {
+    const model = {};
+    const adapter = Object.create(VrmAdapter.prototype);
+    adapter.currentModel = model;
+    adapter.config = {
+        camera: {
+            maxDistance: 5,
+        },
+    };
+    adapter.persistence = { cameraKey: "camera" };
+    adapter.cameraSaveTimer = null;
+    adapter.controlSurface = { hidden: false };
+    adapter.viewCamera = {
+        zoom: 4,
+        projectionUpdates: 0,
+        updateProjectionMatrix() {
+            this.projectionUpdates += 1;
+        },
+    };
+    const calls = [];
+    adapter.applyDefaultModelCamera = (options) => {
+        calls.push(["normal", options]);
+        return true;
+    };
+    adapter.applyDefaultArtifactCamera = (maxDistance) => {
+        calls.push(["artifact", maxDistance]);
+        return true;
+    };
+    adapter.saveCameraState = (key) => calls.push(["save", key]);
+
+    adapter.artifactMode = false;
+    assert.equal(adapter.resetView(), true);
+    assert.equal(adapter.currentModel, model);
+    assert.equal(adapter.viewCamera.zoom, 1);
+    assert.equal(adapter.viewCamera.projectionUpdates, 1);
+    assert.deepEqual(calls, [
+        ["normal", { resetControls: true }],
+        ["save", "camera"],
+    ]);
+    assert.equal(adapter.controlSurface.hidden, true);
+
+    calls.length = 0;
+    adapter.artifactMode = true;
+    adapter.normalMaxDistance = 8;
+    assert.equal(adapter.resetView(), true);
+    assert.equal(adapter.currentModel, model);
+    assert.deepEqual(calls, [
+        ["artifact", 15],
+        ["save", "camera_artifact"],
+    ]);
+});
+
+test("Load settings expose a reset view button", () => {
+    const previousDocument = globalThis.document;
+
+    class FakeElement {
+        constructor(tagName) {
+            this.tagName = tagName;
+            this.children = [];
+            this.listeners = {};
+            this.style = {};
+            this.textContent = "";
+        }
+        append(...children) {
+            this.children.push(...children);
+        }
+        appendChild(child) {
+            this.children.push(child);
+            return child;
+        }
+        replaceChildren(...children) {
+            this.children = children;
+        }
+        addEventListener(type, listener) {
+            this.listeners[type] = listener;
+        }
+        click() {
+            this.listeners.click?.();
+        }
+    }
+
+    globalThis.document = {
+        createElement: (tagName) => new FakeElement(tagName),
+    };
+
+    try {
+        const panels = {};
+        let resetCount = 0;
+        const adapter = {
+            settingsHost: {
+                addTab(name, render) {
+                    const panel = new FakeElement("div");
+                    panels[name] = panel;
+                    render(panel);
+                },
+                onTabReset() {},
+            },
+            animationNames: [],
+            lightDefinitions: [],
+            lighting: {},
+            resetView() {
+                resetCount += 1;
+            },
+        };
+
+        installVrmSettings(adapter);
+        const resetButton = panels.Load.children.find(
+            (child) => child.textContent === "Reset view",
+        );
+        assert.ok(resetButton);
+        resetButton.click();
+        assert.equal(resetCount, 1);
+    } finally {
+        if (previousDocument === undefined) delete globalThis.document;
+        else globalThis.document = previousDocument;
+    }
+});


### PR DESCRIPTION
Track the interaction area from the rendered skeleton so the avatar no longer captures input far outside its visible body. Add a Load-tab button to restore the default camera without unloading the model.