### PR TITLE
Add Google Maps and web app artifacts to WebSocket examples

### DIFF
--- a/aiavatar/cli/config.py
+++ b/aiavatar/cli/config.py
@@ -43,7 +43,7 @@ neutral / joy / angry / sorrow / fun / surprise
 When expressing emotion, insert a tag such as <face name="joy" />. Default is neutral.
 
 ## Artifacts
-To display an image, chart, slide, or video, insert an `<artifact />` tag immediately before the relevant sentence in the response body. Do not read the tag aloud or explain it.
+To display an image, chart, slide, video, map, or route, insert an `<artifact />` tag immediately before the relevant sentence in the response body. Do not read the tag aloud or explain it.
 
 - Registered artifact: `<artifact id="{ARTIFACT_ID}" />`
 - HTTPS URL: `<artifact type="{TYPE}" src="{HTTPS_URL}" />`
@@ -51,6 +51,11 @@ To display an image, chart, slide, or video, insert an `<artifact />` tag immedi
   - A Docswell viewing URL (`https://www.docswell.com/s/...`) can be used directly as a presentation `src`.
   - Speaker Deck requires an embed URL (`https://speakerdeck.com/player/...`).
   - YouTube videos accept `autoplay-delay` as a non-negative number of seconds before the first playback attempt.
+- Map: `<artifact type="map" location="{PLACE_NAME_OR_ADDRESS}" />`
+  - Use this when the user asks to display a map for a place name or address.
+  - Optionally set `zoom` to an integer from `0` to `21`.
+- Directions: `<artifact type="map" origin="{ORIGIN}" destination="{DESTINATION}" travel-mode="{TRAVEL_MODE}" />`
+  - Use `driving` for driving, `walking` for walking, `bicycling` for bicycling, or `transit` for public transit. Omit `travel-mode` when the user does not specify a mode of travel.
 - Presentation controls are available only with `type="presentation"`, not with images, charts, or videos.
   - Move the displayed presentation to a numbered page: `<artifact type="presentation" slide="3" />`
   - To set the starting page of a new presentation, specify `id` or `src` together with `slide` in the same tag.

--- a/examples/websocket/html/3d.html
+++ b/examples/websocket/html/3d.html
@@ -88,13 +88,29 @@
     <script type="module">
         import { start3dPage } from "./avatar3d/3d-main.js";
         import { ImageArtifactPlugin } from "./artifact/image-artifact-plugin.js";
+        import { GoogleMapArtifactPlugin } from "./artifact/google-map-artifact-plugin.js";
         import { PresentationArtifactPlugin } from "./artifact/presentation-artifact-plugin.js";
         import { VideoArtifactPlugin } from "./artifact/video-artifact-plugin.js";
+        import { WebAppArtifactPlugin } from "./artifact/webapp-artifact-plugin.js";
         import { DocswellDriver } from "./artifact/docswell-driver.js";
         import { SpeakerDeckDriver } from "./artifact/speakerdeck-driver.js";
         import { YouTubeDriver } from "./artifact/youtube-driver.js";
 
