### PR TITLE
Fix CLI startup without Semantic VAD dependencies

### DIFF
--- a/aiavatar/cli/builtin.py
+++ b/aiavatar/cli/builtin.py
@@ -23,10 +23,14 @@ def create_app(
     config: AppConfig | None = None,
     components: ComponentSet | None = None,
     download_ui: bool = True,
+    use_namo_turn: bool = True,
 ) -> FastAPI:
     """Assemble the CLI's built-in WebSocket application."""
     config = config or AppConfig.from_env()
-    components = components or build_components(config)
+    components = components or build_components(
+        config,
+        use_namo_turn=use_namo_turn,
+    )
     vad, stt, llm, tts = components
 
     pipeline = STSPipeline(

--- a/aiavatar/cli/command.py
+++ b/aiavatar/cli/command.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.util
 import logging
 import os
+import subprocess
 import sys
 import warnings
 from pathlib import Path
@@ -14,6 +15,13 @@ from dotenv import load_dotenv
 
 
 logger = logging.getLogger(__name__)
+
+
+NAMO_TURN_OPTIONAL_MODULES = (
+    "onnxruntime",
+    "transformers",
+    "huggingface_hub",
+)
 
 
 class ApplicationLoadError(ValueError):
@@ -92,10 +100,81 @@ def load_app(target: str) -> Any:
     return app
 
 
-def _load_builtin_app() -> Any:
+def _load_builtin_app(*, use_namo_turn: bool) -> Any:
     from .builtin import create_app
 
-    return create_app()
+    return create_app(use_namo_turn=use_namo_turn)
+
+
+def _missing_namo_turn_modules() -> list[str]:
+    return [
+        module_name
+        for module_name in NAMO_TURN_OPTIONAL_MODULES
+        if importlib.util.find_spec(module_name) is None
+    ]
+
+
+def _prepare_namo_turn(
+    parser: argparse.ArgumentParser,
+    *,
+    using_builtin_app: bool,
+) -> bool:
+    """Install Namo Turn support when requested, or disable it for this run."""
+    if not using_builtin_app:
+        return False
+
+    missing_modules = _missing_namo_turn_modules()
+    if not missing_modules:
+        return True
+
+    missing_display = ", ".join(missing_modules)
+    if not sys.stdin.isatty():
+        logger.warning(
+            "Semantic VAD is disabled because optional dependencies "
+            "are not installed: %s",
+            missing_display,
+        )
+        return False
+
+    try:
+        answer = input(
+            "Additional dependencies are required to enable Semantic VAD. "
+            "Install them now? [y/N]: "
+        ).strip().lower()
+    except EOFError:
+        answer = ""
+
+    if answer not in {"y", "yes"}:
+        logger.info("Semantic VAD is disabled for this run.")
+        return False
+
+    install_command = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "aiavatar[namo-turn]",
+    ]
+    logger.info("Installing Semantic VAD dependencies...")
+    try:
+        subprocess.run(install_command, check=True)
+    except (OSError, subprocess.CalledProcessError) as ex:
+        parser.error(
+            "Could not install Semantic VAD dependencies. Run "
+            f"'{sys.executable}' -m pip install 'aiavatar[namo-turn]' "
+            "and try again."
+        )
+        raise AssertionError("parser.error() did not exit") from ex
+
+    importlib.invalidate_caches()
+    missing_modules = _missing_namo_turn_modules()
+    if missing_modules:
+        parser.error(
+            "Semantic VAD installation completed, but these modules are still "
+            f"unavailable: {', '.join(missing_modules)}"
+        )
+    logger.info("Semantic VAD dependencies installed.")
+    return True
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -209,14 +288,23 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         os.environ["AIAVATAR_LLM_EXTRA_BODY"] = args.llm_extra_body
     if args.llm_api:
         os.environ["AIAVATAR_LLM_API"] = args.llm_api
