### PR TITLE
Add repository agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AIAvatarKit Agent Guide
+
+## Scope and instruction routing
+
+This guide applies to the whole repository. Before changing a scoped area, read
+its nearest guide:
+
+- `aiavatar/sts/AGENTS.md` for the speech-to-speech pipeline and providers.
+- `aiavatar/adapter/AGENTS.md` for transports, protocols, and clients.
+- `aiavatar/admin/AGENTS.md` for the current Admin Panel.
+- `aiavatar/admin_legacy/` is an independently preserved implementation, not a
+  compatibility layer for the current Admin Panel; change it only when explicitly scoped.
+- `tests/AGENTS.md` before selecting or running tests.
+
+Scoped guides add local rules; they do not replace this guide.
+
+## Sources of truth and compatibility
+
+- Treat implementation, package `__init__.py` exports, and focused tests as the
+  authority for public names, signatures, defaults, and behavior.
+- Treat `README.md`, `FEATURES.md`, `FEATURES_TABLE.md`, and component READMEs as
+  orientation. Re-check their claims against source before relying on them.
+- Keep package versions, Python requirements, dependencies, and package-data
+  declarations in the active packaging metadata; do not copy volatile inventories here.
+- Treat established public names, defaults, protocol fields, and event strings as
+  compatibility surfaces. Change them deliberately and with focused regression coverage.
+
+## Working-tree boundaries
+
+- This checkout may contain ignored databases, recordings, credentials, character
+  data, generated media, caches, and root-level experiments. They are user data,
+  not disposable fixtures.
+- Run `git status --short` and use `git ls-files` to establish canonical scope
+  before broad searches or edits.
+- Preserve unrelated tracked, untracked, and ignored files. Do not use `git clean`,
+  destructive resets, or broad deletion commands.
+- Treat build outputs, caches, recordings, generated media, and local databases as
+  outputs rather than implementation sources unless the task explicitly targets them.
+- Do not inspect ignored local scripts, databases, logs, credentials, or character
+  data unless the user places them in scope.
+- Never print, copy, or commit secrets. Use environment-variable names and obvious
+  placeholders in code, tests, examples, and documentation.
+
+## Repository-wide change invariants
+
+- Keep provider-, hardware-, database-, and platform-specific dependencies optional
+  unless core code imports them unconditionally.
+- Keep optional imports lazy or guarded so unrelated package imports work without
+  every provider extra installed.
+- When changing dependencies or package data, update the active packaging metadata
+  and any compatibility shim that still exists.
+- Do not add blocking network, database, model, audio, or filesystem work to an
+  asyncio event loop.
+- Keep mutable request and conversation state scoped by the relevant session, user,
+  context, and transaction identifiers; do not use process globals for per-session state.
+- Pair tasks, streams, clients, pools, queues, threads, and background workers with
+  cancellation or close paths, including failure and disconnect paths.
+- Treat changes to shared models, callbacks, config fields, and protocol values as
+  cross-boundary changes; inspect every producer and consumer they affect.
+- Where SQLite and PostgreSQL implement the same abstraction, preserve observable
+  parity or document and test an intentional difference.
+- Do not silently change public defaults. Add focused regression tests when behavior changes.
+
+## Examples and runnable applications
+
+- Match implementation size to the request; keep minimal examples minimal.
+- Put maintained repository examples under `examples/`. Root-level scripts may be
+  ignored local experiments and must not be treated as canonical sources.
+- Do not change library internals solely to make an example work. Verify the current
+  public API and document only the prerequisites needed by that example.
+
+## Validation and documentation
+
+- Follow `tests/AGENTS.md`. Start with the narrowest relevant test after inspecting
+  its imports, fixtures, external services, credentials, and filesystem effects.
+- Do not run the full pytest suite by default or use discovered live credentials.
+  Report missing optional dependencies or services instead of starting unrelated systems.
+- For documentation-only changes, validate imports, paths, commands, links, and
+  consistency; runtime tests are unnecessary unless executable behavior changed.
+- Update user-facing documentation when a public feature, setup step, default, or
+  behavior changes, and verify exact claims against source.
+- Add to an `AGENTS.md` only when a rule is durable, non-obvious, and operationally
+  important. Prefer links to owning documentation over copied feature descriptions.