-        await start3dPage({
+        const GOOGLE_MAPS_EMBED_API_KEY = "YOUR_GOOGLE_MAPS_EMBED_API_KEY";
+
+        let avatarApp = null;
+        const webAppArtifactPlugin = new WebAppArtifactPlugin({
+            onInvoke: ({ text, imageDataUrl }) => (
+                avatarApp?.aiavatar.chat(
+                    avatarApp.ui.sessionId,
+                    avatarApp.ui.userId,
+                    text,
+                    imageDataUrl,
+                ) ?? false
+            ),
+        });
+
+        avatarApp = await start3dPage({
             artifactPlugins: [
                 new ImageArtifactPlugin({ type: "image" }),
                 new ImageArtifactPlugin({ type: "chart" }),
@@ -105,6 +121,12 @@
                     drivers: [YouTubeDriver],
                     autoplay: true,
                 }),
+                new GoogleMapArtifactPlugin({
+                    apiKey: GOOGLE_MAPS_EMBED_API_KEY,
+                    language: "ja",
+                    region: "JP",
+                }),
+                webAppArtifactPlugin,
             ],
 
             connection: {

--- a/examples/websocket/html/artifact/google-map-artifact-plugin.js
+++ b/examples/websocket/html/artifact/google-map-artifact-plugin.js
@@ -1,0 +1,206 @@
+import {
+    assertArtifactAttributes,
+    parseArtifactDisplayAttributes,
+} from "./artifact-parser.js";
+
+const MAPS_EMBED_BASE_URL = "https://www.google.com/maps/embed/v1/";
+const MAP_TYPES = new Set(["roadmap", "satellite"]);
+const TRAVEL_MODES = new Set(["driving", "walking", "bicycling", "transit", "flying"]);
+const DEFAULT_ZOOM = 15;
+const MAX_MAP_TERM_LENGTH = 512;
+
+function normalizeApiKey(value) {
+    if (typeof value !== "string" || !value.trim()) {
+        throw new TypeError("Google Maps Embed API key is required");
+    }
+    const apiKey = value.trim();
+    if (apiKey.length > 512 || /\s/.test(apiKey)) {
+        throw new TypeError("Google Maps Embed API key is invalid");
+    }
+    return apiKey;
+}
+
+function parseCoordinate(value, name, minimum, maximum) {
+    if (value === undefined || value === null || String(value).trim() === "") {
+        throw new Error(`Map ${name} is required`);
+    }
+    const coordinate = Number(value);
+    if (!Number.isFinite(coordinate) || coordinate < minimum || coordinate > maximum) {
+        throw new RangeError(`Map ${name} must be between ${minimum} and ${maximum}`);
+    }
+    return coordinate;
+}
+
+function parseMapTerm(value, name) {
+    if (value === undefined || value === null) return null;
+    const term = String(value).trim();
+    if (!term) throw new Error(`Map ${name} must not be empty`);
+    if (term.length > MAX_MAP_TERM_LENGTH || /[\u0000-\u001f\u007f]/.test(term)) {
+        throw new Error(`Map ${name} is invalid or too long`);
+    }
+    return term;
+}
+
+function parseZoom(value, defaultZoom) {
+    if (value === undefined || value === null || String(value).trim() === "") return defaultZoom;
+    const zoom = Number(value);
+    if (!Number.isInteger(zoom) || zoom < 0 || zoom > 21) {
+        throw new RangeError("Map zoom must be an integer between 0 and 21");
+    }
+    return zoom;
+}
+
+function parseMapType(value, defaultMapType) {
+    const mapType = String(value || defaultMapType).toLowerCase();
+    if (!MAP_TYPES.has(mapType)) {
+        throw new Error(`Unsupported map type: ${value}`);
+    }
+    return mapType;
+}
+
+function parseTravelMode(value) {
+    if (value === undefined || value === null || String(value).trim() === "") return null;
+    const travelMode = String(value).toLowerCase();
+    if (!TRAVEL_MODES.has(travelMode)) {
+        throw new Error(`Unsupported map travel mode: ${value}`);
+    }
+    return travelMode;
+}
+
+function normalizeLanguage(value) {
+    if (value === null || value === undefined || value === "") return null;
+    if (typeof value !== "string" || !/^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/i.test(value)) {
+        throw new TypeError("Google Maps language is invalid");
+    }
+    return value;
+}
+
+function normalizeRegion(value) {
+    if (value === null || value === undefined || value === "") return null;
+    if (typeof value !== "string" || !/^[a-z]{2}$/i.test(value)) {
+        throw new TypeError("Google Maps region must be a two-letter code");
+    }
+    return value.toUpperCase();
+}
+
+export class GoogleMapArtifactPlugin {
+    constructor({
+        apiKey,
+        defaultZoom = DEFAULT_ZOOM,
+        defaultMapType = "roadmap",
+        language = null,
+        region = null,
+    } = {}) {
+        this.type = "map";
+        this.aliases = [];
+        this.apiKey = normalizeApiKey(apiKey);
+        this.defaultZoom = parseZoom(defaultZoom, DEFAULT_ZOOM);
+        this.defaultMapType = parseMapType(defaultMapType, "roadmap");
+        this.language = normalizeLanguage(language);
+        this.region = normalizeRegion(region);
+    }
+
+    parse(attributes) {
+        assertArtifactAttributes(attributes, [
+            "location",
+            "latitude",
+            "longitude",
+            "origin",
+            "destination",
+            "travel-mode",
+            "zoom",
+            "maptype",
+        ]);
+        if (attributes.src !== undefined || attributes.href !== undefined) {
+            throw new Error("Map artifacts use a location, coordinates, or route instead of src or href");
+        }
+
+        const location = parseMapTerm(attributes.location, "location");
+        const origin = parseMapTerm(attributes.origin, "origin");
+        const destination = parseMapTerm(attributes.destination, "destination");
+        const travelMode = parseTravelMode(attributes["travel-mode"]);
+        const hasLatitude = attributes.latitude !== undefined;
+        const hasLongitude = attributes.longitude !== undefined;
+        const hasCoordinates = hasLatitude || hasLongitude;
+        const hasRoute = origin !== null || destination !== null;
+
+        if (hasRoute && (!origin || !destination)) {
+            throw new Error("Map origin and destination must be specified together");
+        }
+        const inputCount = Number(Boolean(location)) + Number(hasCoordinates) + Number(hasRoute);
+        if (inputCount === 0) {
+            throw new Error("Map location, coordinates, or route are required");
+        }
+        if (inputCount > 1) {
+            throw new Error("Map artifacts use either a location, coordinates, or route");
+        }
+        if (hasCoordinates && hasLatitude !== hasLongitude) {
+            throw new Error("Map latitude and longitude must be specified together");
+        }
+        if (travelMode && !hasRoute) {
+            throw new Error("Map travel-mode is available only for routes");
+        }
+
+        const mode = hasRoute ? "directions" : location ? "place" : "view";
+        const zoom = mode === "directions" && attributes.zoom === undefined
+            ? null
+            : parseZoom(attributes.zoom, this.defaultZoom);
+
+        return {
+            action: "show",
+            type: this.type,
+            mode,
+            location,
+            latitude: hasCoordinates ? parseCoordinate(attributes.latitude, "latitude", -90, 90) : null,
+            longitude: hasCoordinates ? parseCoordinate(attributes.longitude, "longitude", -180, 180) : null,
+            origin,
+            destination,
+            travelMode,
+            zoom,
+            mapType: parseMapType(attributes.maptype, this.defaultMapType),
+            ...parseArtifactDisplayAttributes(attributes),
+        };
+    }
+
+    resolveSource(command) {
+        const url = new URL(command.mode, MAPS_EMBED_BASE_URL);
+        url.searchParams.set("key", this.apiKey);
+        if (command.mode === "place") url.searchParams.set("q", command.location);
+        else if (command.mode === "directions") {
+            url.searchParams.set("origin", command.origin);
+            url.searchParams.set("destination", command.destination);
+            if (command.travelMode) url.searchParams.set("mode", command.travelMode);
+        } else {
+            url.searchParams.set("center", `${command.latitude},${command.longitude}`);
+        }
+        if (command.zoom !== null) url.searchParams.set("zoom", String(command.zoom));
+        url.searchParams.set("maptype", command.mapType);
+        if (this.language) url.searchParams.set("language", this.language);
+        if (this.region) url.searchParams.set("region", this.region);
+        return { provider: "google-maps-embed", url: url.href };
+    }
+
+    getDefaults() {
+        return { aspect: "16:9" };
+    }
+
+    mount({ documentRoot, command, source, view }) {
+        const iframe = documentRoot.createElement("iframe");
+        iframe.className = "artifact-media";
+        iframe.src = source.url;
+        const defaultTitle = command.mode === "directions"
+            ? `${command.origin} → ${command.destination}`
+            : command.location || "Google Map";
+        iframe.title = command.title || command.alt || defaultTitle;
+        iframe.loading = "eager";
+        iframe.referrerPolicy = "strict-origin-when-cross-origin";
+        iframe.setAttribute("allowfullscreen", "");
+        iframe.addEventListener("load", () => view.loaded(), { once: true });
+        iframe.addEventListener("error", () => view.error("地図を表示できませんでした"), { once: true });
+
+        return {
+            element: iframe,
+            dispose: () => iframe.removeAttribute("src"),
+        };
+    }
+}

--- a/examples/websocket/html/artifact/webapp-artifact-plugin.js
+++ b/examples/websocket/html/artifact/webapp-artifact-plugin.js
@@ -1,0 +1,145 @@
+import {
+    assertArtifactAttributes,
+    parseArtifactDisplayAttributes,
+    parseArtifactSourceAttributes,
+} from "./artifact-parser.js";
+import { parseArtifactHttpUrl } from "./artifact-url.js";
+
+const INVOKE_MESSAGE_TYPE = "aiavatar.webapp.invoke";
+const INVOKE_MESSAGE_VERSION = 1;
+const DEFAULT_MAX_TEXT_LENGTH = 10_000;
+const DEFAULT_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const DEFAULT_INVOKE_COOLDOWN_MS = 1000;
+const MESSAGE_FIELDS = new Set(["type", "version", "text", "imageDataUrl"]);
+const IMAGE_DATA_URL_PATTERN = /^data:image\/(?:png|jpeg|webp);base64,([A-Za-z0-9+/]+={0,2})$/i;
+
+function isObject(value) {
+    return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizePositiveInteger(value, name) {
+    if (!Number.isSafeInteger(value) || value < 1) {
+        throw new TypeError(`${name} must be a positive integer`);
+    }
+    return value;
+}
+
+function normalizeCooldown(value) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+        throw new TypeError("invokeCooldownMs must be a non-negative integer");
+    }
+    return value;
+}
+
+function parseImageDataUrl(value, maxImageBytes) {
+    if (value === undefined || value === null) return null;
+    if (typeof value !== "string") return false;
+
+    const match = IMAGE_DATA_URL_PATTERN.exec(value);
+    if (!match || match[1].length % 4 !== 0) return false;
+
+    const padding = match[1].endsWith("==") ? 2 : match[1].endsWith("=") ? 1 : 0;
+    const decodedBytes = (match[1].length * 3 / 4) - padding;
+    return decodedBytes <= maxImageBytes ? value : false;
+}
+
+export class WebAppArtifactPlugin {
+    constructor({
+        type = "webapp",
+        onInvoke = () => false,
+        maxTextLength = DEFAULT_MAX_TEXT_LENGTH,
+        maxImageBytes = DEFAULT_MAX_IMAGE_BYTES,
+        invokeCooldownMs = DEFAULT_INVOKE_COOLDOWN_MS,
+    } = {}) {
+        if (typeof onInvoke !== "function") throw new TypeError("onInvoke must be a function");
+        this.type = type;
+        this.aliases = [];
+        this.onInvoke = onInvoke;
+        this.maxTextLength = normalizePositiveInteger(maxTextLength, "maxTextLength");
+        this.maxImageBytes = normalizePositiveInteger(maxImageBytes, "maxImageBytes");
+        this.invokeCooldownMs = normalizeCooldown(invokeCooldownMs);
+    }
+
+    parse(attributes) {
+        assertArtifactAttributes(attributes);
+        const src = parseArtifactSourceAttributes(attributes);
+        if (!src) throw new Error("Artifact src is required");
+        return {
+            action: "show",
+            type: this.type,
+            src,
+            ...parseArtifactDisplayAttributes(attributes),
+        };
+    }
+
+    resolveSource(command) {
+        return {
+            provider: "webapp",
+            url: parseArtifactHttpUrl(command.src).href,
+        };
+    }
+
+    getDefaults() {
+        return { aspect: "16:9" };
+    }
+
+    parseInvokeMessage(value) {
+        if (!isObject(value)) return null;
+        if (Object.keys(value).some((name) => !MESSAGE_FIELDS.has(name))) return null;
+        if (value.type !== INVOKE_MESSAGE_TYPE || value.version !== INVOKE_MESSAGE_VERSION) return null;
+        if (typeof value.text !== "string") return null;
+
+        const text = value.text.trim();
+        if (!text || text.length > this.maxTextLength) return null;
+
+        const imageDataUrl = parseImageDataUrl(value.imageDataUrl, this.maxImageBytes);
+        if (imageDataUrl === false) return null;
+        return { text, imageDataUrl };
+    }
+
+    mount({ documentRoot, windowRoot, command, source, view }) {
+        const iframe = documentRoot.createElement("iframe");
+        iframe.className = "artifact-media";
+        iframe.src = source.url;
+        iframe.title = command.title || command.alt || "Web app";
+        iframe.loading = "eager";
+        iframe.referrerPolicy = "no-referrer";
+        iframe.setAttribute("sandbox", "allow-scripts");
+        iframe.addEventListener("load", () => view.loaded(), { once: true });
+
+        let disposed = false;
+        let invokeInFlight = false;
+        let nextInvokeAt = 0;
+        const handleMessage = (event) => {
+            if (disposed || event.source !== iframe.contentWindow) return;
+            const message = this.parseInvokeMessage(event.data);
+            if (!message || invokeInFlight || Date.now() < nextInvokeAt) return;
+
+            invokeInFlight = true;
+            nextInvokeAt = Date.now() + this.invokeCooldownMs;
+            try {
+                const result = this.onInvoke(message);
+                if (result?.then) {
+                    Promise.resolve(result)
+                        .catch((error) => console.warn("Could not invoke from web app artifact:", error))
+                        .finally(() => { invokeInFlight = false; });
+                } else {
+                    invokeInFlight = false;
+                }
+            } catch (error) {
+                invokeInFlight = false;
+                console.warn("Could not invoke from web app artifact:", error);
+            }
+        };
+        windowRoot.addEventListener("message", handleMessage);
+
+        return {
+            element: iframe,
+            dispose: () => {
+                disposed = true;
+                windowRoot.removeEventListener("message", handleMessage);
+                iframe.removeAttribute("src");
+            },
+        };
+    }
+}

--- a/examples/websocket/html/index.html
+++ b/examples/websocket/html/index.html
@@ -113,8 +113,10 @@
     <script type="module">
         import { ArtifactController } from "./artifact/artifact-controller.js";
         import { ImageArtifactPlugin } from "./artifact/image-artifact-plugin.js";
+        import { GoogleMapArtifactPlugin } from "./artifact/google-map-artifact-plugin.js";
         import { PresentationArtifactPlugin } from "./artifact/presentation-artifact-plugin.js";
         import { VideoArtifactPlugin } from "./artifact/video-artifact-plugin.js";
+        import { WebAppArtifactPlugin } from "./artifact/webapp-artifact-plugin.js";
         import { DocswellDriver } from "./artifact/docswell-driver.js";
         import { SpeakerDeckDriver } from "./artifact/speakerdeck-driver.js";
         import { YouTubeDriver } from "./artifact/youtube-driver.js";
@@ -124,6 +126,7 @@
         const PLAYBACK_RMS_SCALE = 1.0; // Lower this (e.g. 0.2) if the mouth stays open
         const VISION_STREAM_ENABLED = false; // Requires the optional Vision server
         const VISION_SERVER_URL = "../vision";
+        const GOOGLE_MAPS_EMBED_API_KEY = "YOUR_GOOGLE_MAPS_EMBED_API_KEY";
 
         // Avatar
         let avatar;
@@ -189,6 +192,16 @@
                 new VideoArtifactPlugin({
                     drivers: [YouTubeDriver],
                     autoplay: true,
+                }),
+                new GoogleMapArtifactPlugin({
+                    apiKey: GOOGLE_MAPS_EMBED_API_KEY,
+                    language: "ja",
+                    region: "JP",
+                }),
+                new WebAppArtifactPlugin({
+                    onInvoke: ({ text, imageDataUrl }) => (
+                        aiavatar.chat(ui.sessionId, ui.userId, text, imageDataUrl)
+                    ),
                 }),
             ],
         });

