### PR TITLE
Add injected OpenAI client support

### DIFF
--- a/aiavatar/admin/README.md
+++ b/aiavatar/admin/README.md
@@ -130,6 +130,9 @@ The Evaluation view accepts a JSON array of scenarios and runs Dialog Evaluation
 
 The Evaluation tab is shown only when an Evaluator is available. An Evaluator is created automatically when the Adapter uses `ChatGPTService` as its LLM. For other LLMs, pass a `DialogEvaluator` through `setup_admin_panel(..., evaluator=...)`.
 
+The automatic Evaluator reuses the source `ChatGPTService` client, preserving Azure,
+custom transport, and tracing configuration. It does not take ownership of that client.
+
 Character and Control UI and APIs are not included in this Admin Panel.
 
 ## Time Semantics

--- a/aiavatar/admin/__init__.py
+++ b/aiavatar/admin/__init__.py
@@ -37,8 +37,7 @@ def _default_evaluator(adapter: Adapter) -> Optional[DialogEvaluator]:
         return None
     source = adapter.sts.llm
     evaluation_llm = ChatGPTService(
-        openai_api_key=source.openai_client.api_key,
-        base_url=str(source.openai_client.base_url),
+        openai_client=source.openai_client,
         model=source.model,
         temperature=source.temperature,
         reasoning_effort=source.reasoning_effort,

--- a/aiavatar/admin/config/runtime.py
+++ b/aiavatar/admin/config/runtime.py
@@ -14,6 +14,7 @@ _EXCLUDED = {
     "llm", "stt", "sts", "tts", "vad", "speech_recognizer",
     "context_manager", "session_state_manager", "response_id_store",
     "performance_recorder", "voice_recorder", "db_pool_provider",
+    "openai_client",
     "audio_filters", "guardrails", "postprocessors", "preprocessors",
     "turn_end_gates", "on_recording_started", "to_linear16",
     # Values coupled to resources, derived state, or registered hooks

--- a/aiavatar/cli/components.py
+++ b/aiavatar/cli/components.py
@@ -93,13 +93,14 @@ class ComponentSet:
             return
         self._closed = True
 
-        llm_resource = getattr(self.llm, "_ws_pool", None)
-        if llm_resource is None:
-            llm_resource = getattr(self.llm, "openai_client", None)
-        if llm_resource is None and (
-            hasattr(self.llm, "close") or hasattr(self.llm, "aclose")
+        if callable(getattr(self.llm, "close", None)) or callable(
+            getattr(self.llm, "aclose", None)
         ):
             llm_resource = self.llm
+        else:
+            llm_resource = getattr(self.llm, "_ws_pool", None)
+            if llm_resource is None:
+                llm_resource = getattr(self.llm, "openai_client", None)
 
         resources = [
             llm_resource,

--- a/aiavatar/sts/llm/chatgpt.py
+++ b/aiavatar/sts/llm/chatgpt.py
@@ -1,4 +1,6 @@
+import inspect
 import json
+import warnings
 from logging import getLogger
 from typing import AsyncGenerator, Dict, List, Protocol, Type, Union
 from urllib.parse import urlparse, parse_qs
@@ -36,6 +38,7 @@ class ChatGPTService(LLMService):
         context_manager: ContextManager = None,
         shared_context_ids: List[str] = None,
         db_connection_str: str = "aiavatar.db",
+        openai_client: openai_module.AsyncOpenAI = None,
         custom_openai_module: OpenAICompatibleModule = None,
         debug: bool = False
     ):
@@ -61,18 +64,50 @@ class ChatGPTService(LLMService):
         self.extra_body = extra_body
         self._edit_chat_completion_params = None
 
-        client_module = custom_openai_module or openai_module
-        if "azure" in model:
-            if base_url:
-                base_url = base_url.rstrip("/")
-            api_version = parse_qs(urlparse(base_url).query).get("api-version", [None])[0]
-            self.openai_client = client_module.AsyncAzureOpenAI(
-                api_key=openai_api_key,
-                api_version=api_version,
-                base_url=base_url
+        uses_legacy_azure_detection = (
+            openai_client is None and "azure" in model
+        )
+        if uses_legacy_azure_detection:
+            warnings.warn(
+                'Selecting Azure by including "azure" in model is deprecated. '
+                "Pass a pre-configured OpenAI client, such as AsyncAzureOpenAI, "
+                "through openai_client and set model to the deployment name.",
+                DeprecationWarning,
+                stacklevel=2,
             )
+
+        if openai_client is None and custom_openai_module is not None:
+            warnings.warn(
+                "custom_openai_module is deprecated. Construct the module's async "
+                "client and pass it through openai_client instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        self._close_openai_client = None
+        if openai_client is not None:
+            self.openai_client = openai_client
         else:
-            self.openai_client = client_module.AsyncClient(api_key=openai_api_key, base_url=base_url)
+            client_module = custom_openai_module or openai_module
+            if uses_legacy_azure_detection:
+                if base_url:
+                    base_url = base_url.rstrip("/")
+                api_version = parse_qs(urlparse(base_url).query).get("api-version", [None])[0]
+                self.openai_client = client_module.AsyncAzureOpenAI(
+                    api_key=openai_api_key,
+                    api_version=api_version,
+                    base_url=base_url
+                )
+            else:
+                self.openai_client = client_module.AsyncClient(
+                    api_key=openai_api_key,
+                    base_url=base_url,
+                )
+            self._close_openai_client = getattr(
+                self.openai_client,
+                "close",
+                None,
+            ) or getattr(self.openai_client, "aclose", None)
 
         self.dynamic_tool_spec = {
             "type": "function",
@@ -102,6 +137,15 @@ class ChatGPTService(LLMService):
         config["enable_tool_filtering"] = self.enable_tool_filtering
         config["extra_body"] = self.extra_body
         return config
+
+    async def close(self):
+        """Close the OpenAI client only when this service constructed it."""
+        close = self._close_openai_client
+        self._close_openai_client = None
+        if close is not None:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
 
     @property
     def dynamic_tool_name(self) -> str:

--- a/aiavatar/sts/llm/openai_responses.py
+++ b/aiavatar/sts/llm/openai_responses.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import json
 from logging import getLogger
 from typing import AsyncGenerator, Dict, List, Union
@@ -36,6 +37,7 @@ class OpenAIResponsesService(LLMService):
         response_id_store: ResponseIdStore = None,
         shared_context_ids: List[str] = None,
         db_connection_str: str = "aiavatar.db",
+        openai_client: openai_module.AsyncOpenAI = None,
         debug: bool = False
     ):
         super().__init__(
@@ -66,15 +68,34 @@ class OpenAIResponsesService(LLMService):
                 self.response_id_store = SQLiteResponseIdStore(db_path=db_connection_str)
         self._edit_response_params = None
 
-        self.openai_client = openai_module.AsyncClient(
-            api_key=openai_api_key, base_url=base_url
-        )
+        self._close_openai_client = None
+        if openai_client is not None:
+            self.openai_client = openai_client
+        else:
+            self.openai_client = openai_module.AsyncClient(
+                api_key=openai_api_key,
+                base_url=base_url,
+            )
+            self._close_openai_client = getattr(
+                self.openai_client,
+                "close",
+                None,
+            ) or getattr(self.openai_client, "aclose", None)
 
     def get_config(self) -> dict:
         config = super().get_config()
         config["reasoning_effort"] = self.reasoning_effort
         config["extra_body"] = self.extra_body
         return config
+
+    async def close(self):
+        """Close the OpenAI client only when this service constructed it."""
+        close = self._close_openai_client
+        self._close_openai_client = None
+        if close is not None:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
 
     @property
     def dynamic_tool_name(self) -> str:

--- a/aiavatar/sts/llm/openai_responses_websocket.py
+++ b/aiavatar/sts/llm/openai_responses_websocket.py
@@ -154,12 +154,20 @@ class OpenAIResponsesWebSocketService(LLMService):
             max_size=max_connections,
             max_age=max_connection_age,
         )
+        self._close_ws_pool = self._ws_pool.close
 
     def get_config(self) -> dict:
         config = super().get_config()
         config["reasoning_effort"] = self.reasoning_effort
         config["extra_body"] = self.extra_body
         return config
+
+    async def close(self):
+        """Close the internally constructed WebSocket pool once."""
+        close = self._close_ws_pool
+        self._close_ws_pool = None
+        if close is not None:
+            await close()
 
     @property
     def dynamic_tool_name(self) -> str:

--- a/aiavatar/sts/pipeline.py
+++ b/aiavatar/sts/pipeline.py
@@ -205,6 +205,7 @@ class STSPipeline:
                 db_connection_str=db_connection_str,
                 debug=debug
             )
+            self._lifecycle.push_async_callback(self.llm.close)
 
         # Text-to-Speech
         self.tts = tts or VoicevoxSpeechSynthesizer(

--- a/tests/admin/test_admin_openai_client_injection.py
+++ b/tests/admin/test_admin_openai_client_injection.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+import aiavatar.admin as admin_module
+
+
+def test_default_evaluator_reuses_preconfigured_openai_client(monkeypatch):
+    created = []
+
+    class FakeChatGPTService:
+        def __init__(
+            self,
+            *,
+            openai_client=None,
+            model="gpt-5.4",
+            temperature=None,
+            reasoning_effort=None,
+        ):
+            self.openai_client = openai_client
+            self.model = model
+            self.temperature = temperature
+            self.reasoning_effort = reasoning_effort
+            self.system_prompt = None
+            created.append(self)
+
+    monkeypatch.setattr(admin_module, "ChatGPTService", FakeChatGPTService)
+    client = object()
+    source = FakeChatGPTService(
+        openai_client=client,
+        model="azure-deployment-name",
+        temperature=0.2,
+        reasoning_effort="low",
+    )
+    adapter = SimpleNamespace(sts=SimpleNamespace(llm=source))
+
+    evaluator = admin_module._default_evaluator(adapter)
+
+    assert evaluator.llm is source
+    assert evaluator.evaluation_llm is created[1]
+    assert evaluator.evaluation_llm.openai_client is client
+    assert evaluator.evaluation_llm.model == "azure-deployment-name"

--- a/tests/cli/test_components.py
+++ b/tests/cli/test_components.py
@@ -66,6 +66,23 @@ async def test_component_set_closes_owned_resources_once():
     preprocessor_client.close.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_component_set_uses_llm_ownership_aware_close():
+    llm_client = SimpleNamespace(close=AsyncMock())
+    llm = SimpleNamespace(close=AsyncMock(), openai_client=llm_client)
+    components = cli_components.ComponentSet(
+        vad=object(),
+        stt=object(),
+        llm=llm,
+        tts=object(),
+    )
+
+    await components.close()
+
+    llm.close.assert_awaited_once()
+    llm_client.close.assert_not_awaited()
+
+
 def test_build_components_preserves_defaults(
     monkeypatch,
     clean_builtin_environment,

--- a/tests/sts/llm/test_openai_client_injection.py
+++ b/tests/sts/llm/test_openai_client_injection.py
@@ -1,0 +1,257 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aiavatar.sts.llm import chatgpt as chatgpt_module
+from aiavatar.sts.llm import openai_responses as responses_module
+from aiavatar.sts.llm import (
+    openai_responses_websocket as responses_websocket_module,
+)
+from aiavatar.sts.llm.chatgpt import ChatGPTService
+from aiavatar.sts.llm.openai_responses import OpenAIResponsesService
+from aiavatar.sts.llm.openai_responses_websocket import (
+    OpenAIResponsesWebSocketService,
+)
+
+
+class FakeAsyncClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.close = AsyncMock()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("service_class", [ChatGPTService, OpenAIResponsesService])
+async def test_http_services_use_injected_client_without_closing_it(
+    service_class,
+    tmp_path,
+):
+    client = FakeAsyncClient()
+    service = service_class(
+        openai_client=client,
+        model="azure-deployment-name",
+        db_connection_str=str(tmp_path / f"{service_class.__name__}.db"),
+    )
+
+    assert service.openai_client is client
+
+    await service.close()
+    await service.close()
+
+    client.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_accepts_official_async_azure_openai_client(tmp_path):
+    client = chatgpt_module.openai_module.AsyncAzureOpenAI(
+        api_key="test-key",
+        azure_endpoint="https://resource.openai.azure.com",
+        api_version="2024-10-21",
+    )
+    try:
+        service = ChatGPTService(
+            openai_client=client,
+            model="chat-deployment",
+            db_connection_str=str(tmp_path / "official-azure-client.db"),
+        )
+
+        assert service.openai_client is client
+        await service.close()
+        assert not client.is_closed()
+    finally:
+        await client.close()
+
+    assert client.is_closed()
+
+
+@pytest.mark.asyncio
+async def test_responses_accepts_official_client_configured_for_azure_v1(
+    tmp_path,
+):
+    client = chatgpt_module.openai_module.AsyncOpenAI(
+        api_key="test-key",
+        base_url="https://resource.openai.azure.com/openai/v1/",
+    )
+    try:
+        service = OpenAIResponsesService(
+            openai_client=client,
+            model="responses-deployment",
+            db_connection_str=str(tmp_path / "azure-v1-client.db"),
+        )
+
+        assert service.openai_client is client
+        await service.close()
+        assert not client.is_closed()
+    finally:
+        await client.close()
+
+    assert client.is_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("module", "service_class"),
+    [
+        (chatgpt_module, ChatGPTService),
+        (responses_module, OpenAIResponsesService),
+    ],
+)
+async def test_http_services_close_internally_created_client_once(
+    monkeypatch,
+    module,
+    service_class,
+    tmp_path,
+):
+    created = []
+
+    def create_client(**kwargs):
+        client = FakeAsyncClient(**kwargs)
+        created.append(client)
+        return client
+
+    monkeypatch.setattr(module.openai_module, "AsyncClient", create_client)
+    service = service_class(
+        openai_api_key="test-key",
+        base_url="https://example.test/v1",
+        db_connection_str=str(tmp_path / f"{service_class.__name__}.db"),
+    )
+
+    await service.close()
+    await service.close()
+
+    assert created[0].kwargs == {
+        "api_key": "test-key",
+        "base_url": "https://example.test/v1",
+    }
+    created[0].close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_injected_client_takes_precedence_over_constructor_options(
+    tmp_path,
+):
+    client = FakeAsyncClient()
+    service = ChatGPTService(
+        openai_client=client,
+        openai_api_key="ignored-key",
+        base_url="https://ignored.example/v1",
+        custom_openai_module=object(),
+        model="azure-deployment-name",
+        db_connection_str=str(tmp_path / "chatgpt.db"),
+    )
+
+    assert service.openai_client is client
+    await service.close()
+    client.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_responses_injected_client_takes_precedence_over_constructor_options(
+    tmp_path,
+):
+    client = FakeAsyncClient()
+    service = OpenAIResponsesService(
+        openai_client=client,
+        openai_api_key="ignored-key",
+        base_url="https://ignored.example/v1",
+        db_connection_str=str(tmp_path / "responses.db"),
+    )
+
+    assert service.openai_client is client
+    await service.close()
+    client.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_legacy_azure_model_still_builds_azure_client_with_warning(
+    monkeypatch,
+    tmp_path,
+):
+    created = []
+
+    def create_azure_client(**kwargs):
+        client = FakeAsyncClient(**kwargs)
+        created.append(client)
+        return client
+
+    monkeypatch.setattr(
+        chatgpt_module.openai_module,
+        "AsyncAzureOpenAI",
+        create_azure_client,
+    )
+
+    with pytest.warns(DeprecationWarning, match="Selecting Azure"):
+        service = ChatGPTService(
+            openai_api_key="azure-key",
+            base_url=(
+                "https://resource.openai.azure.com/openai/deployments/chat"
+                "?api-version=2024-10-21"
+            ),
+            model="azure",
+            db_connection_str=str(tmp_path / "azure.db"),
+        )
+
+    assert created[0].kwargs == {
+        "api_key": "azure-key",
+        "api_version": "2024-10-21",
+        "base_url": (
+            "https://resource.openai.azure.com/openai/deployments/chat"
+            "?api-version=2024-10-21"
+        ),
+    }
+
+    await service.close()
+    created[0].close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_custom_openai_module_remains_available_with_warning(tmp_path):
+    class ClientWithoutClose:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeModule:
+        AsyncClient = ClientWithoutClose
+        AsyncAzureOpenAI = ClientWithoutClose
+
+    with pytest.warns(DeprecationWarning, match="custom_openai_module"):
+        service = ChatGPTService(
+            openai_api_key="test-key",
+            custom_openai_module=FakeModule,
+            db_connection_str=str(tmp_path / "custom-module.db"),
+        )
+
+    assert isinstance(service.openai_client, ClientWithoutClose)
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_websocket_service_closes_internally_created_pool_once(
+    monkeypatch,
+    tmp_path,
+):
+    created = []
+
+    class FakePool:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.close = AsyncMock()
+            created.append(self)
+
+    monkeypatch.setattr(responses_websocket_module, "WebSocketPool", FakePool)
+    service = OpenAIResponsesWebSocketService(
+        openai_api_key="test-key",
+        ws_url="wss://example.test/openai",
+        db_connection_str=str(tmp_path / "owned-websocket.db"),
+    )
+
+    await service.close()
+    await service.close()
+
+    assert created[0].kwargs == {
+        "url": "wss://example.test/openai/v1/responses",
+        "api_key": "test-key",
+        "max_size": 100,
+        "max_age": 3300,
+    }
+    created[0].close.assert_awaited_once()

--- a/tests/sts/test_pipeline_lifecycle.py
+++ b/tests/sts/test_pipeline_lifecycle.py
@@ -23,6 +23,14 @@ class FakeVoiceRecorder:
         self.events.append("voice:stop")
 
 
+class FakeLLM:
+    def __init__(self, events, **kwargs):
+        self.events = events
+
+    async def close(self):
+        self.events.append("llm:close")
+
+
 def create_pipeline(*, performance_recorder=None, voice_recorder=None):
     return STSPipeline(
         vad=SpeechDetectorDummy(),
@@ -68,3 +76,24 @@ async def test_shutdown_leaves_injected_resources_open():
     await pipeline.shutdown()
 
     assert events == []
+
+
+@pytest.mark.asyncio
+async def test_shutdown_closes_internally_created_llm_once(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        "aiavatar.sts.pipeline.ChatGPTService",
+        lambda **kwargs: FakeLLM(events, **kwargs),
+    )
+    pipeline = STSPipeline(
+        vad=SpeechDetectorDummy(),
+        stt=SpeechRecognizerDummy(),
+        tts=SpeechSynthesizerDummy(),
+        performance_recorder=FakePerformanceRecorder(events),
+        voice_recorder=FakeVoiceRecorder(events),
+    )
+
+    await pipeline.shutdown()
+    await pipeline.shutdown()
+
+    assert events == ["llm:close"]


### PR DESCRIPTION
Allow ChatGPT and Responses services to use preconfigured clients, including Azure OpenAI. Reuse clients in admin evaluation while preserving caller ownership and legacy Azure compatibility.