--- a/aiavatar/adapter/AGENTS.md
+++ b/aiavatar/adapter/AGENTS.md
@@ -1,0 +1,106 @@
+# Adapter Agent Guide
+
+This guide applies to `aiavatar/adapter/`. Also follow the repository-root
+`AGENTS.md`, the nearest more-specific guide, and `tests/AGENTS.md` before
+selecting or running tests.
+
+## Scope and sources of truth
+
+- Adapters own transport framing, authentication, encoding, provider callbacks,
+  connection state, and transport cleanup.
+- VAD, STT, LLM, TTS, queueing, and persistence policy belong in
+  `aiavatar/sts/`.
+- Treat adapter models, transport-specific models, and serialized event names as
+  wire contracts.
+- When translating requests or responses, inspect `aiavatar/sts/models.py` and
+  preserve all applicable identifiers, metadata, structured content, control
+  tags, tool calls, text, and audio fields.
+- Read both sides of a transport together: server, client, shared models,
+  maintained browser/example consumers, and focused tests.
+- For Asterisk work, also follow `aiavatar/adapter/asterisk/AGENTS.md`.
+
+## Boundary invariants
+
+- `Adapter` registers a response handler on its supplied `STSPipeline`.
+  Multiple adapters may share a pipeline only when their `can_handle()` rules
+  assign every session to the intended owner without overlap.
+- Do not duplicate pipeline state or processing policy inside an adapter.
+- Keep mutable connection and request state scoped by the correct session,
+  user, context, channel, and transaction identifiers.
+- The identifier passed to STS/VAD identifies its live pipeline session;
+  transport-facing identifiers may be translated at the adapter boundary only
+  as documented by a nearer guide. `user_id` identifies an application user,
+  and `context_id` identifies conversation continuity. Never substitute one for another.
+- Pair every socket, stream, task, callback, mapping, and provider session with
+  deterministic disconnect and error cleanup.
+- Session teardown must run the applicable disconnect hooks, finalize captured
+  pipeline/VAD state, and remove only mappings owned by that connection.
+- Re-check ownership after an `await` whenever disconnect, replacement, or a
+  newer transaction could have changed the active connection.
+- Session-start hooks may rewrite a request before session values are stored.
+  Request hooks run before invocation; response hooks run before delivery.
+  Preserve the established ordering when adding transport-specific callbacks.
+- Provider callback authentication is adapter-specific. Do not assume that
+  authentication on one route or adapter protects another provider entrypoint.
+
+## Runtime configuration
+
+- If an adapter is exposed in the current Admin Panel, configuration candidates
+  are derived from public constructor parameters that also exist as safe,
+  JSON-compatible attributes on the running instance.
+- Admin updates those attributes directly with `setattr` and does not use
+  `get_config()` or `set_config()` as its configuration contract.
+- Constructor-backed secret fields may be editable, but never return or log the
+  existing value. Preserve masking and the convention that an empty submission
+  leaves the current value unchanged.
+- Keep clients, pools, locks, tasks, callbacks, derived state, and resource
+  handles out of Admin-editable constructor fields.
+- Runtime Admin changes are process-local. Do not add persistence or component
+  replacement implicitly.
+
+## AIAvatar WebSocket invariants
+
+- These rules apply to `aiavatar/adapter/websocket/`, not to the Asterisk Media
+  WebSocket or streaming-STT protocols.
+- Treat `start` as client protocol initialization: clients send it to establish
+  socket and session values before `data`, `invoke`, `config`, or `stop`.
+  Adding server-side enforcement is a compatibility change and requires focused tests.
+- Track one active response transaction per session. A newer accepted
+  transaction invalidates stale output from the previous one.
+- Preserve the established interruption notification before activating a new
+  transaction.
+- Responses carrying a stale transaction ID must not be delivered. Events that
+  intentionally have no transaction ID remain valid according to the protocol.
+- Hold the per-session send lock around each complete WebSocket write.
+- During streamed audio, re-check the active transaction before sending further
+  chunks so interrupted audio cannot leak into the next turn.
+- Preserve both native-client and browser-compatible authentication paths.
+- Keep complete-audio and chunked-audio modes compatible. Chunked audio must
+  communicate its PCM format before raw PCM chunks are consumed.
+- The browser example is a maintained protocol consumer; update and verify it
+  when changing messages or audio behavior.
+
+## Other transports
+
+- HTTP chat streams JSON events over SSE; verify route and payload details in
+  the current server and client rather than copying older documentation.
+- OpenAI-shaped endpoints implement only their modeled compatibility surface.
+  Preserve streaming termination and non-streaming response shapes.
+- Streaming STT has its own request/response contract and audio-format
+  assumptions; keep them aligned with the selected VAD and recognizer.
+- Telephony and messaging adapters must preserve provider media conversion,
+  callback ordering, identity mapping, interruption, and cleanup semantics.
+- `ChannelContextBridge` owns channel identity mapping and conversation
+  continuity. Preserve its timeout and context persistence triggered by the STS
+  `start` response.
+
+## Validation
+
+- Update every maintained side of a protocol change: models, server, client,
+  browser/example consumer, documentation, and focused tests as applicable.
+- Test malformed input, missing or invalid identifiers, authentication failure,
+  disconnect during send, concurrent writes, stale transactions, callback
+  failure, cancellation, and finalization—not only the happy path.
+- Start with the narrowest relevant test described by `tests/AGENTS.md`.
+- For documentation-only changes, validate links, route names, examples, and
+  consistency without invoking live integrations.