+    using_builtin_app = args.script is None
+    use_namo_turn = _prepare_namo_turn(
+        parser,
+        using_builtin_app=using_builtin_app,
+    )
     _prepare_openai_api_key(
         parser,
         supplied_key=args.openai_api_key,
-        using_builtin_app=args.script is None,
+        using_builtin_app=using_builtin_app,
     )
 
     try:
-        app = load_app(args.script) if args.script else _load_builtin_app()
+        app = (
+            load_app(args.script)
+            if args.script
+            else _load_builtin_app(use_namo_turn=use_namo_turn)
+        )
     except ApplicationLoadError as ex:
         parser.error(str(ex))
 

--- a/aiavatar/cli/components.py
+++ b/aiavatar/cli/components.py
@@ -14,13 +14,20 @@ from aiavatar.sts.vad import SpeechDetector
 from aiavatar.sts.vad.filters import NearFieldAudioGate
 from aiavatar.sts.vad.stream import SileroStreamSpeechDetector
 from aiavatar.sts.vad.turn_end_gates.filler import FillerOnlyTurnEndGate
-from aiavatar.sts.vad.turn_end_gates.namo_turn import NamoTurnEndGate
 
 from .config import AppConfig
 from .tts import build_default_tts
 
 
 logger = logging.getLogger(__name__)
+
+
+def _namo_turn_end_gate_class():
+    # Keep optional dependencies out of the import path unless the default
+    # component graph will actually use Namo Turn.
+    from aiavatar.sts.vad.turn_end_gates.namo_turn import NamoTurnEndGate
+
+    return NamoTurnEndGate
 
 
 def websocket_base_url(base_url: str | None) -> str | None:
@@ -127,11 +134,14 @@ def build_components(
     stt: SpeechRecognizer | None = None,
     llm: LLMService | None = None,
     tts: SpeechSynthesizer | None = None,
+    use_namo_turn: bool = True,
 ) -> ComponentSet:
     """Build missing speech components without creating a pipeline or adapter.
 
     Explicitly supplied components are kept, and the selected STT is injected
-    into the default streaming VAD when ``vad`` is omitted.
+    into the default streaming VAD when ``vad`` is omitted. Set
+    ``use_namo_turn`` to false to build that VAD without the optional Namo Turn
+    semantic gate.
     """
     config = config or AppConfig.from_env()
     managed_resources = []
@@ -158,18 +168,23 @@ def build_components(
             fillers=config.filler_phrases,
             timeout=config.filler_timeout,
         )
-        namo_turn_gate = NamoTurnEndGate(
-            language=config.namo_language,
-            threshold=config.namo_threshold,
-            timeout=config.namo_timeout,
-            force_end_phrases=config.namo_force_end_phrases,
-        )
+        turn_end_gates = [filler_gate]
+        if use_namo_turn:
+            namo_turn_gate_class = _namo_turn_end_gate_class()
+            turn_end_gates.append(
+                namo_turn_gate_class(
+                    language=config.namo_language,
+                    threshold=config.namo_threshold,
+                    timeout=config.namo_timeout,
+                    force_end_phrases=config.namo_force_end_phrases,
+                )
+            )
         vad = SileroStreamSpeechDetector(
             speech_recognizer=stt,
             silence_duration_threshold=config.vad_silence_duration_threshold,
             segment_silence_threshold=config.vad_segment_silence_threshold,
             audio_filters=[near_field_gate],
-            turn_end_gates=[filler_gate, namo_turn_gate],
+            turn_end_gates=turn_end_gates,
             use_vad_iterator=config.vad_use_iterator,
             debug=config.debug,
         )

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -121,7 +121,11 @@ def component_fakes(monkeypatch):
     )
     monkeypatch.setattr(cli_components, "NearFieldAudioGate", FakeComponent)
     monkeypatch.setattr(cli_components, "FillerOnlyTurnEndGate", FakeComponent)
