### PR TITLE
Fix LLM tool decorator definition

### DIFF
--- a/aiavatar/sts/llm/base.py
+++ b/aiavatar/sts/llm/base.py
@@ -337,7 +337,7 @@ The list of tools is as follows:
             tool_to_add.is_dynamic = is_dynamic
         self.tools[tool_to_add.name] = tool_to_add
 
-    async def get_dynamic_tools(self, func):
+    def get_dynamic_tools(self, func):
         self._get_dynamic_tools = func
         return func
 


### PR DESCRIPTION
Make the decorator factory synchronous so it returns a decorator instead of a coroutine.