--- a/aiavatar/adapter/asterisk/AGENTS.md
+++ b/aiavatar/adapter/asterisk/AGENTS.md
@@ -1,0 +1,86 @@
+# Asterisk Adapter Agent Guide
+
+This guide applies to `aiavatar/adapter/asterisk/`. Also follow the
+repository-root and `aiavatar/adapter/AGENTS.md` guides, and read
+`tests/AGENTS.md` before selecting or running tests.
+
+## Ownership model
+
+- The per-call actor coordinated by `AsteriskCallManager` is the sole owner of
+  call lifecycle state.
+- `AsteriskARIClient` owns ARI transport, the call registry owns indexes, the
+  event handler owns raw-event routing, pre-registration setup, and cleanup of
+  callers that never completed registration, and the call service owns
+  registered-call ARI topology mutations.
+- Do not introduce a second lifecycle state owner for transfers, media recovery,
+  playback, or cleanup.
+- Registry indexes must remain mutually consistent. Do not leave a partially
+  updated index visible across an `await`.
+- The public call `session_id` remains stable across media recovery.
+- Each Media WebSocket channel has a distinct private STS/VAD session key.
+  Translate between the private key and stable public call ID only at the
+  adapter boundary.
+
+## Connection and transaction concurrency
+
+- Claim a new response transaction before the first operation that can yield
+  control.
+- Revoke stale playback and operation ownership before issuing an interrupting
+  media command.
+- After every awaited callback, manager notification, media command, or setup
+  operation, re-check that the session mapping, socket, transaction, connection
+  generation, and cleanup state are still owned by the current operation.
+- Deliver transactionless responses only while the session has no active
+  transaction.
+- Keep Media WebSocket connection ownership separate from playback
+  cancellation. Use connection generation for socket and callback ownership,
+  and playback generation only for audio/playback invalidation.
+- Scope callback tasks to the session and connection generation that created
+  them. An old disconnect must not cancel callbacks owned by a replacement
+  connection.
+- A manager-authorized media channel accepts exactly one Media WebSocket.
+  Recovery creates and registers a new media channel identity rather than
+  attaching a second socket to the old one.
+
+## Cleanup and recovery
+
+- Media and call cleanup must run in shared, shielded cleanup tasks.
+  Cancellation of one waiter must not cancel underlying resource release.
+- Capture the private STS/VAD key owned by the connection being cleaned up.
+  Remove its routing entry before awaiting unrelated cleanup work, then finalize
+  only that captured key.
+- Cleanup that waits for an older connection must re-evaluate current ownership
+  afterward and continue until no manager-authorized replacement resource still
+  requires cleanup.
+- A stale connection may remove only its own socket, tasks, mappings, and media
+  state.
+- Discard adapter-owned synthesis or callback results if connection or playback
+  ownership changes while awaiting them.
+- During graceful shutdown, cancel pending setup work and release the remote
+  caller even when cancellation happens before local session registration.
+- Keep close and cancellation paths idempotent so disconnect, manager shutdown,
+  and error recovery may converge safely.
+
+## Transfers and uncertain outcomes
+
+- Transfer preparation is the veto-capable phase. Started, completed, failed,
+  and unknown callbacks are notifications whose exceptions must be isolated
+  from call control.
+- Notification callbacks must not recursively transfer or hang up the same call.
+- Distinguish confirmed success, confirmed failure, and unknown ARI outcomes.
+  Timeouts, transport failures, and ambiguous server failures may occur after
+  the remote mutation has started.
+- Reconcile unknown outcomes before attempting a fallback that could duplicate
+  or conflict with the original topology mutation.
+- Unknown or empty provider transfer status is not a confirmed failure; fail
+  closed unless ownership can be established safely.
+
+## Validation
+
+- Add focused concurrency coverage for disconnect during setup, replacement
+  Media WebSockets, stale responses, callback cancellation, cleanup waiter
+  cancellation, shutdown before registration, and transfer outcomes.
+- Assert both the stable public call identity and private STS/VAD routing
+  identity after recovery and cleanup.
+- Use fakes for ARI and Media WebSocket behavior unless the user explicitly
+  authorizes a live Asterisk integration.