-    monkeypatch.setattr(cli_components, "NamoTurnEndGate", FakeComponent)
+    monkeypatch.setattr(
+        cli_components,
+        "_namo_turn_end_gate_class",
+        lambda: FakeComponent,
+    )
     monkeypatch.setattr(cli_components, "SileroStreamSpeechDetector", FakeVad)
     monkeypatch.setattr(cli_tts, "AlphabetToKanaPreprocessor", FakePreprocessor)
     monkeypatch.setattr(cli_tts, "VoicevoxSpeechSynthesizer", FakeComponent)

--- a/tests/cli/test_command.py
+++ b/tests/cli/test_command.py
@@ -15,6 +15,7 @@ REAL_LOAD_DOTENV = cli_command.load_dotenv
 def disable_project_dotenv(monkeypatch):
     """Keep CLI tests isolated from a developer's ignored root .env file."""
     monkeypatch.setattr(cli_command, "load_dotenv", lambda **_: False)
+    monkeypatch.setattr(cli_command, "_missing_namo_turn_modules", lambda: [])
 
 
 def test_cli_hides_known_websockets_deprecation_warnings():
@@ -42,6 +43,137 @@ assert 'aiavatar.cli.components' not in sys.modules
 assert 'aiavatar.cli.builtin' not in sys.modules
 """
     subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_prepare_namo_turn_decline_disables_it_for_this_run(monkeypatch):
+    observed = {}
+    monkeypatch.setattr(
+        cli_command,
+        "_missing_namo_turn_modules",
+        lambda: ["onnxruntime", "transformers"],
+    )
+    monkeypatch.setattr(cli_command.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt: observed.update(prompt=prompt) or "n",
+    )
+    monkeypatch.setattr(
+        cli_command.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("pip must not run after declining"),
+    )
+
+    use_namo_turn = cli_command._prepare_namo_turn(
+        cli_command.build_parser(),
+        using_builtin_app=True,
+    )
+
+    assert use_namo_turn is False
+    assert observed["prompt"] == (
+        "Additional dependencies are required to enable Semantic VAD. "
+        "Install them now? [y/N]: "
+    )
+
+
+def test_prepare_namo_turn_installs_and_continues(monkeypatch):
+    observed = {}
+    missing_results = iter([["onnxruntime"], []])
+    monkeypatch.setattr(
+        cli_command,
+        "_missing_namo_turn_modules",
+        lambda: next(missing_results),
+    )
+    monkeypatch.setattr(cli_command.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    monkeypatch.setattr(
+        cli_command.subprocess,
+        "run",
+        lambda command, **kwargs: observed.update(
+            command=command,
+            kwargs=kwargs,
+        ),
+    )
+    monkeypatch.setattr(
+        cli_command.importlib,
+        "invalidate_caches",
+        lambda: observed.update(caches_invalidated=True),
+    )
+
+    use_namo_turn = cli_command._prepare_namo_turn(
+        cli_command.build_parser(),
+        using_builtin_app=True,
+    )
+
+    assert use_namo_turn is True
+    assert observed == {
+        "command": [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "aiavatar[namo-turn]",
+        ],
+        "kwargs": {"check": True},
+        "caches_invalidated": True,
+    }
+
+
+def test_prepare_namo_turn_noninteractive_disables_it(monkeypatch, caplog):
+    monkeypatch.setattr(
+        cli_command,
+        "_missing_namo_turn_modules",
+        lambda: ["huggingface_hub"],
+    )
+    monkeypatch.setattr(cli_command.sys.stdin, "isatty", lambda: False)
+
+    use_namo_turn = cli_command._prepare_namo_turn(
+        cli_command.build_parser(),
+        using_builtin_app=True,
+    )
+
+    assert use_namo_turn is False
+    assert "Semantic VAD is disabled" in caplog.text
+
+
+def test_prepare_namo_turn_does_not_check_script_mode(monkeypatch):
+    monkeypatch.setattr(
+        cli_command,
+        "_missing_namo_turn_modules",
+        lambda: pytest.fail("script mode must not inspect Namo Turn dependencies"),
+    )
+
+    assert cli_command._prepare_namo_turn(
+        cli_command.build_parser(),
+        using_builtin_app=False,
+    ) is False
+
+
+def test_cli_starts_builtin_app_without_namo_after_decline(
+    monkeypatch,
+    clean_builtin_environment,
+):
+    observed = {}
+    application = object()
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        cli_command,
+        "_missing_namo_turn_modules",
+        lambda: ["onnxruntime"],
+    )
+    monkeypatch.setattr(cli_command.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    monkeypatch.setattr(
+        cli_command,
+        "_load_builtin_app",
+        lambda *, use_namo_turn: observed.update(
+            use_namo_turn=use_namo_turn,
+        ) or application,
+    )
+    monkeypatch.setattr(cli_command.uvicorn, "run", lambda *args, **kwargs: None)
+
+    cli_command.main([])
+
+    assert observed == {"use_namo_turn": False}
 
 
 def test_load_app_from_python_file(tmp_path):
@@ -181,7 +313,7 @@ def test_cli_tts_arguments_override_environment(
     monkeypatch.setattr(
         cli_command,
         "_load_builtin_app",
-        lambda: observed.update(
+        lambda **_: observed.update(
             ja_tts=os.environ.get("AIAVATAR_JA_TTS"),
             multi_tts=os.environ.get("AIAVATAR_MULTI_TTS"),
             openai_tts_speaker=os.environ.get("AIAVATAR_OPENAI_TTS_SPEAKER"),
@@ -220,7 +352,9 @@ def test_builtin_app_prompts_for_missing_key(
     monkeypatch.setattr(
         cli_command,
         "_load_builtin_app",
-        lambda: observed.update(key=os.environ.get("OPENAI_API_KEY")) or application,
+        lambda **_: observed.update(
+            key=os.environ.get("OPENAI_API_KEY")
+        ) or application,
     )
     monkeypatch.setattr(
         cli_command.uvicorn,
@@ -247,7 +381,7 @@ def test_builtin_app_accepts_individual_openai_keys(
     monkeypatch.setattr(
         cli_command,
         "_load_builtin_app",
-        lambda: observed.update(loaded=True) or application,
+        lambda **_: observed.update(loaded=True) or application,
     )
     monkeypatch.setattr(cli_command.uvicorn, "run", lambda *args, **kwargs: None)
 
@@ -275,7 +409,7 @@ def test_builtin_app_does_not_require_unused_tts_openai_key(
     monkeypatch.setattr(
         cli_command,
         "_load_builtin_app",
-        lambda: observed.update(loaded=True) or application,
+        lambda **_: observed.update(loaded=True) or application,
     )
     monkeypatch.setattr(cli_command.uvicorn, "run", lambda *args, **kwargs: None)
 

--- a/tests/cli/test_components.py
+++ b/tests/cli/test_components.py
@@ -237,3 +237,25 @@ def test_build_components_uses_overrides_and_injects_stt_into_default_vad(
     assert components.llm is custom_llm
     assert components.tts is custom_tts
     assert components.vad.kwargs["speech_recognizer"] is custom_stt
+
+
+def test_build_components_can_disable_namo_turn(
+    monkeypatch,
+    clean_builtin_environment,
+    component_fakes,
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        cli_components,
+        "_namo_turn_end_gate_class",
+        lambda: pytest.fail("Namo Turn must not be imported"),
+    )
+
+    components = cli_components.build_components(use_namo_turn=False)
+
+    turn_end_gates = components.vad.kwargs["turn_end_gates"]
+    assert len(turn_end_gates) == 1
+    assert turn_end_gates[0].kwargs == {
+        "fillers": cli_config.DEFAULT_JA_FILLERS + cli_config.DEFAULT_EN_FILLERS,
+        "timeout": 3.0,
+    }


### PR DESCRIPTION
Prompt to install missing dependencies or start without Semantic VAD. Lazy-load the optional Namo Turn integration to prevent startup failures.