### PR TITLE
Use the neutral VRM expression as the default

### DIFF
--- a/examples/websocket/html/avatar3d/models/vrm/vrm-adapter.js
+++ b/examples/websocket/html/avatar3d/models/vrm/vrm-adapter.js
@@ -262,7 +262,7 @@ export class VrmAdapter {
 
     async bind(aiavatar) {
         aiavatar.updateFace = (faceName, faceDuration) => {
-            this.idle.applyExpression(faceName, faceDuration || this.config.expression.defaultDurationSeconds);
+            this.idle.applyExpression(faceName, faceDuration ?? this.config.expression.defaultDurationSeconds);
         };
         aiavatar.resetFace = () => {
             this.idle.applyExpression(this.config.expression.neutralName);

--- a/examples/websocket/html/vrm-idle.js
+++ b/examples/websocket/html/vrm-idle.js
@@ -266,16 +266,14 @@ class VRMIdle {
     applyExpression(faceName, duration) {
         faceName = (faceName || 'neutral').toLowerCase();
         faceName = VRMIdle.EXPRESSION_MAP[faceName] || faceName;
-        if (this.currentFaceName && this.currentFaceName !== 'neutral') {
+        if (this.currentFaceName) {
             this._setExpr(this.currentFaceName, 0);
         }
         this.currentFaceName = faceName;
-        if (faceName !== 'neutral') {
-            this._setExpr(faceName, 1.0);
-        }
+        this._setExpr(faceName, 1.0);
 
         if (this._exprTimeout) clearTimeout(this._exprTimeout);
-        if (duration > 0) {
+        if (faceName !== 'neutral' && duration > 0) {
             const updateId = ++this._exprUpdateId;
             this._exprTimeout = setTimeout(() => {
                 if (this._exprUpdateId === updateId) {

--- a/tests/examples/websocket/test_vrm_control_surface.mjs
+++ b/tests/examples/websocket/test_vrm_control_surface.mjs
@@ -432,6 +432,30 @@ test("VRM adapter uses the injected lip sync engine object", async () => {
     });
 });
 
+test("VRM adapter preserves an explicit zero face duration", async () => {
+    const calls = [];
+    const adapter = Object.create(VrmAdapter.prototype);
+    adapter.config = {
+        expression: { neutralName: "neutral", defaultDurationSeconds: 2 },
+        lipsync: {
+            usePhonemeBlend: false,
+            engine: { async initialize() {} },
+        },
+    };
+    adapter.idle = {
+        applyExpression(name, duration) {
+            calls.push([name, duration]);
+        },
+        clearVisemes() {},
+    };
+    const aiavatar = {};
+
+    await adapter.bind(aiavatar);
+    aiavatar.updateFace("neutral", 0);
+
+    assert.deepEqual(calls, [["neutral", 0]]);
+});
+
 test("Load settings expose a reset view button", () => {
     const previousDocument = globalThis.document;
 

--- a/tests/examples/websocket/test_vrm_expression.mjs
+++ b/tests/examples/websocket/test_vrm_expression.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const htmlDirectory = new URL("../../../examples/websocket/html/", import.meta.url);
+const vrmIdleSource = await readFile(new URL("vrm-idle.js", htmlDirectory), "utf8");
+const VRMIdle = new Function(`${vrmIdleSource}; return VRMIdle;`)();
+
+function createIdle(currentFaceName = "happy") {
+    const calls = [];
+    const idle = Object.create(VRMIdle.prototype);
+    idle.currentFaceName = currentFaceName;
+    idle._exprTimeout = null;
+    idle._exprUpdateId = 0;
+    idle._vrm = {
+        expressionManager: {
+            setValue(name, value) {
+                calls.push([name, value]);
+            },
+        },
+    };
+    return { idle, calls };
+}
+
+test("neutral is applied as an explicit VRM expression without a revert timer", () => {
+    const { idle, calls } = createIdle("happy");
+
+    idle.applyExpression(undefined, 2);
+
+    assert.equal(idle.currentFaceName, "neutral");
+    assert.equal(idle._exprTimeout, null);
+    assert.deepEqual(calls, [
+        ["happy", 0],
+        ["neutral", 1],
+    ]);
+});
+
+test("neutral is cleared before another VRM expression is applied", () => {
+    const { idle, calls } = createIdle("neutral");
+
+    idle.applyExpression("Joy", 0);
+
+    assert.equal(idle.currentFaceName, "happy");
+    assert.deepEqual(calls, [
+        ["neutral", 0],
+        ["happy", 1],
+    ]);
+});


### PR DESCRIPTION
Treat neutral as an explicit VRM expression instead of an absence of expression. Clear it before applying another face and avoid redundant neutral reset timers. Preserve explicit zero-duration updates and add regression tests.