--- a/aiavatar/admin/AGENTS.md
+++ b/aiavatar/admin/AGENTS.md
@@ -1,0 +1,76 @@
+# Admin Panel Agent Guide
+
+This guide applies to `aiavatar/admin/`. Also follow the repository-root
+`AGENTS.md` and read `tests/AGENTS.md` before selecting or running tests.
+
+## Scope and boundaries
+
+- This is the current FastAPI-embedded Admin Panel.
+  `aiavatar/admin_legacy/` is a separately preserved implementation; change it
+  only when the task explicitly includes it.
+- Read `aiavatar/admin/README.md`, then verify routes, models, defaults, and UI
+  behavior against current source and focused tests.
+- Keep Admin HTTP handlers thin. Database filtering, grouping, time bucketing,
+  and latency calculations belong in their domain query services.
+- Evaluation is optional. Routes and UI capabilities must reflect whether an
+  evaluator is actually available.
+- Preserve `event_at = speech_end_at ?? created_at` consistently across metrics,
+  logs, ordering, and time buckets.
+
+## Runtime configuration
+
+- Config forms are derived from public constructor parameters that also exist
+  as safe, JSON-compatible attributes on the running component.
+- Updates use direct `setattr`, affect the current process only, and do not use
+  component `get_config()` or `set_config()` methods.
+- Do not persist Admin changes or replace component instances implicitly.
+- Secret constructor fields may be editable, but never return or log their
+  existing values. Preserve masking and the convention that an empty submission
+  leaves the current value unchanged.
+- Exclude clients, pools, tasks, callbacks, locks, resource handles, derived
+  state, and initialization-only parameters.
+- The application owns the object graph. Display the active component class
+  without offering unsafe class replacement.
+- When changing a configurable constructor field, inspect its Admin form type,
+  serialization, validation, and runtime assignment behavior together.
+
+## Authentication and API invariants
+
+- Router-level authentication must protect the page, static assets, and every
+  Admin API route uniformly.
+- Keep custom authentication behind the callable boundary in `auth.py`; do not
+  embed provider-specific SSO logic in individual endpoints.
+- Never hard-code, return, log, or expose credentials.
+- Preserve static-path containment so requests cannot escape the packaged Admin
+  asset directory.
+- Keep endpoint request and response shapes synchronized with the browser
+  modules and Admin documentation.
+- Test both authenticated and rejected requests whenever authentication or
+  routing changes.
+
+## Frontend and assets
+
+- Keep Python route modules focused on their domain services.
+- The frontend uses same-origin, page-relative Admin API requests; preserve that
+  resolution beneath the fixed `/admin` mount.
+- Do not introduce a Node.js runtime or frontend framework without an explicit
+  architectural request.
+- When adding or renaming a static module, update its imports, HTML entrypoint,
+  package-data inclusion, and asset-serving tests together.
+- `static/admin.tailwind.css` is the editable CSS source.
+  `static/admin.css` is the tracked generated package asset.
+- Regenerate `admin.css` with the Tailwind workflow documented in
+  `aiavatar/admin/README.md`; do not hand-edit only the generated file.
+- If the required generator is unavailable, report the ungenerated source
+  change clearly rather than claiming the packaged CSS is current.
+
+## Validation
+
+- Start with the focused Admin test using the isolated invocation prescribed by
+  `tests/AGENTS.md`.
+- For API changes, verify authentication, route prefixes, response shapes,
+  invalid input, empty results, and unavailable capabilities.
+- For browser changes, verify module loading, API failures, empty/loading states,
+  light and dark themes, and relevant viewport sizes.
+- Update `aiavatar/admin/README.md` when public routes, screens, time semantics,
+  authentication, configuration behavior, or the CSS workflow changes.