--- a/tests/examples/websocket/test_google_map_artifact_plugin.mjs
+++ b/tests/examples/websocket/test_google_map_artifact_plugin.mjs
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const artifactDirectory = new URL("../../../examples/websocket/html/artifact/", import.meta.url);
+
+function sourceDataUrl(source) {
+    return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const parserDataUrl = sourceDataUrl(
+    await readFile(new URL("artifact-parser.js", artifactDirectory), "utf8"),
+);
+const pluginDataUrl = sourceDataUrl(
+    (await readFile(new URL("google-map-artifact-plugin.js", artifactDirectory), "utf8"))
+        .replace('"./artifact-parser.js"', `"${parserDataUrl}"`),
+);
+const { GoogleMapArtifactPlugin } = await import(pluginDataUrl);
+
+class FakeElement {
+    constructor() {
+        this.attributes = {};
+        this.listeners = new Map();
+    }
+
+    setAttribute(name, value) {
+        this.attributes[name] = value;
+    }
+
+    removeAttribute(name) {
+        delete this.attributes[name];
+        if (name === "src") delete this.src;
+    }
+
+    addEventListener(name, listener) {
+        this.listeners.set(name, listener);
+    }
+
+    dispatch(name) {
+        this.listeners.get(name)?.();
+    }
+}
+
+class FakeDocument {
+    createElement() {
+        return new FakeElement();
+    }
+}
+
+test("Google map plugin builds a Maps Embed view URL", () => {
+    const plugin = new GoogleMapArtifactPlugin({
+        apiKey: "test-api-key",
+        language: "ja",
+        region: "jp",
+    });
+    const command = plugin.parse({
+        type: "map",
+        latitude: "35.681236",
+        longitude: "139.767125",
+        zoom: "16",
+        maptype: "satellite",
+        title: "Tokyo Station",
+    });
+    const source = plugin.resolveSource(command);
+    const url = new URL(source.url);
+
+    assert.equal(command.latitude, 35.681236);
+    assert.equal(command.longitude, 139.767125);
+    assert.equal(command.zoom, 16);
+    assert.equal(command.mapType, "satellite");
+    assert.equal(source.provider, "google-maps-embed");
+    assert.equal(url.origin, "https://www.google.com");
+    assert.equal(url.pathname, "/maps/embed/v1/view");
+    assert.equal(url.searchParams.get("key"), "test-api-key");
+    assert.equal(url.searchParams.get("center"), "35.681236,139.767125");
+    assert.equal(url.searchParams.get("zoom"), "16");
+    assert.equal(url.searchParams.get("maptype"), "satellite");
+    assert.equal(url.searchParams.get("language"), "ja");
+    assert.equal(url.searchParams.get("region"), "JP");
+    assert.deepEqual(plugin.getDefaults(), { aspect: "16:9" });
+});
+
+test("Google map plugin builds a Maps Embed place URL from a location name", () => {
+    const plugin = new GoogleMapArtifactPlugin({ apiKey: "test-api-key" });
+    const command = plugin.parse({
+        type: "map",
+        location: "  東京駅  ",
+        zoom: "17",
+    });
+    const source = plugin.resolveSource(command);
+    const url = new URL(source.url);
+
+    assert.equal(command.mode, "place");
+    assert.equal(command.location, "東京駅");
+    assert.equal(command.latitude, null);
+    assert.equal(command.longitude, null);
+    assert.equal(url.pathname, "/maps/embed/v1/place");
+    assert.equal(url.searchParams.get("q"), "東京駅");
+    assert.equal(url.searchParams.get("zoom"), "17");
+    assert.equal(url.searchParams.has("center"), false);
+});
+
+test("Google map plugin builds a Maps Embed directions URL", () => {
+    const plugin = new GoogleMapArtifactPlugin({
+        apiKey: "test-api-key",
+        language: "ja",
+        region: "JP",
+    });
+    const command = plugin.parse({
+        type: "map",
+        origin: "東京駅",
+        destination: "東京タワー",
+        "travel-mode": "walking",
+    });
+    const source = plugin.resolveSource(command);
+    const url = new URL(source.url);
+
+    assert.equal(command.mode, "directions");
+    assert.equal(command.origin, "東京駅");
+    assert.equal(command.destination, "東京タワー");
+    assert.equal(command.travelMode, "walking");
+    assert.equal(command.zoom, null);
+    assert.equal(url.pathname, "/maps/embed/v1/directions");
+    assert.equal(url.searchParams.get("origin"), "東京駅");
+    assert.equal(url.searchParams.get("destination"), "東京タワー");
+    assert.equal(url.searchParams.get("mode"), "walking");
+    assert.equal(url.searchParams.has("zoom"), false);
+});
+
+test("Google map plugin validates configuration and artifact attributes", () => {
+    assert.throws(
+        () => new GoogleMapArtifactPlugin(),
+        /API key is required/,
+    );
+    assert.throws(
+        () => new GoogleMapArtifactPlugin({ apiKey: "has whitespace" }),
+        /API key is invalid/,
+    );
+
+    const plugin = new GoogleMapArtifactPlugin({ apiKey: "test-api-key" });
+    assert.throws(
+        () => plugin.parse({ type: "map" }),
+        /location, coordinates, or route are required/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", longitude: "139" }),
+        /latitude and longitude must be specified together/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", location: "Tokyo", latitude: "35", longitude: "139" }),
+        /either a location, coordinates, or route/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", origin: "東京駅" }),
+        /origin and destination must be specified together/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", location: "東京駅", origin: "上野駅", destination: "東京駅" }),
+        /either a location, coordinates, or route/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", location: "東京駅", "travel-mode": "walking" }),
+        /travel-mode is available only for routes/,
+    );
+    assert.throws(
+        () => plugin.parse({
+            type: "map",
+            origin: "東京駅",
+            destination: "東京タワー",
+            "travel-mode": "swimming",
+        }),
+        /Unsupported map travel mode/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", latitude: "91", longitude: "139" }),
+        /latitude must be between -90 and 90/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", latitude: "35", longitude: "181" }),
+        /longitude must be between -180 and 180/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", latitude: "35", longitude: "139", zoom: "1.5" }),
+        /zoom must be an integer/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", latitude: "35", longitude: "139", maptype: "terrain" }),
+        /Unsupported map type/,
+    );
+    assert.throws(
+        () => plugin.parse({ type: "map", src: "https://example.com/map" }),
+        /location, coordinates, or route instead/,
+    );
+});
+
+test("Google map plugin gives only its iframe a Google-compatible referrer policy", () => {
+    const plugin = new GoogleMapArtifactPlugin({ apiKey: "test-api-key" });
+    const command = plugin.parse({
+        type: "map",
+        latitude: "35.681236",
+        longitude: "139.767125",
+    });
+    const source = plugin.resolveSource(command);
+    let loaded = false;
+    let errorMessage = null;
+    const session = plugin.mount({
+        documentRoot: new FakeDocument(),
+        command,
+        source,
+        view: {
+            loaded: () => { loaded = true; },
+            error: (message) => { errorMessage = message; },
+        },
+    });
+
+    assert.equal(session.element.referrerPolicy, "strict-origin-when-cross-origin");
+    assert.equal(session.element.attributes.allowfullscreen, "");
+    assert.equal(Object.hasOwn(session.element.attributes, "sandbox"), false);
+    assert.equal(session.element.title, "Google Map");
+
+    session.element.dispatch("load");
+    assert.equal(loaded, true);
+    assert.equal(errorMessage, null);
+
+    session.dispose();
+    assert.equal(session.element.src, undefined);
+});
+
+test("Google map plugin uses the location as the default iframe title", () => {
+    const plugin = new GoogleMapArtifactPlugin({ apiKey: "test-api-key" });
+    const command = plugin.parse({ type: "map", location: "東京駅" });
+    const session = plugin.mount({
+        documentRoot: new FakeDocument(),
+        command,
+        source: plugin.resolveSource(command),
+        view: { loaded() {}, error() {} },
+    });
+
+    assert.equal(session.element.title, "東京駅");
+});
+
+test("Google map plugin uses route endpoints as the default iframe title", () => {
+    const plugin = new GoogleMapArtifactPlugin({ apiKey: "test-api-key" });
+    const command = plugin.parse({
+        type: "map",
+        origin: "東京駅",
+        destination: "東京タワー",
+    });
+    const session = plugin.mount({
+        documentRoot: new FakeDocument(),
+        command,
+        source: plugin.resolveSource(command),
+        view: { loaded() {}, error() {} },
+    });
+
+    assert.equal(session.element.title, "東京駅 → 東京タワー");
+});
+
+test("web viewers register the Google map plugin with a replaceable API key", async () => {
+    for (const pageName of ["index.html", "3d.html"]) {
+        const page = await readFile(new URL(`../${pageName}`, artifactDirectory), "utf8");
+        assert.match(page, /import \{ GoogleMapArtifactPlugin \} from "\.\/artifact\/google-map-artifact-plugin\.js";/);
+        assert.match(page, /const GOOGLE_MAPS_EMBED_API_KEY = "YOUR_GOOGLE_MAPS_EMBED_API_KEY";/);
+        assert.match(page, /new GoogleMapArtifactPlugin\(\{[\s\S]*?apiKey: GOOGLE_MAPS_EMBED_API_KEY,/);
+    }
+});

--- a/tests/examples/websocket/test_webapp_artifact_plugin.mjs
+++ b/tests/examples/websocket/test_webapp_artifact_plugin.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const artifactDirectory = new URL("../../../examples/websocket/html/artifact/", import.meta.url);
+
+function sourceDataUrl(source) {
+    return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const parserDataUrl = sourceDataUrl(
+    await readFile(new URL("artifact-parser.js", artifactDirectory), "utf8"),
+);
+const urlDataUrl = sourceDataUrl(
+    await readFile(new URL("artifact-url.js", artifactDirectory), "utf8"),
+);
+const pluginDataUrl = sourceDataUrl(
+    (await readFile(new URL("webapp-artifact-plugin.js", artifactDirectory), "utf8"))
+        .replace('"./artifact-parser.js"', `"${parserDataUrl}"`)
+        .replace('"./artifact-url.js"', `"${urlDataUrl}"`),
+);
+const { WebAppArtifactPlugin } = await import(pluginDataUrl);
+
+class FakeWindow {
+    constructor() {
+        this.listeners = new Map();
+    }
+
+    addEventListener(name, listener) {
+        this.listeners.set(name, listener);
+    }
+
+    removeEventListener(name, listener) {
+        if (this.listeners.get(name) === listener) this.listeners.delete(name);
+    }
+
+    dispatchMessage(source, data) {
+        this.listeners.get("message")?.({ source, data });
+    }
+}
+
+class FakeElement {
+    constructor() {
+        this.attributes = {};
+        this.listeners = new Map();
+        this.contentWindow = {};
+    }
+
+    setAttribute(name, value) {
+        this.attributes[name] = value;
+    }
+
+    removeAttribute(name) {
+        delete this.attributes[name];
+        if (name === "src") delete this.src;
+    }
+
+    addEventListener(name, listener) {
+        this.listeners.set(name, listener);
+    }
+
+    dispatch(name) {
+        this.listeners.get(name)?.();
+    }
+}
+
+class FakeDocument {
+    createElement() {
+        return new FakeElement();
+    }
+}
+
+function mount(plugin) {
+    const documentRoot = new FakeDocument();
+    const windowRoot = new FakeWindow();
+    let loaded = false;
+    const session = plugin.mount({
+        documentRoot,
+        windowRoot,
+        command: { title: "Lunch picker", alt: "" },
+        source: { url: "https://example.com/app" },
+        view: { loaded: () => { loaded = true; } },
+    });
+    return { windowRoot, session, wasLoaded: () => loaded };
+}
+
+test("web app plugin parses URLs and mounts a sandboxed iframe", () => {
+    const plugin = new WebAppArtifactPlugin();
+    const command = plugin.parse({
+        type: "webapp",
+        src: "https://example.com/app",
+        title: "Lunch picker",
+    });
+    assert.equal(command.type, "webapp");
+    assert.equal(plugin.resolveSource(command).url, "https://example.com/app");
+    assert.deepEqual(plugin.getDefaults(), { aspect: "16:9" });
+
+    const { session, wasLoaded } = mount(plugin);
+    assert.equal(session.element.attributes.sandbox, "allow-scripts");
+    assert.equal(session.element.referrerPolicy, "no-referrer");
+    session.element.dispatch("load");
+    assert.equal(wasLoaded(), true);
+});
+
+test("web app plugin forwards only valid messages from its iframe", () => {
+    const invocations = [];
+    const plugin = new WebAppArtifactPlugin({
+        onInvoke: (message) => invocations.push(message),
+        invokeCooldownMs: 0,
+    });
+    const { windowRoot, session } = mount(plugin);
+    const iframeWindow = session.element.contentWindow;
+
+    windowRoot.dispatchMessage({}, {
+        type: "aiavatar.webapp.invoke",
+        version: 1,
+        text: "Ignored source",
+    });
+    windowRoot.dispatchMessage(iframeWindow, {
+        type: "aiavatar.webapp.invoke",
+        version: 2,
+        text: "Ignored version",
+    });
+    windowRoot.dispatchMessage(iframeWindow, {
+        type: "aiavatar.webapp.invoke",
+        version: 1,
+        text: "  Find lunch in Shinjuku.  ",
+        imageDataUrl: "data:image/png;base64,YQ==",
+    });
+
+    assert.deepEqual(invocations, [{
+        text: "Find lunch in Shinjuku.",
+        imageDataUrl: "data:image/png;base64,YQ==",
+    }]);
+
+    session.dispose();
+    assert.equal(windowRoot.listeners.has("message"), false);
+    windowRoot.dispatchMessage(iframeWindow, {
+        type: "aiavatar.webapp.invoke",
+        version: 1,
+        text: "Ignored after dispose",
+    });
+    assert.equal(invocations.length, 1);
+});
+
+test("web app plugin rejects oversized or unexpected invoke payloads", () => {
+    const invocations = [];
+    const plugin = new WebAppArtifactPlugin({
+        onInvoke: (message) => invocations.push(message),
+        maxTextLength: 4,
+        maxImageBytes: 1,
+        invokeCooldownMs: 0,
+    });
+    const { windowRoot, session } = mount(plugin);
+    const iframeWindow = session.element.contentWindow;
+    const send = (data) => windowRoot.dispatchMessage(iframeWindow, data);
+
+    send({ type: "aiavatar.webapp.invoke", version: 1, text: "12345" });
+    send({ type: "aiavatar.webapp.invoke", version: 1, text: "okay", extra: true });
+    send({
+        type: "aiavatar.webapp.invoke",
+        version: 1,
+        text: "okay",
+        imageDataUrl: "https://example.com/image.png",
+    });
+    send({
+        type: "aiavatar.webapp.invoke",
+        version: 1,
+        text: "okay",
+        imageDataUrl: "data:image/png;base64,YWI=",
+    });
+
+    assert.deepEqual(invocations, []);
+});


### PR DESCRIPTION
- Add Google Maps Embed support for places, coordinates, and directions
- Add a sandboxed web app artifact plugin with validated invoke messages
- Register both artifact plugins in the standard and 3D WebSocket viewers
- Update the CLI system prompt with map and directions artifact instructions
- Add focused tests for URL generation, validation, iframe behavior, and viewer integration