--- a/aiavatar/sts/AGENTS.md
+++ b/aiavatar/sts/AGENTS.md
@@ -1,0 +1,98 @@
+# Speech-to-Speech Agent Guide
+
+This guide applies to `aiavatar/sts/`. Follow the repository-root `AGENTS.md`;
+before selecting or running tests, also follow `tests/AGENTS.md`. This file
+contains only speech-pipeline-specific rules.
+
+## Boundaries and public surface
+
+- `pipeline.py` owns VAD -> STT -> LLM/tools -> TTS orchestration. Keep transport
+  encoding, connection management, client protocols, and wire models in
+  `aiavatar/adapter/`.
+- `models.py` contains pipeline messages; adapters translate them into public
+  transport models.
+- Treat package `__init__.py` files as the authority for supported imports.
+  Concrete providers normally remain imported from their implementation modules.
+- Treat exported spellings and event strings as compatibility surfaces. In
+  particular, do not incidentally normalize `GuardrailRespose`, direct
+  `"canceled"`, or queued `"cancelled"`.
+
+## Pipeline and event invariants
+
+- Construct `STSRequest` and `STSResponse` by keyword and preserve each event's
+  established identifier shape; some control and queued events intentionally
+  omit otherwise available identifiers.
+- Preserve the request `transaction_id` across every response path, including
+  cancellation, timeout, validation failure, and exceptions.
+- `accepted` is dispatched out of band before processing. A normal invocation
+  streams `start`, zero or more `chunk` and `tool_call` events, then `final`;
+  validation or no-speech exits use `canceled`, and failures use `error`.
+- Do not reorder or rename events without checking adapters and clients. Transaction
+  filtering, barge-in, and stream completion depend on this lifecycle.
+- A newer active transaction must suppress stale LLM and synthesis output for the
+  same session. Preserve active-transaction checks on both streaming boundaries.
+- Invocation queues are per session. Preserve the distinction between clearing
+  pending work with `wait_in_queue=False` and processing it sequentially with
+  `wait_in_queue=True`.
+- Treat changes to queue mode while requests are active as lifecycle changes;
+  balance workers, response queues, timeouts, cancellation, and idle cleanup.
+- Hooks may intentionally mutate the current request. Do not move request-specific
+  values into shared component configuration or module globals.
+
+## Session and VAD invariants
+
+- Batch recognition overrides belong to `STSPipeline`; streaming recognition
+  overrides belong to the stream VAD. Keep both override paths scoped by session.
+- Do not mutate a shared recognizer to switch one session. Concurrent sessions may
+  require different engines, and reset behavior must preserve session isolation.
+- Use explicit audio-state reset when a boundary must discard buffered audio;
+  the streaming implementation also uses it to cancel pending recognition.
+  Preserve the normal per-turn reset behavior that retains pre-roll/VAD buffering
+  for continuous recording.
+- Keep session deletion and finalization teardown idempotent, and preserve their
+  detector-specific gate, filter, and session cleanup. Do not assume that teardown
+  cancels recognition work already in flight; inspect that lifecycle before changing it.
+- Treat turn-end gate ordering, wait state, timeouts, cleanup, and failure fallback
+  as observable policy. Change them only with focused concurrency coverage.
+- Preserve the VAD callback contract
+  `(audio, text, metadata, recorded_duration, session_id)`.
+- When VAD performance metadata is present, preserve the timing fields in
+  `metadata["vad_performance"]` across recording, persistence, queries, and Admin
+  consumers. Keep recorder and query `time_origin` settings aligned.
+- Keep audio assumptions explicit and consistent across detectors, recognizers,
+  synthesizers, recorders, and adapters: sample rate, channels, sample width,
+  raw PCM versus WAV, preprocessing, and chunk boundaries.
+
+## Component contracts
+
+- STT providers implement `transcribe()` and retain the base `recognize()`
+  preprocessing, postprocessing, and `SpeechRecognitionResult` flow.
+- LLM providers keep shared guardrail, tool-call, context-update, voice-text, and
+  streaming behavior in `LLMService.chat_stream()`. Preserve shared response and
+  structured-content shapes.
+- TTS providers implement `generate()` without bypassing the common
+  `SpeechSynthesizer.synthesize()` flow for empty input, preprocessing, caching,
+  and postprocessing. Provider methods receive already-preprocessed text.
+- A synthesis cache key must include every request field that can change generated
+  audio; override the base key when provider-specific model, speaker, speed, or
+  equivalent settings affect output.
+- Register resources constructed by `STSPipeline` with its lifecycle so shutdown
+  closes them. Caller-injected resources remain caller-owned; lifecycle changes
+  must be explicit and covered by cleanup and failure-path tests.
+- For persistent STS state, preserve schema migration, SQLite/PostgreSQL behavior,
+  pool ownership, and idempotent cleanup.
+
+## Change routing and validation
+
+- Start from the owning base class and compare sibling implementations before
+  changing a provider contract.
+- For pipeline message or event changes, inspect adapters, client filtering,
+  examples, and focused adapter tests.
+- For VAD timing or persistence changes, inspect recorders, query semantics,
+  schema migrations, both database backends, and Admin consumers.
+- For public import changes, update the owning `__init__.py` only when a new public
+  API is intended; test that exact import and update user-facing documentation.
+- Use deterministic dummies, fakes, and monkeypatches for concurrency and error
+  paths. Do not substitute live providers for focused regression coverage.
+- Select tests through `tests/AGENTS.md`; provider, PostgreSQL, model-backed,
+  local-service, and hardware tests require their stated prerequisites and authorization.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,90 @@
+# Test Guide
+
+These instructions apply to everything under `tests/`. Also follow the
+repository-root `AGENTS.md`. Run test commands from the repository root.
+
+## Instruction routing
+
+- Read this guide before selecting, collecting, or running any test.
+- For tests that mirror a scoped source area, also read its source guide even
+  when only test files are changing:
+  - `tests/sts/**` -> `aiavatar/sts/AGENTS.md`
+  - `tests/adapter/**` -> `aiavatar/adapter/AGENTS.md`
+  - `tests/adapter/asterisk/**` -> `aiavatar/adapter/asterisk/AGENTS.md`
+  - `tests/admin/**` -> `aiavatar/admin/AGENTS.md`
+- If a more specific guide exists for the source under test, read it too.
+
+## Excluded suite
+
+- Exclude `tests/character/**` from routine validation, collection, and broad
+  test selection. It is slow and covers `aiavatar/character`, which is planned
+  for deprecation and is outside the supported test scope.
+- Run it only when the user explicitly scopes the task to `aiavatar/character`
+  or `tests/character`.
+- When an authorized broader selection could include it, pass
+  `--ignore=tests/character`.
+
+## Safe execution
+
+- Read the target test, its fixtures, imported helpers, and subject imports
+  before executing it. Collection imports modules, so `--collect-only` is not a
+  substitute for inspection.
+- Run the narrowest relevant target: one test node, one file, or a small
+  confirmed-local group.
+- Do not run the full pytest suite by default. It mixes hermetic tests with paid
+  APIs, databases, local services, model downloads, servers, and hardware.
+- Use the isolated invocation:
+
+  ```sh
+  python -m pytest -c /dev/null --rootdir=. -p no:cacheprovider \
+    tests/path/test_file.py::test_name -q
+  ```
+
+- Replace the target only after confirming its dependencies and side effects.
+- Run async tests through pytest so async fixtures and teardown execute normally.
+- Check `git status --short` before and after testing when filesystem effects are
+  possible.
+- Report the exact target, pass/fail/skip counts, warnings, and unavailable
+  prerequisites.
+
+## External dependencies and secrets
+
+- Never open, print, copy, edit, or reuse secrets from `.env`, the ignored root
+  `pytest.ini`, or other ignored local configuration.
+- Some legacy helpers read `pytest.ini` directly. The isolated pytest command
+  prevents pytest itself from loading that file, but cannot prevent test code
+  from opening it.
+- Inspect selected tests and helpers for environment access, localhost URLs,
+  client SDKs, subprocesses, databases, model loading, and device access.
+- A skip marker—or the absence of one—is not proof that a test is hermetic.
+- Run tests that contact a real provider, PostgreSQL database, network or local
+  service, model runtime, or hardware only after explicit authorization for the
+  named dependency, credentials, possible cost, and side effects.
+- If a prerequisite is unavailable, report it. Do not borrow local credentials,
+  install unrelated dependencies, or start services merely to make a test pass.
+- Supply authorized credentials through the process environment only.
+- Do not add tests that read ignored local configuration.
+
+## Isolation and cleanup
+
+- Prefer `tmp_path`, fakes, deterministic dummy services, and monkeypatching.
+- Pass explicit temporary paths for databases, caches, recordings, media, and
+  generated output; do not rely on repository-local defaults.
+- Keep mutable test state scoped to the test or fixture.
+- Use yielding fixtures or `try/finally` so cleanup also runs after failure.
+- Await client and pool shutdown, cancel and join tasks, and close streams,
+  queues, recorder workers, and subprocesses.
+- Database tests must use unique records and remove only records they created.
+  Never assume a local database is disposable.
+- Remove only artifacts created by the current test. Do not use `git clean` or
+  delete ignored user data.
+
+## Adding or changing tests
+
+- Prefer deterministic unit tests over live provider calls.
+- Keep integration tests visibly separate and document their prerequisites,
+  network use, cost, and cleanup behavior.
+- Skip integrations safely when their explicit configuration is absent.
+- Keep tests order-independent and free of state left by earlier tests.
+- Add focused regression coverage for changed behavior and failure paths.
+- Match nearby test style and avoid unrelated rewrites.


### PR DESCRIPTION
Add repository-wide and scoped agent guides for STS, adapters, Asterisk, Admin, and tests. The guides define ownership boundaries, safe validation practices, and exclude `tests/character` from routine test runs.